### PR TITLE
Create better resampling

### DIFF
--- a/src/tdastro/base_models.py
+++ b/src/tdastro/base_models.py
@@ -87,7 +87,7 @@ class PhysicalModel:
         Raise a ``KeyError`` if there is a parameter collision.
         Raise a ``ValueError`` if the parameter is required, but set to None.
         """
-        if hasattr(self, name):
+        if hasattr(self, name) and getattr(self, name) is not None:
             raise KeyError(f"Duplicate parameter set: {KeyError}")
 
         if value is None and name in kwargs:

--- a/src/tdastro/sources/spline_model.py
+++ b/src/tdastro/sources/spline_model.py
@@ -64,8 +64,12 @@ class SplineModel(PhysicalModel):
         """
         super().__init__(**kwargs)
 
+        # Set the attributes that can be changed (e.g. sampled)
+        self.add_parameter("amplitude", amplitude, **kwargs)
+
+        # These parameters are directly set, because they cannot be changed once
+        # the object is created.
         self.name = name
-        self.amplitude = amplitude
         self._times = times
         self._wavelengths = wavelengths
         self._spline = RectBivariateSpline(times, wavelengths, flux, kx=time_degree, ky=wave_degree)

--- a/src/tdastro/sources/static_source.py
+++ b/src/tdastro/sources/static_source.py
@@ -1,5 +1,3 @@
-import types
-
 import numpy as np
 
 from tdastro.base_models import PhysicalModel
@@ -25,16 +23,7 @@ class StaticSource(PhysicalModel):
            Any additional keyword arguments.
         """
         super().__init__(**kwargs)
-
-        if brightness is None:
-            # If we were not given the parameter, use a default sampling function.
-            self.brightness = np.random.rand(10.0, 20.0)
-        elif isinstance(brightness, types.FunctionType):
-            # If we were given a sampling function, use it.
-            self.brightness = brightness(**kwargs)
-        else:
-            # Otherwise assume we were given the parameter itself.
-            self.brightness = brightness
+        self.add_parameter("brightness", brightness, **kwargs)
 
     def _evaluate(self, times, wavelengths, **kwargs):
         """Draw effect-free observations for this object.

--- a/src/tdastro/sources/step_source.py
+++ b/src/tdastro/sources/step_source.py
@@ -1,29 +1,38 @@
 import numpy as np
 
-from tdastro.base_models import PhysicalModel
+from tdastro.sources.static_source import StaticSource
 
 
-class StaticSource(PhysicalModel):
-    """A static source.
+class StepSource(StaticSource):
+    """A static source that is on for a fixed amount of time
 
     Attributes
     ----------
     brightness : `float`
         The inherent brightness
+    t_start : `float`
+        The time the step function starts
+    t_end : `float`
+        The time the step function ends
     """
 
-    def __init__(self, brightness, **kwargs):
+    def __init__(self, brightness, t_start, t_end, **kwargs):
         """Create a StaticSource object.
 
         Parameters
         ----------
         brightness : `float`, `function`, or `None`
             The inherent brightness
+        t_start : `float`
+            The time the step function starts
+        t_end : `float`
+            The time the step function ends
         **kwargs : `dict`, optional
            Any additional keyword arguments.
         """
-        super().__init__(**kwargs)
-        self.add_parameter("brightness", brightness, required=True, **kwargs)
+        super().__init__(brightness, **kwargs)
+        self.add_parameter("t_start", t_start, required=True, **kwargs)
+        self.add_parameter("t_end", t_end, required=True, **kwargs)
 
     def _evaluate(self, times, wavelengths, **kwargs):
         """Draw effect-free observations for this object.
@@ -42,4 +51,8 @@ class StaticSource(PhysicalModel):
         flux_density : `numpy.ndarray`
             A length T x N matrix of SED values.
         """
-        return np.full((len(times), len(wavelengths)), self.brightness)
+        flux_density = np.zeros((len(times), len(wavelengths)))
+
+        time_mask = (times >= self.t_start) & (times <= self.t_end)
+        flux_density[time_mask] = self.brightness
+        return flux_density

--- a/tests/tdastro/sources/test_static_source.py
+++ b/tests/tdastro/sources/test_static_source.py
@@ -4,8 +4,16 @@ import numpy as np
 from tdastro.sources.static_source import StaticSource
 
 
-def _sampler_fun(magnitude):
-    """Return a random value between 0 and magnitude"""
+def _sampler_fun(magnitude, **kwargs):
+    """Return a random value between 0 and magnitude.
+
+    Parameters
+    ----------
+    magnitude : `float`
+        The range of brightness magnitude
+    **kwargs : `dict`, optional
+        Absorbs additional parameters
+    """
     return magnitude * random.random()
 
 

--- a/tests/tdastro/sources/test_static_source.py
+++ b/tests/tdastro/sources/test_static_source.py
@@ -1,5 +1,12 @@
+import random
+
 import numpy as np
 from tdastro.sources.static_source import StaticSource
+
+
+def _sampler_fun(magnitude):
+    """Return a random value between 0 and magnitude"""
+    return magnitude * random.random()
 
 
 def test_static_source() -> None:
@@ -27,3 +34,21 @@ def test_static_source_host() -> None:
     assert model.ra == 1.0
     assert model.dec == 2.0
     assert model.distance == 3.0
+
+
+def test_static_source_resample() -> None:
+    """Check that we can call resample on the model parameters."""
+    model = StaticSource(brightness=_sampler_fun, magnitude=100.0)
+
+    num_samples = 100
+    values = np.zeros((num_samples, 1))
+    for i in range(num_samples):
+        model.sample_parameters(magnitude=100.0)
+        values[i] = model.brightness
+
+    # Check that the values fall within the expected bounds.
+    assert np.all(values >= 0.0)
+    assert np.all(values <= 100.0)
+
+    # Check that the values are not all the same.
+    assert not np.all(values == values[0])

--- a/tests/tdastro/sources/test_step_source.py
+++ b/tests/tdastro/sources/test_step_source.py
@@ -1,0 +1,83 @@
+import random
+
+import numpy as np
+from tdastro.sources.static_source import StaticSource
+from tdastro.sources.step_source import StepSource
+
+
+def _sample_brightness(magnitude, **kwargs):
+    """Return a random value between 0 and magnitude
+
+    Parameters
+    ----------
+    magnitude : `float`
+        The range of brightness magnitude
+    **kwargs : `dict`, optional
+        Absorbs additional parameters
+    """
+    return magnitude * random.random()
+
+
+def _sample_end(duration, **kwargs):
+    """Return a random value between 1 and 1 + duration
+
+    Parameters
+    ----------
+    duration : `float`
+        The range of time lengths
+    **kwargs : `dict`, optional
+        Absorbs additional parameters
+    """
+    return duration * random.random() + 1.0
+
+
+def test_step_source() -> None:
+    """Test that we can sample and create a StepSource object."""
+    host = StaticSource(brightness=150.0, ra=1.0, dec=2.0, distance=3.0)
+    model = StepSource(brightness=15.0, t_start=1.0, t_end=2.0, host=host)
+    assert model.brightness == 15.0
+    assert model.t_start == 1.0
+    assert model.t_end == 2.0
+    assert model.ra == 1.0
+    assert model.dec == 2.0
+    assert model.distance == 3.0
+
+    times = np.array([0.0, 1.0, 2.0, 3.0])
+    wavelengths = np.array([100.0, 200.0])
+    expected = np.array([[0.0, 0.0], [15.0, 15.0], [15.0, 15.0], [0.0, 0.0]])
+
+    values = model.evaluate(times, wavelengths)
+    assert values.shape == (4, 2)
+    assert np.array_equal(values, expected)
+
+
+def test_step_source_resample() -> None:
+    """Check that we can call resample on the model parameters."""
+    model = StepSource(
+        brightness=_sample_brightness,
+        t_start=0.0,
+        t_end=_sample_end,
+        magnitude=100.0,
+        duration=5.0,
+    )
+
+    num_samples = 100
+    brightness_vals = np.zeros((num_samples, 1))
+    t_end_vals = np.zeros((num_samples, 1))
+    t_start_vals = np.zeros((num_samples, 1))
+    for i in range(num_samples):
+        model.sample_parameters(magnitude=100.0, duration=5.0)
+        brightness_vals[i] = model.brightness
+        t_end_vals[i] = model.t_end
+        t_start_vals[i] = model.t_start
+
+    # Check that the values fall within the expected bounds.
+    assert np.all(brightness_vals >= 0.0)
+    assert np.all(brightness_vals <= 100.0)
+    assert np.all(t_start_vals == 0.0)
+    assert np.all(t_end_vals >= 1.0)
+    assert np.all(t_end_vals <= 6.0)
+
+    # Check that the brightness or end values are not all the same.
+    assert not np.all(brightness_vals == brightness_vals[0])
+    assert not np.all(t_end_vals == t_end_vals[0])


### PR DESCRIPTION
Currently TDAstro requires the creation of a new `PhysicalModel`s anytime we resample the parameters. This might be expensive. This PR adds a slightly more flexible model where the `PhysicalModel` can pull attributes samples from functions. It is still a bit awkward because the function parameters need different names.

A next step will be to extend this to take in a DAG of sampling effects and do the sampling based on that DAG.