### PR TITLE
Allow DAG construction from models

### DIFF
--- a/src/tdastro/base_models.py
+++ b/src/tdastro/base_models.py
@@ -4,70 +4,53 @@ from enum import Enum
 
 class ParameterSource(Enum):
     """ParameterSource specifies where a PhysicalModel should get the value
-    for a given parameter: a constant value, a function, or from the host.
+    for a given parameter: a constant value, a function, or from another
+    parameterized model.
     """
 
-    # TODO support something like TensorFlow probability to provide a DAG
-    # of sampling dependencies.
     CONSTANT = 1
     FUNCTION = 2
-    HOST = 3
+    MODEL_ATTRIBUTE = 3
+    MODEL_METHOD = 4
 
 
-class PhysicalModel:
-    """A physical model of a source of flux. Physical models can have fixed attributes
-    (where you need to create a new model to change them) and settable attributes that
-    can be passed functions or constants.
+class ParameterizedModel:
+    """Any model that uses parameters that can be set by constants,
+    functions, or other parameterized models. ParameterizedModels can
+    include physical objects or statistical distributions.
 
     Attributes
     ----------
-    host : `PhysicalModel`
-        A physical model of the current source's host.
-    ra : `float`
-        The object's right ascension (in degrees)
-    dec : `float`
-        The object's declination (in degrees)
-    distance : `float`
-        The object's distance (in au)
     setters : `dict` or `tuple`
         A dictionary to information about the setters for the parameters in the form:
         (ParameterSource, value).
-    effects : `list`
-        A list of effects to apply to an observations.
+    sample_iteration : `int`
+        A counter used to syncronize  sampling runs. Tracks how many times this
+        model's parameters have been resampled.
     """
 
-    def __init__(self, host=None, ra=None, dec=None, distance=None, **kwargs):
-        """Create a PhysicalModel object.
+    def __init__(self, **kwargs):
+        """Create a ParameterizedModel object.
 
         Parameters
         ----------
-        host : `PhysicalModel`, optional
-            A physical model of the current source's host.
-        ra : `float`, optional
-            The object's right ascension (in degrees)
-        dec : `float`, optional
-            The object's declination (in degrees)
-        distance : `float`, optional
-            The object's distance (in au)
         **kwargs : `dict`, optional
            Any additional keyword arguments.
         """
-        self.host = host
-        self.effects = []
+        self.model_name = "ParameterizedModel"
         self.setters = {}
+        self.sample_iteration = 0
 
-        # Set RA, dec, and distance from the parameters.
-        self.add_parameter("ra", ra)
-        self.add_parameter("dec", dec)
-        self.add_parameter("distance", distance)
+    def __str__(self):
+        """Return the string representation of the model."""
+        return "ParameterizedModel"
 
     def add_parameter(self, name, value=None, required=False, **kwargs):
-        """Add a single parameter to the PhysicalModel. Checks multiple sources
+        """Add a single parameter to the ParameterizedModel. Checks multiple sources
         in the following order:
             1. Manually specified ``value``
             2. An entry in ``kwargs``
-            3. An entry in the object's host.
-            4. ``None``
+            3. ``None``
         Sets an initial value for the attribute based on the given information.
 
         Parameters
@@ -75,8 +58,8 @@ class PhysicalModel:
         name : `str`
             The parameter name to add.
         value : any, optional
-            The information to use to set the parameter. Can be a constant
-            or a function.
+            The information to use to set the parameter. Can be a constant,
+            function, ParameterizedModel, or self.
         required : `bool`
             Fail if the parameter is set to ``None``.
         **kwargs : `dict`, optional
@@ -84,7 +67,8 @@ class PhysicalModel:
 
         Raises
         ------
-        Raise a ``KeyError`` if there is a parameter collision.
+        Raise a ``KeyError`` if there is a parameter collision or the parameter
+        cannot be found.
         Raise a ``ValueError`` if the parameter is required, but set to None.
         """
         if hasattr(self, name) and getattr(self, name) is not None:
@@ -95,30 +79,49 @@ class PhysicalModel:
             value = kwargs[name]
         if value is not None:
             if isinstance(value, types.FunctionType):
+                # Case #1: If we are getting from a static function, sample it.
                 self.setters[name] = (ParameterSource.FUNCTION, value)
                 setattr(self, name, value(**kwargs))
+            elif isinstance(value, types.MethodType) and isinstance(value.__self__, ParameterizedModel):
+                # Case 2: We are trying to use the method from a ParameterizedModel.
+                self.setters[name] = (ParameterSource.MODEL_METHOD, value)
+                setattr(self, name, value(**kwargs))
+            elif isinstance(value, ParameterizedModel):
+                # Case 3: We are trying to access an attribute from a parameterized model.
+                if not hasattr(value, name):
+                    raise ValueError(f"Attribute {name} missing from parent.")
+                self.setters[name] = (ParameterSource.MODEL_ATTRIBUTE, value)
+                setattr(self, name, getattr(value, name))
             else:
+                # Case 4: The value is constant.
                 self.setters[name] = (ParameterSource.CONSTANT, value)
                 setattr(self, name, value)
-        elif self.host is not None and hasattr(self.host, name):
-            self.setters[name] = (ParameterSource.HOST, name)
-            setattr(self, name, getattr(self.host, name))
         elif not required:
             self.setters[name] = (ParameterSource.CONSTANT, None)
             setattr(self, name, None)
         else:
             raise ValueError(f"Missing required parameter {name}")
 
-    def sample_parameters(self, **kwargs):
-        """Sample the model's underlying parameters if they are provided by a function.
+    def sample_parameters(self, max_depth=50, **kwargs):
+        """Sample the model's underlying parameters if they are provided by a function
+        or ParameterizedModel.
 
         Parameters
         ----------
+        max_depth : `int`
+            The maximum recursive depth. Used to prevent infinite loops.
+            Most users should not need to set this manually.
         **kwargs : `dict`, optional
-           All the keyword arguments, including the values needed to sample parameters.
+            All the keyword arguments, including the values needed to sample
+            parameters.
+
+        Raises
+        ------
+        Raise a ``ValueError`` the depth of the sampling encounters a problem
+        with the order of dependencies.
         """
-        if self.host is not None:
-            self.host.sample_parameters(**kwargs)
+        if max_depth == 0:
+            raise ValueError(f"Maximum sampling depth exceeded at {self}. Potential infinite loop.")
 
         # Run through each parameter and sample it based on the given recipe.
         for param, value in self.setters.items():
@@ -127,11 +130,69 @@ class PhysicalModel:
                 sampled_value = value[1]
             elif value[0] == ParameterSource.FUNCTION:
                 sampled_value = value[1](**kwargs)
-            elif value[0] == ParameterSource.HOST:
-                sampled_value = self.host.getattr(param)
+            elif value[0] == ParameterSource.MODEL_ATTRIBUTE:
+                # Check if we need to resample the parent (needs to be done before
+                # we read its attribute).
+                if value[1].sample_iteration == self.sample_iteration:
+                    value[1].sample_parameters(max_depth - 1, **kwargs)
+                sampled_value = getattr(value[1], param)
+            elif value[0] == ParameterSource.MODEL_METHOD:
+                # Check if we need to resample the parent (needs to be done before
+                # we evaluate its method).
+                parent = value[1].__self__
+                if parent.sample_iteration == self.sample_iteration:
+                    parent.sample_parameters(max_depth - 1, **kwargs)
+                sampled_value = value[1](**kwargs)
             else:
                 raise ValueError(f"Unknown ParameterSource type {value[0]}")
             setattr(self, param, sampled_value)
+
+        # Increase the sampling iteration.
+        self.sample_iteration += 1
+
+
+class PhysicalModel(ParameterizedModel):
+    """A physical model of a source of flux. Physical models can have fixed attributes
+    (where you need to create a new model to change them) and settable attributes that
+    can be passed functions or constants.
+
+    Attributes
+    ----------
+    ra : `float`
+        The object's right ascension (in degrees)
+    dec : `float`
+        The object's declination (in degrees)
+    distance : `float`
+        The object's distance (in au)
+    effects : `list`
+        A list of effects to apply to an observations.
+    """
+
+    def __init__(self, ra=None, dec=None, distance=None, **kwargs):
+        """Create a PhysicalModel object.
+
+        Parameters
+        ----------
+        ra : `float`, `function`, or `ParameterizedModel`, optional
+            The object's right ascension (in degrees)
+        dec : `float`, `function`, or `ParameterizedModel`, optional
+            The object's declination (in degrees)
+        distance : `float`, `function`, or `ParameterizedModel`, optional
+            The object's distance (in au)
+        **kwargs : `dict`, optional
+           Any additional keyword arguments.
+        """
+        super().__init__(**kwargs)
+        self.effects = []
+
+        # Set RA, dec, and distance from the parameters.
+        self.add_parameter("ra", ra)
+        self.add_parameter("dec", dec)
+        self.add_parameter("distance", distance)
+
+    def __str__(self):
+        """Return the string representation of the model."""
+        return "PhysicalModel"
 
     def add_effect(self, effect):
         """Add a transformational effect to the PhysicalModel.

--- a/src/tdastro/base_models.py
+++ b/src/tdastro/base_models.py
@@ -37,7 +37,6 @@ class ParameterizedModel:
         **kwargs : `dict`, optional
            Any additional keyword arguments.
         """
-        self.model_name = "ParameterizedModel"
         self.setters = {}
         self.sample_iteration = 0
 

--- a/src/tdastro/base_models.py
+++ b/src/tdastro/base_models.py
@@ -162,7 +162,7 @@ class PhysicalModel(ParameterizedModel):
     dec : `float`
         The object's declination (in degrees)
     distance : `float`
-        The object's distance (in au)
+        The object's distance (in pc)
     effects : `list`
         A list of effects to apply to an observations.
     """
@@ -177,7 +177,7 @@ class PhysicalModel(ParameterizedModel):
         dec : `float`, `function`, or `ParameterizedModel`, optional
             The object's declination (in degrees)
         distance : `float`, `function`, or `ParameterizedModel`, optional
-            The object's distance (in au)
+            The object's distance (in pc)
         **kwargs : `dict`, optional
            Any additional keyword arguments.
         """

--- a/src/tdastro/base_models.py
+++ b/src/tdastro/base_models.py
@@ -78,7 +78,7 @@ class ParameterizedModel:
             value = kwargs[name]
         if value is not None:
             if isinstance(value, types.FunctionType):
-                # Case #1: If we are getting from a static function, sample it.
+                # Case 1: If we are getting from a static function, sample it.
                 self.setters[name] = (ParameterSource.FUNCTION, value)
                 setattr(self, name, value(**kwargs))
             elif isinstance(value, types.MethodType) and isinstance(value.__self__, ParameterizedModel):

--- a/src/tdastro/sources/spline_model.py
+++ b/src/tdastro/sources/spline_model.py
@@ -76,7 +76,7 @@ class SplineModel(PhysicalModel):
 
     def __str__(self):
         """Return the string representation of the model."""
-        return f"SplineSource{self.name}"
+        return f"SplineModel({self.name})"
 
     def _evaluate(self, times, wavelengths, **kwargs):
         """Draw effect-free observations for this object.

--- a/src/tdastro/sources/spline_model.py
+++ b/src/tdastro/sources/spline_model.py
@@ -51,7 +51,7 @@ class SplineModel(PhysicalModel):
         flux : `numpy.ndarray`
             A shape (T, W) matrix with flux values for each pair of time and wavelength.
             Fluxes provided in erg / s / cm^2 / Angstrom.
-        amplitude : `float`
+        amplitude : `float`, `function`, `ParameterizedModel`, or `None`
             A unitless scaling parameter for the flux density values. Default = 1.0
         time_degree : `int`
             The polynomial degree to use in the time dimension.
@@ -73,6 +73,10 @@ class SplineModel(PhysicalModel):
         self._times = times
         self._wavelengths = wavelengths
         self._spline = RectBivariateSpline(times, wavelengths, flux, kx=time_degree, ky=wave_degree)
+
+    def __str__(self):
+        """Return the string representation of the model."""
+        return f"SplineSource{self.name}"
 
     def _evaluate(self, times, wavelengths, **kwargs):
         """Draw effect-free observations for this object.

--- a/src/tdastro/sources/static_source.py
+++ b/src/tdastro/sources/static_source.py
@@ -27,7 +27,7 @@ class StaticSource(PhysicalModel):
 
     def __str__(self):
         """Return the string representation of the model."""
-        return "StaticSource(self.brightness)"
+        return f"StaticSource({self.brightness})"
 
     def _evaluate(self, times, wavelengths, **kwargs):
         """Draw effect-free observations for this object.

--- a/src/tdastro/sources/static_source.py
+++ b/src/tdastro/sources/static_source.py
@@ -17,13 +17,17 @@ class StaticSource(PhysicalModel):
 
         Parameters
         ----------
-        brightness : `float`, `function`, or `None`
+        brightness : `float`, `function`, `ParameterizedModel`, or `None`
             The inherent brightness
         **kwargs : `dict`, optional
            Any additional keyword arguments.
         """
         super().__init__(**kwargs)
         self.add_parameter("brightness", brightness, required=True, **kwargs)
+
+    def __str__(self):
+        """Return the string representation of the model."""
+        return "StaticSource(self.brightness)"
 
     def _evaluate(self, times, wavelengths, **kwargs):
         """Draw effect-free observations for this object.

--- a/src/tdastro/sources/step_source.py
+++ b/src/tdastro/sources/step_source.py
@@ -36,7 +36,7 @@ class StepSource(StaticSource):
 
     def __str__(self):
         """Return the string representation of the model."""
-        return f"StepSource(self.brightness)_{self.t_start}_to_{self.t_end}"
+        return f"StepSource({self.brightness})_{self.t_start}_to_{self.t_end}"
 
     def _evaluate(self, times, wavelengths, **kwargs):
         """Draw effect-free observations for this object.

--- a/src/tdastro/sources/step_source.py
+++ b/src/tdastro/sources/step_source.py
@@ -21,7 +21,7 @@ class StepSource(StaticSource):
 
         Parameters
         ----------
-        brightness : `float`, `function`, or `None`
+        brightness : `float`, `function`, `ParameterizedModel`, or `None`
             The inherent brightness
         t_start : `float`
             The time the step function starts
@@ -33,6 +33,10 @@ class StepSource(StaticSource):
         super().__init__(brightness, **kwargs)
         self.add_parameter("t_start", t_start, required=True, **kwargs)
         self.add_parameter("t_end", t_end, required=True, **kwargs)
+
+    def __str__(self):
+        """Return the string representation of the model."""
+        return f"StepSource(self.brightness)_{self.t_start}_to_{self.t_end}"
 
     def _evaluate(self, times, wavelengths, **kwargs):
         """Draw effect-free observations for this object.

--- a/tests/tdastro/sources/test_spline_source.py
+++ b/tests/tdastro/sources/test_spline_source.py
@@ -8,6 +8,7 @@ def test_spline_model_flat() -> None:
     wavelengths = np.linspace(100.0, 500.0, 25)
     fluxes = np.full((len(times), len(wavelengths)), 1.0)
     model = SplineModel(times, wavelengths, fluxes)
+    assert str(model) == "SplineModel(None)"
 
     test_times = np.array([0.0, 1.0, 2.0, 3.0, 10.0])
     test_waves = np.array([0.0, 100.0, 200.0, 1000.0])
@@ -17,7 +18,9 @@ def test_spline_model_flat() -> None:
     expected = np.full_like(values, 1.0)
     np.testing.assert_array_almost_equal(values, expected)
 
-    model2 = SplineModel(times, wavelengths, fluxes, amplitude=5.0)
+    model2 = SplineModel(times, wavelengths, fluxes, amplitude=5.0, name="test")
+    assert str(model2) == "SplineModel(test)"
+
     values2 = model2.evaluate(test_times, test_waves)
     assert values2.shape == (5, 4)
     expected2 = np.full_like(values2, 5.0)

--- a/tests/tdastro/sources/test_static_source.py
+++ b/tests/tdastro/sources/test_static_source.py
@@ -24,6 +24,7 @@ def test_static_source() -> None:
     assert model.ra is None
     assert model.dec is None
     assert model.distance is None
+    assert str(model) == "StaticSource(10.0)"
 
     times = np.array([1, 2, 3, 4, 5, 10])
     wavelengths = np.array([100.0, 200.0, 300.0])

--- a/tests/tdastro/sources/test_static_source.py
+++ b/tests/tdastro/sources/test_static_source.py
@@ -37,7 +37,7 @@ def test_static_source_host() -> None:
     """Test that we can sample and create a StaticSource object with properties
     derived from the host object."""
     host = StaticSource(brightness=15.0, ra=1.0, dec=2.0, distance=3.0)
-    model = StaticSource(brightness=10.0, host=host)
+    model = StaticSource(brightness=10.0, ra=host, dec=host, distance=host)
     assert model.brightness == 10.0
     assert model.ra == 1.0
     assert model.dec == 2.0

--- a/tests/tdastro/sources/test_step_source.py
+++ b/tests/tdastro/sources/test_step_source.py
@@ -41,6 +41,7 @@ def test_step_source() -> None:
     assert model.ra == 1.0
     assert model.dec == 2.0
     assert model.distance == 3.0
+    assert str(model) == "StepSource(15.0)_1.0_to_2.0"
 
     times = np.array([0.0, 1.0, 2.0, 3.0])
     wavelengths = np.array([100.0, 200.0])

--- a/tests/tdastro/sources/test_step_source.py
+++ b/tests/tdastro/sources/test_step_source.py
@@ -34,7 +34,7 @@ def _sample_end(duration, **kwargs):
 def test_step_source() -> None:
     """Test that we can sample and create a StepSource object."""
     host = StaticSource(brightness=150.0, ra=1.0, dec=2.0, distance=3.0)
-    model = StepSource(brightness=15.0, t_start=1.0, t_end=2.0, host=host)
+    model = StepSource(brightness=15.0, t_start=1.0, t_end=2.0, ra=host, dec=host, distance=host)
     assert model.brightness == 15.0
     assert model.t_start == 1.0
     assert model.t_end == 2.0

--- a/tests/tdastro/test_base_models.py
+++ b/tests/tdastro/test_base_models.py
@@ -1,0 +1,107 @@
+import random
+
+import pytest
+from tdastro.base_models import ParameterizedModel
+
+
+def _sampler_fun(**kwargs):
+    """Return a random value between 0 and 1.0.
+
+    Parameters
+    ----------
+    **kwargs : `dict`, optional
+        Absorbs additional parameters
+    """
+    return random.random()
+
+
+class PairModel(ParameterizedModel):
+    """A test class for the parameterized model.
+
+    Attributes
+    ----------
+    value1 : `float`, `function`, `ParameterizedModel`, or `None`
+        The first value.
+    value2 : `float`, `function`, `ParameterizedModel`, or `None`
+        The second value.
+    """
+
+    def __init__(self, value1, value2, **kwargs):
+        """Create a ConstModel object.
+
+        Parameters
+        ----------
+        value1 : `float`, `function`, `ParameterizedModel`, or `None`
+            The first value.
+        value2 : `float`, `function`, `ParameterizedModel`, or `None`
+            The second value.
+        **kwargs : `dict`, optional
+           Any additional keyword arguments.
+        """
+        super().__init__(**kwargs)
+        self.add_parameter("value1", value1, required=True, **kwargs)
+        self.add_parameter("value2", value2, required=True, **kwargs)
+
+    def result(self, **kwargs):
+        """Add the pair of values together
+
+        Parameters
+        ----------
+        **kwargs : `dict`, optional
+           Any additional keyword arguments.
+        """
+        return self.value1 + self.value2
+
+
+def test_parameterized_model() -> None:
+    """Test that we can sample and create a PairModel object."""
+    # Simple addition
+    model1 = PairModel(value1=0.5, value2=0.5)
+    assert model1.value1 == 0.5
+    assert model1.value1 == 0.5
+    assert model1.result() == 1.0
+    assert model1.sample_iteration == 0
+
+    # Use value1=model.value and value2=1.0
+    model2 = PairModel(value1=model1, value2=1.0)
+    assert model2.value1 == 0.5
+    assert model2.value2 == 1.0
+    assert model2.result() == 1.5
+    assert model2.sample_iteration == 0
+
+    # Compute value1 from model2's result and value2 from the sampler function.
+    model3 = PairModel(value1=model2.result, value2=_sampler_fun)
+    rand_val = model3.value2
+    assert model3.result() == pytest.approx(1.5 + rand_val)
+    assert model3.sample_iteration == 0
+
+    # Compute value1 from model3's result (which is itself the result for model2 +
+    # a random value) and value2 = -1.0.
+    model4 = PairModel(value1=model3.result, value2=-1.0)
+    assert model4.result() == pytest.approx(0.5 + rand_val)
+    assert model4.sample_iteration == 0
+    final_res = model4.result()
+
+    # We can resample and it should change the result.
+    while model3.value2 == rand_val:
+        print(f"{model3.value2}")
+        model4.sample_parameters()
+    rand_val = model3.value2
+
+    # Nothing changes in model1 or model2
+    assert model1.value1 == 0.5
+    assert model1.value1 == 0.5
+    assert model1.result() == 1.0
+    assert model2.value1 == 0.5
+    assert model2.value2 == 1.0
+    assert model2.result() == 1.5
+
+    # Models 3 and 4 use the data from the new random value.
+    assert model3.result() == pytest.approx(1.5 + rand_val)
+    assert model4.result() == pytest.approx(0.5 + rand_val)
+    assert final_res != model4.result()
+
+    # All models should have the same sample iteration.
+    assert model1.sample_iteration == model2.sample_iteration
+    assert model1.sample_iteration == model3.sample_iteration
+    assert model1.sample_iteration == model4.sample_iteration


### PR DESCRIPTION
Create a more flexible sampling model that is closer to the DAG. Instead of being able to sample parameters from three sources (a constant, a function, or a host's attribute) allow the following sources:
- A constant value
- A function
- The attribute of any other model (including a host, statistical distribution, or something else)
- A function from any other model (including a host, statistical distribution, or something else)

This removes the use of a pre-specified `host` attribute. It also creates a generalized `ParameterizedModel` that we can use for populations or even effects. The various `ParameterizedModel`s can form a DAG.