### PR TITLE
Move __init__ comments into class comments

### DIFF
--- a/src/tdastro/base_models.py
+++ b/src/tdastro/base_models.py
@@ -30,13 +30,6 @@ class ParameterizedModel:
     """
 
     def __init__(self, **kwargs):
-        """Create a ParameterizedModel object.
-
-        Parameters
-        ----------
-        **kwargs : `dict`, optional
-           Any additional keyword arguments.
-        """
         self.setters = {}
         self.sample_iteration = 0
 
@@ -168,19 +161,6 @@ class PhysicalModel(ParameterizedModel):
     """
 
     def __init__(self, ra=None, dec=None, distance=None, **kwargs):
-        """Create a PhysicalModel object.
-
-        Parameters
-        ----------
-        ra : `float`, `function`, or `ParameterizedModel`, optional
-            The object's right ascension (in degrees)
-        dec : `float`, `function`, or `ParameterizedModel`, optional
-            The object's declination (in degrees)
-        distance : `float`, `function`, or `ParameterizedModel`, optional
-            The object's distance (in pc)
-        **kwargs : `dict`, optional
-           Any additional keyword arguments.
-        """
         super().__init__(**kwargs)
         self.effects = []
 

--- a/src/tdastro/effects/white_noise.py
+++ b/src/tdastro/effects/white_noise.py
@@ -13,15 +13,6 @@ class WhiteNoise(EffectModel):
     """
 
     def __init__(self, scale, **kwargs):
-        """Create a WhiteNoise effect model.
-
-        Parameters
-        ----------
-        scale : `float`
-            The scale of the noise.
-        **kwargs : `dict`, optional
-           Any additional keyword arguments.
-        """
         super().__init__(**kwargs)
         self.scale = scale
 

--- a/src/tdastro/sources/spline_model.py
+++ b/src/tdastro/sources/spline_model.py
@@ -27,6 +27,26 @@ class SplineModel(PhysicalModel):
         The name of the model being used.
     amplitude : `float`
         A unitless scaling parameter for the flux density values.
+
+    Parameters
+    ----------
+    times : `numpy.ndarray`
+        A length T array containing the times at which the data was sampled.
+    wavelengths : `numpy.ndarray`
+        A length W array containing the wavelengths at which the data was sampled.
+    flux : `numpy.ndarray`
+        A shape (T, W) matrix with flux values for each pair of time and wavelength.
+        Fluxes provided in erg / s / cm^2 / Angstrom.
+    amplitude : `float`, `function`, `ParameterizedModel`, or `None`
+        A unitless scaling parameter for the flux density values. Default = 1.0
+    time_degree : `int`
+        The polynomial degree to use in the time dimension.
+    wave_degree : `int`
+        The polynomial degree to use in the wavelength dimension.
+    name : `str`, optional
+        The name of the model.
+    **kwargs : `dict`, optional
+        Any additional keyword arguments.
     """
 
     def __init__(
@@ -40,28 +60,6 @@ class SplineModel(PhysicalModel):
         name=None,
         **kwargs,
     ):
-        """Create the SplineModel from a grid of (timestep, wavelength, flux) points.
-
-        Parameters
-        ----------
-        times : `numpy.ndarray`
-            A length T array containing the times at which the data was sampled.
-        wavelengths : `numpy.ndarray`
-            A length W array containing the wavelengths at which the data was sampled.
-        flux : `numpy.ndarray`
-            A shape (T, W) matrix with flux values for each pair of time and wavelength.
-            Fluxes provided in erg / s / cm^2 / Angstrom.
-        amplitude : `float`, `function`, `ParameterizedModel`, or `None`
-            A unitless scaling parameter for the flux density values. Default = 1.0
-        time_degree : `int`
-            The polynomial degree to use in the time dimension.
-        wave_degree : `int`
-            The polynomial degree to use in the wavelength dimension.
-        name : `str`, optional
-            The name of the model.
-        **kwargs : `dict`, optional
-           Any additional keyword arguments.
-        """
         super().__init__(**kwargs)
 
         # Set the attributes that can be changed (e.g. sampled)

--- a/src/tdastro/sources/static_source.py
+++ b/src/tdastro/sources/static_source.py
@@ -13,15 +13,6 @@ class StaticSource(PhysicalModel):
     """
 
     def __init__(self, brightness, **kwargs):
-        """Create a StaticSource object.
-
-        Parameters
-        ----------
-        brightness : `float`, `function`, `ParameterizedModel`, or `None`
-            The inherent brightness
-        **kwargs : `dict`, optional
-           Any additional keyword arguments.
-        """
         super().__init__(**kwargs)
         self.add_parameter("brightness", brightness, required=True, **kwargs)
 

--- a/src/tdastro/sources/step_source.py
+++ b/src/tdastro/sources/step_source.py
@@ -10,33 +10,20 @@ class StepSource(StaticSource):
     ----------
     brightness : `float`
         The inherent brightness
-    t_start : `float`
+    t0 : `float`
         The time the step function starts
-    t_end : `float`
+    t1 : `float`
         The time the step function ends
     """
 
-    def __init__(self, brightness, t_start, t_end, **kwargs):
-        """Create a StaticSource object.
-
-        Parameters
-        ----------
-        brightness : `float`, `function`, `ParameterizedModel`, or `None`
-            The inherent brightness
-        t_start : `float`
-            The time the step function starts
-        t_end : `float`
-            The time the step function ends
-        **kwargs : `dict`, optional
-           Any additional keyword arguments.
-        """
+    def __init__(self, brightness, t0, t1, **kwargs):
         super().__init__(brightness, **kwargs)
-        self.add_parameter("t_start", t_start, required=True, **kwargs)
-        self.add_parameter("t_end", t_end, required=True, **kwargs)
+        self.add_parameter("t0", t0, required=True, **kwargs)
+        self.add_parameter("t1", t1, required=True, **kwargs)
 
     def __str__(self):
         """Return the string representation of the model."""
-        return f"StepSource({self.brightness})_{self.t_start}_to_{self.t_end}"
+        return f"StepSource({self.brightness})_{self.t0}_to_{self.t1}"
 
     def _evaluate(self, times, wavelengths, **kwargs):
         """Draw effect-free observations for this object.
@@ -57,6 +44,6 @@ class StepSource(StaticSource):
         """
         flux_density = np.zeros((len(times), len(wavelengths)))
 
-        time_mask = (times >= self.t_start) & (times <= self.t_end)
+        time_mask = (times >= self.t0) & (times <= self.t1)
         flux_density[time_mask] = self.brightness
         return flux_density

--- a/tests/tdastro/sources/test_step_source.py
+++ b/tests/tdastro/sources/test_step_source.py
@@ -34,10 +34,10 @@ def _sample_end(duration, **kwargs):
 def test_step_source() -> None:
     """Test that we can sample and create a StepSource object."""
     host = StaticSource(brightness=150.0, ra=1.0, dec=2.0, distance=3.0)
-    model = StepSource(brightness=15.0, t_start=1.0, t_end=2.0, ra=host, dec=host, distance=host)
+    model = StepSource(brightness=15.0, t0=1.0, t1=2.0, ra=host, dec=host, distance=host)
     assert model.brightness == 15.0
-    assert model.t_start == 1.0
-    assert model.t_end == 2.0
+    assert model.t0 == 1.0
+    assert model.t1 == 2.0
     assert model.ra == 1.0
     assert model.dec == 2.0
     assert model.distance == 3.0
@@ -56,8 +56,8 @@ def test_step_source_resample() -> None:
     """Check that we can call resample on the model parameters."""
     model = StepSource(
         brightness=_sample_brightness,
-        t_start=0.0,
-        t_end=_sample_end,
+        t0=0.0,
+        t1=_sample_end,
         magnitude=100.0,
         duration=5.0,
     )
@@ -69,8 +69,8 @@ def test_step_source_resample() -> None:
     for i in range(num_samples):
         model.sample_parameters(magnitude=100.0, duration=5.0)
         brightness_vals[i] = model.brightness
-        t_end_vals[i] = model.t_end
-        t_start_vals[i] = model.t_start
+        t_end_vals[i] = model.t1
+        t_start_vals[i] = model.t0
 
     # Check that the values fall within the expected bounds.
     assert np.all(brightness_vals >= 0.0)


### PR DESCRIPTION
Closes #15 

Most of the `__init__()` level comments were duplicates anyway.