### PR TITLE
Wrap sncosmo models

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "astropy",
     "numpy",
     "scipy",
+    "sncosmo",
 ]
 
 [project.urls]

--- a/src/tdastro/sources/sncomso_models.py
+++ b/src/tdastro/sources/sncomso_models.py
@@ -4,7 +4,7 @@ https://github.com/sncosmo/sncosmo/blob/v2.10.1/sncosmo/models.py
 https://sncosmo.readthedocs.io/en/stable/models.html
 """
 
-import sncosmo
+from sncosmo.models import Model
 
 from tdastro.base_models import PhysicalModel
 
@@ -30,7 +30,7 @@ class SncosmoModel(PhysicalModel):
     def __init__(self, model_name, **kwargs):
         super().__init__(**kwargs)
         self.model_name = model_name
-        self.model = sncosmo.Model(source=model_name)
+        self.model = Model(source=model_name)
 
     def __str__(self):
         """Return the string representation of the model."""

--- a/src/tdastro/sources/sncomso_models.py
+++ b/src/tdastro/sources/sncomso_models.py
@@ -1,0 +1,102 @@
+"""Wrappers for the models defined in sncosmo.
+
+https://github.com/sncosmo/sncosmo/blob/v2.10.1/sncosmo/models.py
+https://sncosmo.readthedocs.io/en/stable/models.html
+"""
+
+import sncosmo
+
+from tdastro.base_models import PhysicalModel
+
+
+class SncosmoModel(PhysicalModel):
+    """A wrapper for sncosmo models.
+
+    Attributes
+    ----------
+    model : `sncosmo.Model`
+        The underlying model.
+    model_name : `str`
+        The name used to set the model.
+
+    Parameters
+    ----------
+    model_name : `str`
+        The name used to set the model.
+    **kwargs : `dict`, optional
+        Any additional keyword arguments.
+    """
+
+    def __init__(self, model_name, **kwargs):
+        super().__init__(**kwargs)
+        self.model_name = model_name
+        self.model = sncosmo.Model(source=model_name)
+
+    def __str__(self):
+        """Return the string representation of the model."""
+        return f"SncosmoModel({self.model_name})"
+
+    @property
+    def param_names(self):
+        """Return a list of the model's parameter names."""
+        return self.model.param_names
+
+    @property
+    def parameters(self):
+        """Return a list of the model's parameter values."""
+        return self.model.parameters
+
+    @property
+    def source(self):
+        """Return the model's sncosmo source instance."""
+        return self.model.source
+
+    def get(self, name):
+        """Get the value of a specific parameter.
+
+        Parameters
+        ----------
+        name : `str`
+            The name of the parameter.
+
+        Returns
+        -------
+        The parameter value.
+        """
+        return self.model.get(name)
+
+    def set(self, **kwargs):
+        """Set the parameters of the model.
+
+        These must all be constants to be compatible with sncosmo.
+
+        Parameters
+        ----------
+        **kwargs : `dict`
+            The parameters to set and their values.
+        """
+        self.model.set(**kwargs)
+        for key, value in kwargs.items():
+            if hasattr(self, key):
+                self.set_parameter(key, value)
+            else:
+                self.add_parameter(key, value)
+
+    def _evaluate(self, times, wavelengths, **kwargs):
+        """Draw effect-free observations for this object.
+
+        Parameters
+        ----------
+        times : `numpy.ndarray`
+            A length T array of timestamps.
+        wavelengths : `numpy.ndarray`, optional
+            A length N array of wavelengths.
+        **kwargs : `dict`, optional
+           Any additional keyword arguments.
+
+        Returns
+        -------
+        flux_density : `numpy.ndarray`
+            A length T x N matrix of SED values.
+        """
+        return self.model.flux(times, wavelengths)

--- a/tests/tdastro/sources/test_sncosmo_models.py
+++ b/tests/tdastro/sources/test_sncosmo_models.py
@@ -1,0 +1,19 @@
+import numpy as np
+from tdastro.sources.sncomso_models import SncosmoModel
+
+
+def test_sncomso_models_hsiao() -> None:
+    """Test that we can create and evalue a 'hsiao' model."""
+    model = SncosmoModel("hsiao")
+    model.set(z=0.5, t0=55000.0, amplitude=1.0e-10)
+    assert model.z == 0.5
+    assert model.t0 == 55000.0
+    assert model.amplitude == 1.0e-10
+    assert str(model) == "SncosmoModel(hsiao)"
+
+    assert np.array_equal(model.param_names, ["z", "t0", "amplitude"])
+    assert np.array_equal(model.parameters, [0.5, 55000.0, 1.0e-10])
+
+    # Test with the example from: https://sncosmo.readthedocs.io/en/stable/models.html
+    fluxes = model.evaluate([54990.0], [4000.0, 4100.0, 4200.0])
+    assert np.allclose(fluxes, [4.31210900e-20, 7.46619962e-20, 1.42182787e-19])

--- a/tests/tdastro/sources/test_static_source.py
+++ b/tests/tdastro/sources/test_static_source.py
@@ -33,6 +33,12 @@ def test_static_source() -> None:
     assert values.shape == (6, 3)
     assert np.all(values == 10.0)
 
+    # We can set a value we have already added.
+    model.set_parameter("brightness", 5.0)
+    values = model.evaluate(times, wavelengths)
+    assert values.shape == (6, 3)
+    assert np.all(values == 5.0)
+
 
 def test_static_source_host() -> None:
     """Test that we can sample and create a StaticSource object with properties

--- a/tests/tdastro/test_base_models.py
+++ b/tests/tdastro/test_base_models.py
@@ -102,7 +102,7 @@ def test_parameterized_model() -> None:
 
     # Nothing changes in model1 or model2
     assert model1.value1 == 0.5
-    assert model1.value1 == 0.5
+    assert model1.value2 == 0.5
     assert model1.result() == 1.0
     assert model1.value_sum == 1.0
     assert model2.value1 == 0.5
@@ -121,3 +121,23 @@ def test_parameterized_model() -> None:
     assert model1.sample_iteration == model2.sample_iteration
     assert model1.sample_iteration == model3.sample_iteration
     assert model1.sample_iteration == model4.sample_iteration
+
+
+def test_parameterized_model_modify() -> None:
+    """Test that we can modify the parameters in a model."""
+    model = PairModel(value1=0.5, value2=0.5)
+    assert model.value1 == 0.5
+    assert model.value2 == 0.5
+
+    # We cannot add a parameter a second time.
+    with pytest.raises(KeyError):
+        model.add_parameter("value1", 5.0)
+
+    # We can set the parameter.
+    model.set_parameter("value1", 5.0)
+    assert model.value1 == 5.0
+    assert model.value2 == 0.5
+
+    # We cannot set a value that hasn't been added.
+    with pytest.raises(KeyError):
+        model.set_parameter("brightness", 5.0)


### PR DESCRIPTION
This PR does two things:
1) Wrap all the sncosmo models in a `PhysicalModel` that can be used in our flow. This implementation will be a slower due to levels of indirection, but will provide access to the library for anything we haven't implemented natively.
2) Add the ability to change the parameter setting for a `PhysicalModel`. This is needed to provide compatibility with sncosmo's `set()` function.