### PR TITLE
Reorganize the base classes

### DIFF
--- a/src/tdastro/effects/effect_model.py
+++ b/src/tdastro/effects/effect_model.py
@@ -1,0 +1,47 @@
+"""The base EffectModel class used for all effects."""
+
+from tdastro.base_models import ParameterizedNode
+
+
+class EffectModel(ParameterizedNode):
+    """A physical or systematic effect to apply to an observation."""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+    def __str__(self):
+        """Return the string representation of the model."""
+        return "EffectModel"
+
+    def required_parameters(self):
+        """Returns a list of the parameters of a PhysicalModel
+        that this effect needs to access.
+
+        Returns
+        -------
+        parameters : `list` of `str`
+            A list of every required parameter the effect needs.
+        """
+        return []
+
+    def apply(self, flux_density, wavelengths=None, physical_model=None, **kwargs):
+        """Apply the effect to observations (flux_density values)
+
+        Parameters
+        ----------
+        flux_density : `numpy.ndarray`
+            A length T X N matrix of flux density values.
+        wavelengths : `numpy.ndarray`, optional
+            A length N array of wavelengths.
+        physical_model : `PhysicalModel`
+            A PhysicalModel from which the effect may query parameters
+            such as redshift, position, or distance.
+        **kwargs : `dict`, optional
+           Any additional keyword arguments.
+
+        Returns
+        -------
+        flux_density : `numpy.ndarray`
+            A length T x N matrix of flux densities after the effect is applied.
+        """
+        raise NotImplementedError()

--- a/src/tdastro/effects/white_noise.py
+++ b/src/tdastro/effects/white_noise.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from tdastro.base_models import EffectModel
+from tdastro.effects.effect_model import EffectModel
 
 
 class WhiteNoise(EffectModel):

--- a/src/tdastro/populations/fixed_population.py
+++ b/src/tdastro/populations/fixed_population.py
@@ -1,6 +1,6 @@
 import random
 
-from tdastro.base_models import PopulationModel
+from tdastro.populations.population_model import PopulationModel
 
 
 class FixedPopulation(PopulationModel):

--- a/src/tdastro/populations/population_model.py
+++ b/src/tdastro/populations/population_model.py
@@ -1,0 +1,106 @@
+"""The base population models."""
+
+import numpy as np
+
+from tdastro.base_models import ParameterizedNode
+from tdastro.sources.physical_model import PhysicalModel
+
+
+class PopulationModel(ParameterizedNode):
+    """A model of a population of PhysicalModels.
+
+    Attributes
+    ----------
+    num_sources : `int`
+        The number of different sources in the population.
+    sources : `list`
+        A list of sources from which to draw.
+    """
+
+    def __init__(self, rng=None, **kwargs):
+        super().__init__(**kwargs)
+        self.num_sources = 0
+        self.sources = []
+
+    def __str__(self):
+        """Return the string representation of the model."""
+        return f"PopulationModel with {self.num_sources} sources."
+
+    def add_source(self, new_source, **kwargs):
+        """Add a new source to the population.
+
+        Parameters
+        ----------
+        new_source : `PhysicalModel`
+            A source from the population.
+        **kwargs : `dict`, optional
+           Any additional keyword arguments.
+        """
+        if not isinstance(new_source, PhysicalModel):
+            raise ValueError("All sources must be PhysicalModels")
+        self.sources.append(new_source)
+        self.num_sources += 1
+
+    def draw_source(self):
+        """Sample a single source from the population.
+
+        Returns
+        -------
+        source : `PhysicalModel`
+            A source from the population.
+        """
+        raise NotImplementedError()
+
+    def add_effect(self, effect, allow_dups=False, **kwargs):
+        """Add a transformational effect to all PhysicalModels in this population.
+        Effects are applied in the order in which they are added.
+
+        Parameters
+        ----------
+        effect : `EffectModel`
+            The effect to apply.
+        allow_dups : `bool`
+            Allow multiple effects of the same type.
+            Default = ``True``
+        **kwargs : `dict`, optional
+           Any additional keyword arguments.
+
+        Raises
+        ------
+        Raises a ``AttributeError`` if the PhysicalModel does not have all of the
+        required attributes.
+        """
+        for source in self.sources:
+            source.add_effect(effect, allow_dups=allow_dups, **kwargs)
+
+    def evaluate(self, samples, times, wavelengths, resample_parameters=False, **kwargs):
+        """Draw observations from a single (randomly sampled) source.
+
+        Parameters
+        ----------
+        samples : `int`
+            The number of sources to samples.
+        times : `numpy.ndarray`
+            A length T array of timestamps.
+        wavelengths : `numpy.ndarray`, optional
+            A length N array of wavelengths.
+        resample_parameters : `bool`
+            Treat this evaluation as a completely new object, resampling the
+            parameters from the original provided functions.
+        **kwargs : `dict`, optional
+           Any additional keyword arguments.
+
+        Returns
+        -------
+        results : `numpy.ndarray`
+            A shape (samples, T, N) matrix of SED values.
+        """
+        if samples <= 0:
+            raise ValueError("The number of samples must be > 0.")
+
+        results = []
+        for _ in range(samples):
+            source = self.draw_source()
+            object_fluxes = source.evaluate(times, wavelengths, resample_parameters, **kwargs)
+            results.append(object_fluxes)
+        return np.array(results)

--- a/src/tdastro/sources/galaxy_models.py
+++ b/src/tdastro/sources/galaxy_models.py
@@ -1,7 +1,7 @@
 import numpy as np
 from astropy.coordinates import angular_separation
 
-from tdastro.base_models import PhysicalModel
+from tdastro.sources.physical_model import PhysicalModel
 
 
 class GaussianGalaxy(PhysicalModel):

--- a/src/tdastro/sources/periodic_source.py
+++ b/src/tdastro/sources/periodic_source.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 
-from tdastro.base_models import PhysicalModel
+from tdastro.sources.physical_model import PhysicalModel
 
 
 class PeriodicSource(PhysicalModel, ABC):

--- a/src/tdastro/sources/physical_model.py
+++ b/src/tdastro/sources/physical_model.py
@@ -1,0 +1,149 @@
+"""The base PhysicalModel used for all sources."""
+
+from tdastro.base_models import ParameterizedNode
+
+
+class PhysicalModel(ParameterizedNode):
+    """A physical model of a source of flux.
+
+    Physical models can have fixed attributes (where you need to create a new model
+    to change them) and settable attributes that can be passed functions or constants.
+    They can also have special background pointers that link to another PhysicalModel
+    producing flux. We can chain these to have a supernova in front of a star in front
+    of a static background.
+
+    Attributes
+    ----------
+    ra : `float`
+        The object's right ascension (in degrees)
+    dec : `float`
+        The object's declination (in degrees)
+    distance : `float`
+        The object's distance (in pc).
+    background : `PhysicalModel`
+        A source of background flux such as a host galaxy.
+    effects : `list`
+        A list of effects to apply to an observations.
+    """
+
+    def __init__(self, ra=None, dec=None, distance=None, background=None, **kwargs):
+        super().__init__(**kwargs)
+        self.effects = []
+
+        # Set RA, dec, and redshift from the parameters.
+        self.add_parameter("ra", ra)
+        self.add_parameter("dec", dec)
+        self.add_parameter("distance", distance)
+
+        # Background is an object not a sampled parameter
+        self.background = background
+
+    def __str__(self):
+        """Return the string representation of the model."""
+        return "PhysicalModel"
+
+    def add_effect(self, effect, allow_dups=True, **kwargs):
+        """Add a transformational effect to the PhysicalModel.
+        Effects are applied in the order in which they are added.
+
+        Parameters
+        ----------
+        effect : `EffectModel`
+            The effect to apply.
+        allow_dups : `bool`
+            Allow multiple effects of the same type.
+            Default = ``True``
+        **kwargs : `dict`, optional
+           Any additional keyword arguments.
+
+        Raises
+        ------
+        Raises a ``AttributeError`` if the PhysicalModel does not have all of the
+        required attributes.
+        """
+        # Check that we have not added this effect before.
+        if not allow_dups:
+            effect_type = type(effect)
+            for prev in self.effects:
+                if effect_type == type(prev):
+                    raise ValueError("Added the effect type to a model {effect_type} more than once.")
+
+        required: list = effect.required_parameters()
+        for parameter in required:
+            # Raise an AttributeError if the parameter is missing or set to None.
+            if getattr(self, parameter) is None:
+                raise AttributeError(f"Parameter {parameter} unset for model {type(self).__name__}")
+
+        self.effects.append(effect)
+
+    def _evaluate(self, times, wavelengths, **kwargs):
+        """Draw effect-free observations for this object.
+
+        Parameters
+        ----------
+        times : `numpy.ndarray`
+            A length T array of timestamps.
+        wavelengths : `numpy.ndarray`, optional
+            A length N array of wavelengths.
+        **kwargs : `dict`, optional
+           Any additional keyword arguments.
+
+        Returns
+        -------
+        flux_density : `numpy.ndarray`
+            A length T x N matrix of SED values.
+        """
+        raise NotImplementedError()
+
+    def evaluate(self, times, wavelengths, resample_parameters=False, **kwargs):
+        """Draw observations for this object and apply the noise.
+
+        Parameters
+        ----------
+        times : `numpy.ndarray`
+            A length T array of timestamps.
+        wavelengths : `numpy.ndarray`, optional
+            A length N array of wavelengths.
+        resample_parameters : `bool`
+            Treat this evaluation as a completely new object, resampling the
+            parameters from the original provided functions.
+        **kwargs : `dict`, optional
+           Any additional keyword arguments.
+
+        Returns
+        -------
+        flux_density : `numpy.ndarray`
+            A length T x N matrix of SED values.
+        """
+        if resample_parameters:
+            self.sample_parameters(kwargs)
+
+        # Compute the flux density for both the current object and add in anything
+        # behind it, such as a host galaxy.
+        flux_density = self._evaluate(times, wavelengths, **kwargs)
+        if self.background is not None:
+            flux_density += self.background._evaluate(times, wavelengths, ra=self.ra, dec=self.dec, **kwargs)
+
+        for effect in self.effects:
+            flux_density = effect.apply(flux_density, wavelengths, self, **kwargs)
+        return flux_density
+
+    def sample_parameters(self, include_effects=True, **kwargs):
+        """Sample the model's underlying parameters if they are provided by a function
+        or ParameterizedModel.
+
+        Parameters
+        ----------
+        include_effects : `bool`
+            Resample the parameters for the effects models.
+        **kwargs : `dict`, optional
+            All the keyword arguments, including the values needed to sample
+            parameters.
+        """
+        if self.background is not None:
+            self.background.sample_parameters(include_effects, **kwargs)
+        super().sample_parameters(**kwargs)
+
+        if include_effects:
+            for effect in self.effects:
+                effect.sample_parameters(**kwargs)

--- a/src/tdastro/sources/sncomso_models.py
+++ b/src/tdastro/sources/sncomso_models.py
@@ -6,7 +6,7 @@ https://sncosmo.readthedocs.io/en/stable/models.html
 
 from sncosmo.models import get_source
 
-from tdastro.base_models import PhysicalModel
+from tdastro.sources.physical_model import PhysicalModel
 
 
 class SncosmoWrapperModel(PhysicalModel):

--- a/src/tdastro/sources/spline_model.py
+++ b/src/tdastro/sources/spline_model.py
@@ -7,7 +7,7 @@ https://github.com/sncosmo/sncosmo/blob/v2.10.1/sncosmo/models.py
 
 from scipy.interpolate import RectBivariateSpline
 
-from tdastro.base_models import PhysicalModel
+from tdastro.sources.physical_model import PhysicalModel
 
 
 class SplineModel(PhysicalModel):

--- a/src/tdastro/sources/static_source.py
+++ b/src/tdastro/sources/static_source.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from tdastro.base_models import PhysicalModel
+from tdastro.sources.physical_model import PhysicalModel
 
 
 class StaticSource(PhysicalModel):

--- a/tests/tdastro/sources/test_physical_models.py
+++ b/tests/tdastro/sources/test_physical_models.py
@@ -1,0 +1,10 @@
+from tdastro.sources.physical_model import PhysicalModel
+
+
+def test_physical_model():
+    """Test that we can create a PhysicalModel."""
+    # Everything is specified.
+    model1 = PhysicalModel(ra=1.0, dec=2.0, distance=3.0)
+    assert model1.ra == 1.0
+    assert model1.dec == 2.0
+    assert model1.distance == 3.0

--- a/tests/tdastro/test_base_models.py
+++ b/tests/tdastro/test_base_models.py
@@ -1,7 +1,7 @@
 import random
 
 import pytest
-from tdastro.base_models import ParameterizedModel
+from tdastro.base_models import ParameterizedNode
 
 
 def _sampler_fun(**kwargs):
@@ -15,8 +15,8 @@ def _sampler_fun(**kwargs):
     return random.random()
 
 
-class PairModel(ParameterizedModel):
-    """A test class for the parameterized model.
+class PairModel(ParameterizedNode):
+    """A test class for the ParameterizedNode.
 
     Attributes
     ----------
@@ -33,9 +33,9 @@ class PairModel(ParameterizedModel):
 
         Parameters
         ----------
-        value1 : `float`, `function`, `ParameterizedModel`, or `None`
+        value1 : `float`, `function`, `ParameterizedNode`, or `None`
             The first value.
-        value2 : `float`, `function`, `ParameterizedModel`, or `None`
+        value2 : `float`, `function`, `ParameterizedNode`, or `None`
             The second value.
         **kwargs : `dict`, optional
            Any additional keyword arguments.
@@ -61,7 +61,7 @@ class PairModel(ParameterizedModel):
         return self.value1 + self.value2
 
 
-def test_parameterized_model() -> None:
+def test_parameterized_node() -> None:
     """Test that we can sample and create a PairModel object."""
     # Simple addition
     model1 = PairModel(value1=0.5, value2=0.5)
@@ -123,8 +123,8 @@ def test_parameterized_model() -> None:
     assert model1.sample_iteration == model4.sample_iteration
 
 
-def test_parameterized_model_modify() -> None:
-    """Test that we can modify the parameters in a model."""
+def test_parameterized_node_modify() -> None:
+    """Test that we can modify the parameters in a node."""
     model = PairModel(value1=0.5, value2=0.5)
     assert model.value1 == 0.5
     assert model.value2 == 0.5


### PR DESCRIPTION
Break about `base_models.py` because it is becoming too large and complex. Moves the second level models (`PhysicalModel`, `EffectModel`, and `PopulationModel`) into the corresponding subdirectories. Update the comments to clarify what `base_models.py` contains.

Also renames `ParameterizedModel` to `ParameterizedNode` in preparation for more substantial DAG PR.