### PR TITLE
Extend the __str__() method of FunctionNode

### DIFF
--- a/src/tdastro/base_models.py
+++ b/src/tdastro/base_models.py
@@ -391,7 +391,10 @@ class FunctionNode(ParameterizedNode):
 
     def __str__(self):
         """Return the string representation of the function."""
-        return f"FunctionNode({self.func.__name__})"
+        # Extend the FunctionNode's string to include the name of the
+        # function it calls so we can wrap a variety of raw functions.
+        super_name = super().__str__()
+        return f"{super_name}:{self.func.__name__}"
 
     def compute(self, **kwargs):
         """Execute the wrapped function.

--- a/tests/tdastro/test_base_models.py
+++ b/tests/tdastro/test_base_models.py
@@ -275,6 +275,8 @@ def test_function_node_basic():
     assert my_func.compute(value2=3.0, unused_param=5.0) == 4.0
     assert my_func.compute(value2=3.0, value1=1.0) == 4.0
 
+    assert str(my_func) == "tdastro.base_models.FunctionNode:_test_func"
+
 
 def test_function_node_chain():
     """Test that we can create and query a chained FunctionNode."""


### PR DESCRIPTION
We want to __str__() result of a `FunctionNode` to include the function it is calling so we can use multiple `FunctionNode`s in a single graph.