### PR TITLE
Streamline random seed setting

### DIFF
--- a/src/tdastro/base_models.py
+++ b/src/tdastro/base_models.py
@@ -34,9 +34,6 @@ class ParameterizedNode:
         model's parameters have been resampled.
     _object_seed : `int`
         A object-specific seed to control random number generation.
-    _graph_base_seed, `int`
-        A base random seed to use for this specific evaluation graph. Used
-        for validity checking.
 
     Parameters
     ----------
@@ -65,6 +62,21 @@ class ParameterizedNode:
         else:
             return name
 
+    def _update_object_seed(self, new_value):
+        """Update the object seed to the new value.
+
+        Note
+        ----
+        Override this function if an object maintains its
+        own random number generator objects.
+
+        Parameters
+        ----------
+        new_value : `int`
+             The new seed value.
+        """
+        self._object_seed = new_value
+
     def set_graph_base_seed(self, graph_base_seed):
         """Set a new graph base seed.
 
@@ -80,11 +92,11 @@ class ParameterizedNode:
         """
         if graph_base_seed is None:
             graph_base_seed = int.from_bytes(urandom(4), "big")
-        self._graph_base_seed = graph_base_seed
 
         hashed_object_name = md5(str(self).encode())
         seed_offset = int(hashed_object_name.hexdigest(), base=16)
-        self._object_seed = (graph_base_seed + seed_offset) % (2**31)
+        new_seed = (graph_base_seed + seed_offset) % (2**31)
+        self._update_object_seed(new_seed)
 
     def check_resample(self, other):
         """Check if we need to resample the current node based

--- a/src/tdastro/sources/galaxy_models.py
+++ b/src/tdastro/sources/galaxy_models.py
@@ -21,6 +21,17 @@ class GaussianGalaxy(PhysicalModel):
         self.add_parameter("galaxy_radius_std", radius, required=True, **kwargs)
         self.add_parameter("brightness", brightness, required=True, **kwargs)
 
+    def _update_object_seed(self, new_value):
+        """Update the object seed to the new value.
+
+        Parameters
+        ----------
+        new_value : `int`
+             The new seed value.
+        """
+        self._object_seed = new_value
+        self._rng = np.random.default_rng(self._object_seed)
+
     def sample_ra(self):
         """Sample an right ascension coordinate based on the center and radius of the galaxy.
 
@@ -29,7 +40,7 @@ class GaussianGalaxy(PhysicalModel):
         ra : `float`
             The sampled right ascension in degrees.
         """
-        return np.random.normal(loc=self.ra, scale=self.galaxy_radius_std)
+        return self._rng.normal(loc=self.ra, scale=self.galaxy_radius_std)
 
     def sample_dec(self):
         """Sample a declination coordinate based on the center and radius of the galaxy.
@@ -39,7 +50,7 @@ class GaussianGalaxy(PhysicalModel):
         dec : `float`
             The sampled declination in degrees.
         """
-        return np.random.normal(loc=self.dec, scale=self.galaxy_radius_std)
+        return self._rng.normal(loc=self.dec, scale=self.galaxy_radius_std)
 
     def _evaluate(self, times, wavelengths, ra=None, dec=None, **kwargs):
         """Draw effect-free observations for this object.

--- a/src/tdastro/util_nodes/jax_random.py
+++ b/src/tdastro/util_nodes/jax_random.py
@@ -20,24 +20,16 @@ class JaxRandomFunc(FunctionNode):
 
     def __init__(self, func, **kwargs):
         super().__init__(func, **kwargs)
-        self._key = jax.random.key(self._object_seed)
 
-    def set_graph_base_seed(self, graph_base_seed):
-        """Set a new graph base seed.
-
-        Notes
-        -----
-        WARNING: This seed should almost never be set manually. Using the same
-        seed for multiple graph instances will produce biased samples.
+    def _update_object_seed(self, new_value):
+        """Update the object seed to the new value.
 
         Parameters
         ----------
-        graph_base_seed : `int`, optional
-            A base random seed to use for this specific evaluation graph.
+        new_value : `int`
+             The new seed value.
         """
-        super().set_graph_base_seed(graph_base_seed)
-
-        # We recompute the JAX key with the new object seed.
+        self._object_seed = new_value
         self._key = jax.random.key(self._object_seed)
 
     def compute(self, **kwargs):

--- a/src/tdastro/util_nodes/np_random.py
+++ b/src/tdastro/util_nodes/np_random.py
@@ -38,20 +38,15 @@ class NumpyRandomFunc(FunctionNode):
         func = getattr(self._rng, func_name)
         super().__init__(func, **kwargs)
 
-    def set_graph_base_seed(self, graph_base_seed):
-        """Set a new graph base seed.
-
-        Notes
-        -----
-        WARNING: This seed should almost never be set manually. Using the same
-        seed for multiple graph instances will produce biased samples.
+    def _update_object_seed(self, new_value):
+        """Update the object seed to the new value.
 
         Parameters
         ----------
-        graph_base_seed : `int`, optional
-            A base random seed to use for this specific evaluation graph.
+        new_value : `int`
+             The new seed value.
         """
-        super().set_graph_base_seed(graph_base_seed)
+        self._object_seed = new_value
 
         # We create a new random number generator with the new object seed and
         # link to that object's function.


### PR DESCRIPTION
Instead of having subclasses override the entire `set_graph_base_seed()` function, break out a smaller, private function that sets the seed and creates and random number generators.