### PR TITLE
Redo the random seeding

### DIFF
--- a/src/tdastro/base_models.py
+++ b/src/tdastro/base_models.py
@@ -135,7 +135,7 @@ class ParameterizedNode:
 
         hashed_object_name = md5(str(self).encode())
         seed_offset = int(hashed_object_name.hexdigest(), base=16)
-        new_seed = (self._graph_base_seed + seed_offset) % (2**31)
+        new_seed = (self._graph_base_seed + seed_offset) % (2**32)
         self._object_seed = new_seed
 
     def update_graph_information(self, new_graph_base_seed=None, seen_nodes=None):

--- a/src/tdastro/base_models.py
+++ b/src/tdastro/base_models.py
@@ -43,6 +43,8 @@ from enum import Enum
 from hashlib import md5
 from os import urandom
 
+import numpy as np
+
 
 class ParameterSource(Enum):
     """ParameterSource specifies where a ParameterizedNode should get the value
@@ -63,101 +65,110 @@ class ParameterizedNode:
     Attributes
     ----------
     node_identifier : `str`
-        An identifier (or name) for the current node.
+        An optional identifier (name) for the current node.
     setters : `dict` of `tuple`
         A dictionary to information about the setters for the parameters in the form:
         (ParameterSource, setter information, required). The attributes are
         stored in the order in which they need to be set.
-    sample_iteration : `int`
-        A counter used to syncronize sampling runs. Tracks how many times this
-        model's parameters have been resampled.
     direct_dependencies : `set`
         A set of other ParameterizedNodes on that this node needs to directly access.
-    _object_seed : `int`
+    _object_seed : `int` or None
         A object-specific seed to control random number generation.
-    _graph_base_seed, `int`
+    _graph_base_seed, `int` or None
         A base random seed to use for this specific evaluation graph. Used
         for validity checking.
+    _node_id : `int` or None
+        A unique ID number for each node in the graph. Assigned during
+        resampling.
 
     Parameters
     ----------
     node_identifier : `str`, optional
         An identifier (or name) for the current node.
-    graph_base_seed : `int`, optional
-        A base random seed to use for this specific evaluation graph.
-        WARNING: This seed should almost never be set manually. Using the same
-        seed for multiple graph instances will produce biased samples.
-        If set to ``None`` will use urandom() to produce a fully random seed.
     **kwargs : `dict`, optional
         Any additional keyword arguments.
     """
 
-    def __init__(self, node_identifier=None, graph_base_seed=None, **kwargs):
+    def __init__(self, node_identifier=None, **kwargs):
         self.setters = {}
-        self.sample_iteration = 0
-        self.node_identifier = node_identifier
-        self.set_graph_base_seed(graph_base_seed)
         self.direct_dependencies = set()
+        self.node_identifier = node_identifier
+        self._node_id = None
+        self._object_seed = None  # A default until set is called.
+        self._graph_base_seed = None
+
+        # We start all nodes with a completely random base seed.
+        base_seed = int.from_bytes(urandom(4), "big")
+        self.set_seed(graph_base_seed=base_seed)
 
     def __str__(self):
         """Return the string representation of the node."""
-        name = f"{self.__class__.__module__}.{self.__class__.__qualname__}"
-        if self.node_identifier:
-            return f"{self.node_identifier}={name}"
-        else:
-            return name
+        name = f"{self.node_identifier}=" if self.node_identifier else ""
+        id_str = f"{self._node_id}: " if self._node_id is not None else ""
+        return f"{id_str}{name}{self.__class__.__module__}.{self.__class__.__qualname__}"
 
-    def set_graph_base_seed(self, graph_base_seed):
-        """Set a new graph base seed.
+    def set_seed(self, new_seed=None, graph_base_seed=None):
+        """Update the object seed to the new value based.
 
-        Notes
-        -----
-        WARNING: This seed should almost never be set manually. Using the same
-        seed for multiple graph instances will produce biased samples.
+        The new value can be: 1) a given seed (new_seed), 2) a value computed from
+        the graph's base seed (graph_base_seed) and the object's string representation,
+        or a completely random seed (if neither option is set).
+
+        WARNING: This seed should almost never be set manually. Using the duplicate
+        seeds for multiple graph instances or runs will produce biased samples.
 
         Parameters
         ----------
+        new_seed : `int`, optional
+            The given seed
         graph_base_seed : `int`, optional
             A base random seed to use for this specific evaluation graph.
         """
-        if graph_base_seed is None:
-            graph_base_seed = int.from_bytes(urandom(4), "big")
-        self._graph_base_seed = graph_base_seed
+        # If we are given a predefined seed, use that.
+        if new_seed is not None:
+            self._object_seed = new_seed
+            return
+
+        # Update the base seed if needed.
+        if graph_base_seed is not None:
+            self._graph_base_seed = graph_base_seed
 
         hashed_object_name = md5(str(self).encode())
         seed_offset = int(hashed_object_name.hexdigest(), base=16)
-        self._object_seed = (graph_base_seed + seed_offset) % (2**31)
+        new_seed = (self._graph_base_seed + seed_offset) % (2**31)
+        self._object_seed = new_seed
 
-    def check_resample(self, other):
-        """Check if we need to resample the current node based
-        on the state of another node trying to access its attributes
-        or methods.
+    def update_graph_information(self, new_graph_base_seed=None, seen_nodes=None):
+        """Force an update of the graph structure and the seeds.
+
+        Updates the node ids to capture their location in the graph. Also updates
+        the graph_base_seed (if given).
+
+        WARNING: This will modify the per-node seeds to account for the new graph base
+        seed (if there is one) and any changes in their position within the graph structure.
 
         Parameters
         ----------
-        other : `ParameterizedNode`
-            The node that is accessing the attribute or method
-            of the current node.
-
-        Returns
-        -------
-        bool
-            Indicates whether to resample or not.
-
-        Raises
-        ------
-        ``ValueError`` if the graph has gotten out of sync.
+        new_graph_base_seed : `int`, optional
+            A base random seed to use for this specific evaluation graph.
+        seen_nodes : `set`, optional
+            A set of nodes that have already been processed to prevent infinite loops.
+            Caller should not set.
         """
-        if other == self:
-            return False
-        if other.sample_iteration == self.sample_iteration:
-            return False
-        if other.sample_iteration != self.sample_iteration + 1:
-            raise ValueError(
-                f"Node {str(other)} at iteration {other.sample_iteration} accessing"
-                f" parent {str(self)} at iteration {self.sample_iteration}."
-            )
-        return True
+        # Make sure that we do not process the same nodes multiple times.
+        if seen_nodes is None:
+            seen_nodes = set()
+        if self in seen_nodes:
+            return
+        seen_nodes.add(self)
+
+        # Update the graph ID and (possibly) the seed.
+        self._node_id = len(seen_nodes) - 1
+        self.set_seed(graph_base_seed=new_graph_base_seed)
+
+        # Recursively update any direct dependencies.
+        for dep in self.direct_dependencies:
+            dep.update_graph_information(new_graph_base_seed, seen_nodes)
 
     def _update_dependencies(self):
         """Update the set of direct dependencies."""
@@ -301,15 +312,18 @@ class ParameterizedNode:
         self.setters[name] = (None, None, required)
         self.set_parameter(name, value, **kwargs)
 
-    def sample_parameters(self, max_depth=50, **kwargs):
-        """Sample the model's underlying parameters if they are provided by a function
-        or ParameterizedNode.
+    def _sample_helper(self, depth, seen_nodes, **kwargs):
+        """Internal recursive function to sample the model's underlying parameters
+        if they are provided by a function or ParameterizedNode.
 
         Parameters
         ----------
-        max_depth : `int`
-            The maximum recursive depth. Used to prevent infinite loops.
+        depth : `int`
+            The recursive depth remaining. Used to prevent infinite loops.
             Users should not need to set this manually.
+        seen_nodes : `dict`
+            A dictionary mapping nodes seen during this sampling run to their ID.
+            Used to avoid sampling nodes multiple times and to validity check the graph.
         **kwargs : `dict`, optional
             All the keyword arguments, including the values needed to sample
             parameters.
@@ -319,11 +333,11 @@ class ParameterizedNode:
         Raise a ``ValueError`` the depth of the sampling encounters a problem
         with the order of dependencies.
         """
-        if max_depth == 0:
+        if depth == 0:
             raise ValueError(f"Maximum sampling depth exceeded at {self}. Potential infinite loop.")
-
-        # Increase the sampling iteration.
-        self.sample_iteration += 1
+        if self in seen_nodes:
+            return  # Nothing to do
+        seen_nodes[self] = self._node_id
 
         # Run through each parameter and sample it based on the given recipe.
         # As of Python 3.7 dictionaries are guaranteed to preserve insertion ordering,
@@ -336,24 +350,55 @@ class ParameterizedNode:
                 sampled_value = setter(**kwargs)
             elif source_type == ParameterSource.MODEL_ATTRIBUTE:
                 # Check if we need to resample the parent (before accessing the attribute).
-                if setter[0].check_resample(self):
-                    setter[0].sample_parameters(max_depth - 1, **kwargs)
-                # We store MODEL_ATTRIBUTE setters as a tuple of (object, attribute_name).
+                if setter[0] not in seen_nodes:
+                    setter[0]._sample_helper(depth - 1, seen_nodes, **kwargs)
                 sampled_value = getattr(setter[0], setter[1])
             elif source_type == ParameterSource.MODEL_METHOD:
                 # Check if we need to resample the parent (before calling the method).
                 parent_node = setter.__self__
-                if parent_node.check_resample(self):
-                    parent_node.sample_parameters(max_depth - 1, **kwargs)
+                if parent_node not in seen_nodes:
+                    parent_node._sample_helper(depth - 1, seen_nodes, **kwargs)
                 sampled_value = setter(**kwargs)
             elif source_type == ParameterSource.FUNCTION_NODE:
                 # Check if we need to resample the parent function (before calling compute).
-                if setter.check_resample(self):
-                    setter.sample_parameters(max_depth - 1, **kwargs)
+                if setter not in seen_nodes:
+                    setter._sample_helper(depth - 1, seen_nodes, **kwargs)
                 sampled_value = setter.compute(**kwargs)
             else:
                 raise ValueError(f"Unknown ParameterSource type {source_type} for {name}")
             setattr(self, name, sampled_value)
+
+    def sample_parameters(self, **kwargs):
+        """Sample the model's underlying parameters if they are provided by a function
+        or ParameterizedNode.
+
+        Parameters
+        ----------
+        **kwargs : `dict`, optional
+            All the keyword arguments, including the values needed to sample
+            parameters.
+
+        Raises
+        ------
+        Raise a ``ValueError`` the depth of the sampling encounters a problem
+        with the order of dependencies.
+        """
+        # If the graph structure has never been set, do that now.
+        if self._node_id is None:
+            nodes = set()
+            self.update_graph_information(seen_nodes=nodes)
+
+        # Resample the nodes.
+        seen_nodes = {}
+        self._sample_helper(50, seen_nodes, **kwargs)
+
+        # Validity check that we do not see duplicate IDs.
+        seen_ids = np.array(list(seen_nodes.values()))
+        if len(seen_ids) != len(np.unique(seen_ids)):
+            raise ValueError(
+                "The graph nodes do not have unique IDs, which can indicate the graph "
+                "structure has changed. Please use update_graph_information()."
+            )
 
     def get_all_parameter_values(self, recursive=True, seen=None):
         """Get the values of the current parameters and (optionally) those of

--- a/src/tdastro/effects/white_noise.py
+++ b/src/tdastro/effects/white_noise.py
@@ -10,11 +10,19 @@ class WhiteNoise(EffectModel):
     ----------
     scale : `float`
         The scale of the noise.
+    _rng : `numpy.random._generator.Generator`
+        This object's random number generator.
     """
 
     def __init__(self, scale, **kwargs):
+        self._rng = np.random.default_rng()
         super().__init__(**kwargs)
         self.add_parameter("scale", scale, required=True, **kwargs)
+
+    def _update_object_seed(self):
+        """Update the object seed to the new value."""
+        super()._update_object_seed()
+        self._rng = np.random.default_rng()
 
     def apply(self, flux_density, wavelengths=None, physical_model=None, **kwargs):
         """Apply the effect to observations (flux_density values)

--- a/src/tdastro/sources/galaxy_models.py
+++ b/src/tdastro/sources/galaxy_models.py
@@ -20,41 +20,6 @@ class GaussianGalaxy(PhysicalModel):
         super().__init__(**kwargs)
         self.add_parameter("galaxy_radius_std", radius, required=True, **kwargs)
         self.add_parameter("brightness", brightness, required=True, **kwargs)
-        self._rng = np.random.default_rng(self._object_seed)
-
-    def set_graph_base_seed(self, graph_base_seed):
-        """Set a new graph base seed.
-
-        Notes
-        -----
-        WARNING: This seed should almost never be set manually. Using the same
-        seed for multiple graph instances will produce biased samples.
-
-        Parameters
-        ----------
-        graph_base_seed : `int`, optional
-            A base random seed to use for this specific evaluation graph.
-        """
-        super().set_graph_base_seed(graph_base_seed)
-        self._rng = np.random.default_rng(self._object_seed)
-
-    def sample_ra(self):
-        """Sample an right ascension coordinate based on the center and radius of the galaxy.
-        Returns
-        -------
-        ra : `float`
-            The sampled right ascension in degrees.
-        """
-        return self._rng.normal(loc=self.ra, scale=self.galaxy_radius_std)
-
-    def sample_dec(self):
-        """Sample a declination coordinate based on the center and radius of the galaxy.
-        Returns
-        -------
-        dec : `float`
-            The sampled declination in degrees.
-        """
-        return self._rng.normal(loc=self.dec, scale=self.galaxy_radius_std)
 
     def _evaluate(self, times, wavelengths, ra=None, dec=None, **kwargs):
         """Draw effect-free observations for this object.

--- a/src/tdastro/sources/physical_model.py
+++ b/src/tdastro/sources/physical_model.py
@@ -150,11 +150,13 @@ class PhysicalModel(ParameterizedNode):
             All the keyword arguments, including the values needed to sample
             parameters.
         """
-        if self.background is not None and self.background.check_resample(self):
-            self.background.sample_parameters(include_effects, **kwargs)
-        super().sample_parameters(**kwargs)
+        # We use the same seen_nodes for all sampling calls so each node
+        # is sampled at most one time regardless of link structure.
+        seen_nodes = {}
+        if self.background is not None:
+            self.background._sample_helper(50, seen_nodes, **kwargs)
+        self._sample_helper(50, seen_nodes, **kwargs)
 
         if include_effects:
             for effect in self.effects:
-                if effect.check_resample(self):
-                    effect.sample_parameters(**kwargs)
+                effect._sample_helper(50, seen_nodes, **kwargs)

--- a/src/tdastro/util_nodes/np_random.py
+++ b/src/tdastro/util_nodes/np_random.py
@@ -90,17 +90,3 @@ class NumpyRandomFunc(FunctionNode):
         """
         args = self._build_args_dict(**kwargs)
         return self.func(**args)
-
-
-class NumpyUniformRA(NumpyRandomFunc):
-    """A helper class from generating RA from a uniform distribution [0, 360.0)"""
-
-    def __init__(self, low=0.0, high=360.0, **kwargs):
-        super().__init__("uniform", low=low, high=high, **kwargs)
-
-
-class NumpyUniformDec(NumpyRandomFunc):
-    """A helper class from generating Dec from a uniform distribution [-90.0, 90.0]"""
-
-    def __init__(self, low=-90.0, high=90.0, **kwargs):
-        super().__init__("uniform", low=low, high=high, **kwargs)

--- a/tests/tdastro/effects/test_white_noise.py
+++ b/tests/tdastro/effects/test_white_noise.py
@@ -1,16 +1,12 @@
 import numpy as np
 from tdastro.effects.white_noise import WhiteNoise
 from tdastro.sources.static_source import StaticSource
-
-
-def rand_generator():
-    """A test generator function."""
-    return 10.0 + 0.5 * np.random.rand(1)
+from tdastro.util_nodes.np_random import NumpyRandomFunc
 
 
 def test_white_noise() -> None:
     """Test that we can sample and create a WhiteNoise object."""
-    model = StaticSource(brightness=rand_generator)
+    model = StaticSource(brightness=100.0)
     model.add_effect(WhiteNoise(scale=0.01))
 
     times = np.array([1, 2, 3, 5, 10])
@@ -18,12 +14,13 @@ def test_white_noise() -> None:
 
     values = model.evaluate(times, wavelengths)
     assert values.shape == (5, 3)
-    assert not np.all(values == 10.0)
-    assert np.all(np.abs(values - 10.0) < 1.0)
+    assert not np.all(values == 100.0)
+    assert np.all(np.abs(values - 100.0) <= 1.0)
 
 
 def test_white_noise_random() -> None:
     """Test that we can resample effects to change their parameters."""
+    rand_generator = NumpyRandomFunc("uniform", low=1.0, high=2.0)
     wn_effect = WhiteNoise(scale=rand_generator)
     scale = wn_effect.scale
     wn_effect.sample_parameters()

--- a/tests/tdastro/sources/test_galaxy_models.py
+++ b/tests/tdastro/sources/test_galaxy_models.py
@@ -1,43 +1,20 @@
-import random
-
 import numpy as np
 from tdastro.sources.galaxy_models import GaussianGalaxy
 from tdastro.sources.static_source import StaticSource
-
-
-def _sample_ra(**kwargs):
-    """Return a random value between 0 and 360.
-
-    Parameters
-    ----------
-    **kwargs : `dict`, optional
-        Absorbs additional parameters
-    """
-    return 360.0 * random.random()
-
-
-def _sample_dec(**kwargs):
-    """Return a random value between -90 and 90.
-
-    Parameters
-    ----------
-    **kwargs : `dict`, optional
-        Absorbs additional parameters
-    """
-    return 180.0 * random.random() - 90.0
+from tdastro.util_nodes.np_random import NumpyRandomFunc, NumpyUniformDec, NumpyUniformRA
 
 
 def test_gaussian_galaxy() -> None:
     """Test that we can sample and create a StaticSource object."""
-    random.seed(1001)
-
-    host = GaussianGalaxy(ra=_sample_ra, dec=_sample_dec, brightness=10.0, radius=1.0 / 3600.0)
+    # Create a host galaxy anywhere on the sky.
+    host = GaussianGalaxy(ra=NumpyUniformRA(), dec=NumpyUniformDec(), brightness=10.0, radius=1.0 / 3600.0)
     host_ra = host.ra
     host_dec = host.dec
 
-    # We define the position of the source using Gaussian noise from the center
-    # of the host galaxy.
-    source = StaticSource(ra=host.sample_ra, dec=host.sample_dec, background=host, brightness=100.0)
+    # We define the position of the source using Gaussian noise from the center of the host galaxy.
+    offset_ra = NumpyRandomFunc("normal", loc=(host, "ra"), scale=host.galaxy_radius_std)
+    offset_dec = NumpyRandomFunc("normal", loc=(host, "dec"), scale=host.galaxy_radius_std)
+    source = StaticSource(ra=offset_ra, dec=offset_dec, background=host, brightness=100.0)
 
     # Both RA and dec should be "close" to (but not exactly at) the center of the galaxy.
     source_ra_offset = source.ra - host_ra

--- a/tests/tdastro/sources/test_galaxy_models.py
+++ b/tests/tdastro/sources/test_galaxy_models.py
@@ -1,20 +1,28 @@
 import numpy as np
 from tdastro.sources.galaxy_models import GaussianGalaxy
 from tdastro.sources.static_source import StaticSource
-from tdastro.util_nodes.np_random import NumpyRandomFunc, NumpyUniformDec, NumpyUniformRA
+from tdastro.util_nodes.np_random import NumpyRandomFunc
 
 
 def test_gaussian_galaxy() -> None:
     """Test that we can sample and create a StaticSource object."""
     # Create a host galaxy anywhere on the sky.
-    host = GaussianGalaxy(ra=NumpyUniformRA(), dec=NumpyUniformDec(), brightness=10.0, radius=1.0 / 3600.0)
+    host = GaussianGalaxy(
+        ra=NumpyRandomFunc("uniform", low=0.0, high=360.0),
+        dec=NumpyRandomFunc("uniform", low=-90.0, high=90.0),
+        brightness=10.0,
+        radius=1.0 / 3600.0,
+    )
     host_ra = host.ra
     host_dec = host.dec
 
     # We define the position of the source using Gaussian noise from the center of the host galaxy.
-    offset_ra = NumpyRandomFunc("normal", loc=(host, "ra"), scale=host.galaxy_radius_std)
-    offset_dec = NumpyRandomFunc("normal", loc=(host, "dec"), scale=host.galaxy_radius_std)
-    source = StaticSource(ra=offset_ra, dec=offset_dec, background=host, brightness=100.0)
+    source = StaticSource(
+        ra=NumpyRandomFunc("normal", loc=(host, "ra"), scale=host.galaxy_radius_std),
+        dec=NumpyRandomFunc("normal", loc=(host, "dec"), scale=host.galaxy_radius_std),
+        background=host,
+        brightness=100.0,
+    )
 
     # Both RA and dec should be "close" to (but not exactly at) the center of the galaxy.
     source_ra_offset = source.ra - host_ra

--- a/tests/tdastro/util_nodes/test_jax_random.py
+++ b/tests/tdastro/util_nodes/test_jax_random.py
@@ -5,7 +5,8 @@ from tdastro.util_nodes.jax_random import JaxRandomFunc, JaxRandomNormal
 
 def test_jax_random_uniform():
     """Test that we can generate numbers from a uniform distribution."""
-    jax_node = JaxRandomFunc(jax.random.uniform, graph_base_seed=100)
+    jax_node = JaxRandomFunc(jax.random.uniform, seed=100)
+    jax_node.set_seed(new_seed=100)
 
     values = np.array([jax_node.compute() for _ in range(10_000)])
     assert len(np.unique(values)) > 10
@@ -13,36 +14,51 @@ def test_jax_random_uniform():
     assert np.all(values >= 0.0)
     assert np.abs(np.mean(values) - 0.5) < 0.01
 
-    # If we reuse the seed, we get the same number.
-    jax_node2 = JaxRandomFunc(jax.random.uniform, graph_base_seed=100)
+    # If we reuse the seed, we get the same numbers.
+    jax_node2 = JaxRandomFunc(jax.random.uniform, seed=100)
+    values2 = np.array([jax_node2.compute() for _ in range(10_000)])
+    assert np.allclose(values, values2)
+
+    # If we reuse the seed, we get the same numbers.
+    jax_node2 = JaxRandomFunc(jax.random.uniform, seed=100)
+    values2 = np.array([jax_node2.compute() for _ in range(10_000)])
+    assert np.allclose(values, values2)
+
+    # If we use a different seed, we get different numbers
+    jax_node2 = JaxRandomFunc(jax.random.uniform, seed=101)
+    values2 = np.array([jax_node2.compute() for _ in range(10_000)])
+    assert not np.allclose(values, values2)
+
+    # We can also set the seed with `set_seed()`
+    jax_node2.set_seed(100)
     values2 = np.array([jax_node2.compute() for _ in range(10_000)])
     assert np.allclose(values, values2)
 
     # We can change the range.
-    jax_node3 = JaxRandomFunc(jax.random.uniform, graph_base_seed=101, minval=10.0, maxval=20.0)
+    jax_node3 = JaxRandomFunc(jax.random.uniform, seed=101, minval=10.0, maxval=20.0)
     values = np.array([jax_node3.compute() for _ in range(10_000)])
     assert len(np.unique(values)) > 10
     assert np.all(values <= 20.0)
     assert np.all(values >= 10.0)
-    assert np.abs(np.mean(values) - 15.0) < 0.05
+    assert np.abs(np.mean(values) - 15.0) < 0.5
 
     # We can override the range dynamically.
     values = np.array([jax_node3.compute(minval=2.0) for _ in range(10_000)])
     assert len(np.unique(values)) > 10
     assert np.all(values <= 20.0)
     assert np.all(values >= 2.0)
-    assert np.abs(np.mean(values) - 11.0) < 0.05
+    assert np.abs(np.mean(values) - 11.0) < 0.5
 
 
 def test_jax_random_normal():
     """Test that we can generate numbers from a normal distribution."""
-    jax_node = JaxRandomNormal(loc=100.0, scale=10.0, graph_base_seed=100)
+    jax_node = JaxRandomNormal(loc=100.0, scale=10.0, seed=100)
 
     values = np.array([jax_node.compute() for _ in range(10_000)])
     assert np.abs(np.mean(values) - 100.0) < 0.5
     assert np.abs(np.std(values) - 10.0) < 0.5
 
     # If we reuse the seed, we get the same number.
-    jax_node2 = JaxRandomNormal(loc=100.0, scale=10.0, graph_base_seed=100)
+    jax_node2 = JaxRandomNormal(loc=100.0, scale=10.0, seed=100)
     values2 = np.array([jax_node2.compute() for _ in range(10_000)])
     assert np.allclose(values, values2)

--- a/tests/tdastro/util_nodes/test_np_random.py
+++ b/tests/tdastro/util_nodes/test_np_random.py
@@ -1,10 +1,10 @@
 import numpy as np
-from tdastro.util_nodes.np_random import NumpyRandomFunc
+from tdastro.util_nodes.np_random import NumpyRandomFunc, NumpyUniformDec, NumpyUniformRA
 
 
 def test_numpy_random_uniform():
     """Test that we can generate numbers from a uniform distribution."""
-    np_node = NumpyRandomFunc("uniform", graph_base_seed=100)
+    np_node = NumpyRandomFunc("uniform", seed=100)
 
     values = np.array([np_node.compute() for _ in range(10_000)])
     assert len(np.unique(values)) > 10
@@ -12,36 +12,82 @@ def test_numpy_random_uniform():
     assert np.all(values >= 0.0)
     assert np.abs(np.mean(values) - 0.5) < 0.01
 
-    # If we reuse the seed, we get the same number.
-    np_node2 = NumpyRandomFunc("uniform", graph_base_seed=100)
+    # If we reuse the seed, we get the same numbers.
+    np_node2 = NumpyRandomFunc("uniform", seed=100)
+    values2 = np.array([np_node2.compute() for _ in range(10_000)])
+    assert np.allclose(values, values2)
+
+    # If we use a different seed, we get different numbers
+    np_node2 = NumpyRandomFunc("uniform", seed=101)
+    values2 = np.array([np_node2.compute() for _ in range(10_000)])
+    assert not np.allclose(values, values2)
+
+    # We can also set the seed with `set_seed()`
+    np_node2.set_seed(100)
     values2 = np.array([np_node2.compute() for _ in range(10_000)])
     assert np.allclose(values, values2)
 
     # We can change the range.
-    np_node3 = NumpyRandomFunc("uniform", graph_base_seed=101, low=10.0, high=20.0)
+    np_node3 = NumpyRandomFunc("uniform", low=10.0, high=20.0)
     values = np.array([np_node3.compute() for _ in range(10_000)])
     assert len(np.unique(values)) > 10
     assert np.all(values <= 20.0)
     assert np.all(values >= 10.0)
-    assert np.abs(np.mean(values) - 15.0) < 0.05
+    assert np.abs(np.mean(values) - 15.0) < 0.5
 
     # We can override the range dynamically.
     values = np.array([np_node3.compute(low=2.0) for _ in range(10_000)])
     assert len(np.unique(values)) > 10
     assert np.all(values <= 20.0)
     assert np.all(values >= 2.0)
-    assert np.abs(np.mean(values) - 11.0) < 0.05
+    assert np.abs(np.mean(values) - 11.0) < 0.5
 
 
 def test_numpy_random_normal():
     """Test that we can generate numbers from a normal distribution."""
-    np_node = NumpyRandomFunc("normal", loc=100.0, scale=10.0, graph_base_seed=100)
+    np_node = NumpyRandomFunc("normal", loc=100.0, scale=10.0, seed=100)
 
     values = np.array([np_node.compute() for _ in range(10_000)])
     assert np.abs(np.mean(values) - 100.0) < 0.5
     assert np.abs(np.std(values) - 10.0) < 0.5
 
     # If we reuse the seed, we get the same number.
-    jax_node2 = NumpyRandomFunc("normal", loc=100.0, scale=10.0, graph_base_seed=100)
-    values2 = np.array([jax_node2.compute() for _ in range(10_000)])
+    np_node2 = NumpyRandomFunc("normal", loc=100.0, scale=10.0, seed=100)
+    values2 = np.array([np_node2.compute() for _ in range(10_000)])
     assert np.allclose(values, values2)
+
+
+def test_numpy_random_ra():
+    """Test that we generate numbers [0.0, 360.0]"""
+    np_node = NumpyUniformRA()
+
+    values = np.array([np_node.compute() for _ in range(10_000)])
+    assert len(np.unique(values)) > 10
+    assert np.all(values <= 360.0)
+    assert np.all(values >= 0.0)
+    assert np.abs(np.mean(values) - 180.0) < 5.0
+
+    # We see at least one sample in each of the major bin.
+    num_bins = 10
+    for bin in range(num_bins):
+        start_val = bin * (360.0 / float(num_bins))
+        end_val = (bin + 1) * (360.0 / float(num_bins))
+        assert np.any((start_val < values) & (values < end_val))
+
+
+def test_numpy_random_dec():
+    """Test that we generate numbers [-90.0, 90.0]"""
+    np_node = NumpyUniformDec()
+
+    values = np.array([np_node.compute() for _ in range(10_000)])
+    assert len(np.unique(values)) > 10
+    assert np.all(values <= 90.0)
+    assert np.all(values >= -90.0)
+    assert np.abs(np.mean(values) - 0.0) < 5.0
+
+    # We see at least one sample in each of the major bin.
+    num_bins = 10
+    for bin in range(num_bins):
+        start_val = bin * (180.0 / float(num_bins)) - 90.0
+        end_val = (bin + 1) * (180.0 / float(num_bins)) - 90.0
+        assert np.any((start_val < values) & (values < end_val))

--- a/tests/tdastro/util_nodes/test_np_random.py
+++ b/tests/tdastro/util_nodes/test_np_random.py
@@ -1,5 +1,5 @@
 import numpy as np
-from tdastro.util_nodes.np_random import NumpyRandomFunc, NumpyUniformDec, NumpyUniformRA
+from tdastro.util_nodes.np_random import NumpyRandomFunc
 
 
 def test_numpy_random_uniform():
@@ -55,39 +55,3 @@ def test_numpy_random_normal():
     np_node2 = NumpyRandomFunc("normal", loc=100.0, scale=10.0, seed=100)
     values2 = np.array([np_node2.compute() for _ in range(10_000)])
     assert np.allclose(values, values2)
-
-
-def test_numpy_random_ra():
-    """Test that we generate numbers [0.0, 360.0]"""
-    np_node = NumpyUniformRA()
-
-    values = np.array([np_node.compute() for _ in range(10_000)])
-    assert len(np.unique(values)) > 10
-    assert np.all(values <= 360.0)
-    assert np.all(values >= 0.0)
-    assert np.abs(np.mean(values) - 180.0) < 5.0
-
-    # We see at least one sample in each of the major bin.
-    num_bins = 10
-    for bin in range(num_bins):
-        start_val = bin * (360.0 / float(num_bins))
-        end_val = (bin + 1) * (360.0 / float(num_bins))
-        assert np.any((start_val < values) & (values < end_val))
-
-
-def test_numpy_random_dec():
-    """Test that we generate numbers [-90.0, 90.0]"""
-    np_node = NumpyUniformDec()
-
-    values = np.array([np_node.compute() for _ in range(10_000)])
-    assert len(np.unique(values)) > 10
-    assert np.all(values <= 90.0)
-    assert np.all(values >= -90.0)
-    assert np.abs(np.mean(values) - 0.0) < 5.0
-
-    # We see at least one sample in each of the major bin.
-    num_bins = 10
-    for bin in range(num_bins):
-        start_val = bin * (180.0 / float(num_bins)) - 90.0
-        end_val = (bin + 1) * (180.0 / float(num_bins)) - 90.0
-        assert np.any((start_val < values) & (values < end_val))


### PR DESCRIPTION
Changes how the set is set in the `ParameterizedNode`. Seeds are still determined by a combination of a `graph_base_seed` (which is initially set to completely random) and the node's string. The node's string has been expanded to include its position in the graph (if known).

**Why?** The previous approach of just using the node’s identifier (and **not** the position in the graph) was easy to make a mistake when using two of the same nodes in the graph. This makes it more difficult for a user to make such a mistake.

Other changes:
- `sample_iteration` has been replaced by using a depth-first search and passing along the seen nodes. This will allow us to sample a subset of the graph while keeping the rest fixed. This means we can also get rid of `check_resample()`.
- `_node_id` has been added to provide a unique numeric ID to each node in the graph.
- `graph_base_seed` is no longer passed into the constructor of `ParameterizedNode`.
- A single `set_seed()` function takes care of setting the node's seed.
- A `update_graph_information()` function takes care of both numbering the graph nodes (using DFS ordering) and setting a new global seed if there is one.
- `sample_parameters()` now does node labeling if needed and validity checking.
- `WhiteNoise` effect nodes have a random number generator that is updated the same way as other graph nodes.
- The functions `sample_ra` and `sample_dec` in `GaussianGalaxy` were replaced by just using the numpy random functions that already exist.