### PR TITLE
Make the ordering of direct_dependencies stable

### DIFF
--- a/tests/tdastro/test_base_models.py
+++ b/tests/tdastro/test_base_models.py
@@ -157,9 +157,9 @@ def test_parameterized_node_attributes():
     # reset or sample is called for the first time.
     settings = model1.get_all_parameter_values(True)
     assert len(settings) == 3
-    assert settings["1=test_base_models.PairModel.value1"] == 0.5
-    assert settings["1=test_base_models.PairModel.value2"] == 1.5
-    assert settings["1=test_base_models.PairModel.value_sum"] == 2.0
+    assert settings["0: 1=test_base_models.PairModel.value1"] == 0.5
+    assert settings["0: 1=test_base_models.PairModel.value2"] == 1.5
+    assert settings["0: 1=test_base_models.PairModel.value_sum"] == 2.0
 
     # Use value1=model.value1 and value2=3.0
     model2 = PairModel(value1=model1, value2=3.0, node_identifier="2")
@@ -171,12 +171,12 @@ def test_parameterized_node_attributes():
 
     settings = model2.get_all_parameter_values(True)
     assert len(settings) == 6
-    assert settings["1=test_base_models.PairModel.value1"] == 0.5
-    assert settings["1=test_base_models.PairModel.value2"] == 1.5
-    assert settings["1=test_base_models.PairModel.value_sum"] == 2.0
-    assert settings["2=test_base_models.PairModel.value1"] == 0.5
-    assert settings["2=test_base_models.PairModel.value2"] == 3.0
-    assert settings["2=test_base_models.PairModel.value_sum"] == 3.5
+    assert settings["1: 1=test_base_models.PairModel.value1"] == 0.5
+    assert settings["1: 1=test_base_models.PairModel.value2"] == 1.5
+    assert settings["1: 1=test_base_models.PairModel.value_sum"] == 2.0
+    assert settings["0: 2=test_base_models.PairModel.value1"] == 0.5
+    assert settings["0: 2=test_base_models.PairModel.value2"] == 3.0
+    assert settings["0: 2=test_base_models.PairModel.value_sum"] == 3.5
 
 
 def test_parameterized_node_get_dependencies():


### PR DESCRIPTION
Make the ordering of `direct_dependencies` stable by changing it from a set to a dict. Test this by forcing an update of the graph numbering when we call `get_all_parameter_values()` and augmenting the test to check the node numbers (their names start with "number: ...").