### PR TITLE
Change how we access another node's attributes

### DIFF
--- a/src/tdastro/astro_utils/cosmology.py
+++ b/src/tdastro/astro_utils/cosmology.py
@@ -32,9 +32,6 @@ class RedshiftDistFunc(FunctionNode):
     ----------
     cosmology : `astropy.cosmology`
         The cosmology specification.
-    kind : `str`
-        The distance type for the Equivalency as defined by
-        astropy.cosmology.units.redshift_distance.
 
     Parameters
     ----------

--- a/src/tdastro/base_models.py
+++ b/src/tdastro/base_models.py
@@ -29,7 +29,7 @@ lightcurve. Each of these parameters might depend on parameters in other nodes, 
 as those of the host galaxy.
 
 The execution graph is processed by starting at the final node, examining each
-model parameter for that node, and recursively proceeding 'up' the graph for any'
+model parameter for that node, and recursively proceeding 'up' the graph for any
 of its parameters that has a dependency. For example the function.
 
 f(a, b) = x

--- a/src/tdastro/base_models.py
+++ b/src/tdastro/base_models.py
@@ -17,7 +17,7 @@ sources:
 4) The parameters of another ParameterizedNode.
 5) The method of another ParameterizedNode.
 
-We say that parameters X is dependent on parameters Y if the value of Y is necessary
+We say that parameter X is dependent on parameter Y if the value of Y is necessary
 to compute the value of X. For example if X is set by evaluating a FunctionNode that
 uses parameter Y in the computation, X is dependent on Y. The dependencies impose an
 ordering of model parameters in the graph. Y must be computed before X.

--- a/src/tdastro/effects/redshift.py
+++ b/src/tdastro/effects/redshift.py
@@ -53,10 +53,10 @@ class Redshift(EffectModel):
             which will later be redshifted  back to observer-frame flux densities at the observer-frame
             times and wavelengths.
         """
-        observed_times_rel_to_t0 = observer_frame_times - self.t0
-        rest_frame_times_rel_to_t0 = observed_times_rel_to_t0 / (1 + self.redshift)
-        rest_frame_times = rest_frame_times_rel_to_t0 + self.t0
-        rest_frame_wavelengths = observer_frame_wavelengths / (1 + self.redshift)
+        observed_times_rel_to_t0 = observer_frame_times - self.parameters["t0"]
+        rest_frame_times_rel_to_t0 = observed_times_rel_to_t0 / (1 + self.parameters["redshift"])
+        rest_frame_times = rest_frame_times_rel_to_t0 + self.parameters["t0"]
+        rest_frame_wavelengths = observer_frame_wavelengths / (1 + self.parameters["redshift"])
         return (rest_frame_times, rest_frame_wavelengths)
 
     def apply(self, flux_density, wavelengths, physical_model=None, **kwargs):
@@ -79,4 +79,4 @@ class Redshift(EffectModel):
         flux_density : `numpy.ndarray`
             The redshifted results.
         """
-        return flux_density / (1 + self.redshift)
+        return flux_density / (1 + self.parameters["redshift"])

--- a/src/tdastro/effects/white_noise.py
+++ b/src/tdastro/effects/white_noise.py
@@ -8,10 +8,13 @@ class WhiteNoise(EffectModel):
 
     Attributes
     ----------
-    scale : `float`
-        The scale of the noise.
     _rng : `numpy.random._generator.Generator`
         This object's random number generator.
+
+    Parameters
+    ----------
+    scale : `float`
+        The scale of the noise.
     """
 
     def __init__(self, scale, **kwargs):

--- a/src/tdastro/effects/white_noise.py
+++ b/src/tdastro/effects/white_noise.py
@@ -44,4 +44,4 @@ class WhiteNoise(EffectModel):
         flux_density : `numpy.ndarray`
             The results.
         """
-        return np.random.normal(loc=flux_density, scale=self.scale)
+        return np.random.normal(loc=flux_density, scale=self.parameters["scale"])

--- a/src/tdastro/populations/population_model.py
+++ b/src/tdastro/populations/population_model.py
@@ -64,7 +64,7 @@ class PopulationModel(ParameterizedNode):
         Raises
         ------
         Raises a ``AttributeError`` if the PhysicalModel does not have all of the
-        required attributes.
+        required model parameters.
         """
         for source in self.sources:
             source.add_effect(effect, allow_dups=allow_dups, **kwargs)

--- a/src/tdastro/sources/galaxy_models.py
+++ b/src/tdastro/sources/galaxy_models.py
@@ -42,18 +42,17 @@ class GaussianGalaxy(PhysicalModel):
         flux_density : `numpy.ndarray`
             A length T x N matrix of SED values.
         """
-        if ra is None:
-            ra = self.ra
-        if dec is None:
-            dec = self.dec
+        dist = 0.0
+        if ra is not None and dec is not None:
+            dist = angular_separation(
+                self.parameters["ra"] * np.pi / 180.0,
+                self.parameters["dec"] * np.pi / 180.0,
+                ra * np.pi / 180.0,
+                dec * np.pi / 180.0,
+            )
 
         # Scale the brightness as a Guassian function centered on the object's RA and Dec.
-        dist = angular_separation(
-            self.ra * np.pi / 180.0,
-            self.dec * np.pi / 180.0,
-            ra * np.pi / 180.0,
-            dec * np.pi / 180.0,
-        )
-        scale = np.exp(-(dist * dist) / (2.0 * self.galaxy_radius_std * self.galaxy_radius_std))
+        std = self.parameters["galaxy_radius_std"]
+        scale = np.exp(-(dist * dist) / (2.0 * std * std))
 
-        return np.full((len(times), len(wavelengths)), self.brightness * scale)
+        return np.full((len(times), len(wavelengths)), self.parameters["brightness"] * scale)

--- a/src/tdastro/sources/galaxy_models.py
+++ b/src/tdastro/sources/galaxy_models.py
@@ -7,13 +7,15 @@ from tdastro.sources.physical_model import PhysicalModel
 class GaussianGalaxy(PhysicalModel):
     """A static source.
 
-    Attributes
+    Parameters
     ----------
     radius_std : `float`
         The standard deviation of the brightness as we move away
         from the galaxy's center (in degrees).
     brightness : `float`
         The inherent brightness at the center of the galaxy.
+    **kwargs : `dict`, optional
+        Any additional keyword arguments.
     """
 
     def __init__(self, brightness, radius, **kwargs):

--- a/src/tdastro/sources/periodic_source.py
+++ b/src/tdastro/sources/periodic_source.py
@@ -57,7 +57,8 @@ class PeriodicSource(PhysicalModel, ABC):
         flux_density : `numpy.ndarray`
             A length T x N matrix of SED values.
         """
-        phases = (times - self.t0) % self.period / self.period
+        period = self.parameters["period"]
+        phases = (times - self.parameters["t0"]) % period / period
         flux_density = self._evaluate_phases(phases, wavelengths, **kwargs)
 
         return flux_density

--- a/src/tdastro/sources/periodic_source.py
+++ b/src/tdastro/sources/periodic_source.py
@@ -6,13 +6,15 @@ from tdastro.sources.physical_model import PhysicalModel
 class PeriodicSource(PhysicalModel, ABC):
     """A periodic source.
 
-    Attributes
+    Parameters
     ----------
     period : `float`
         The period of the source, in days.
     t0 : `float`
         The t0 of the zero phase, date. Could be date of the minimum or maximum light
         or any other reference time point.
+    **kwargs : `dict`, optional
+        Any additional keyword arguments.
     """
 
     def __init__(self, period, t0, **kwargs):

--- a/src/tdastro/sources/physical_model.py
+++ b/src/tdastro/sources/physical_model.py
@@ -45,7 +45,7 @@ class PhysicalModel(ParameterizedNode):
         if distance is not None:
             self.add_parameter("distance", distance)
         elif redshift is not None and kwargs.get("cosmology", None) is not None:
-            self._redshift_func = RedshiftDistFunc(redshift=self, **kwargs)
+            self._redshift_func = RedshiftDistFunc(redshift=self.redshift, **kwargs)
             self.add_parameter("distance", self._redshift_func)
         else:
             self.add_parameter("distance", None)
@@ -132,7 +132,13 @@ class PhysicalModel(ParameterizedNode):
         # behind it, such as a host galaxy.
         flux_density = self._evaluate(times, wavelengths, **kwargs)
         if self.background is not None:
-            flux_density += self.background._evaluate(times, wavelengths, ra=self.ra, dec=self.dec, **kwargs)
+            flux_density += self.background._evaluate(
+                times,
+                wavelengths,
+                ra=self.parameters["ra"],
+                dec=self.parameters["dec"],
+                **kwargs,
+            )
 
         for effect in self.effects:
             flux_density = effect.apply(flux_density, wavelengths, self, **kwargs)

--- a/src/tdastro/sources/physical_model.py
+++ b/src/tdastro/sources/physical_model.py
@@ -7,13 +7,22 @@ from tdastro.base_models import ParameterizedNode
 class PhysicalModel(ParameterizedNode):
     """A physical model of a source of flux.
 
-    Physical models can have fixed attributes (where you need to create a new model
-    to change them) and settable attributes that can be passed functions or constants.
-    They can also have special background pointers that link to another PhysicalModel
+    Physical models can have fixed attributes (where you need to create a new model or use
+    a setter function to change them) and settable model parameters that can be passed functions
+    or constants and are automatically updated by resampling the model parameters.
+
+    Physical models  can also have special background pointers that link to another PhysicalModel
     producing flux. We can chain these to have a supernova in front of a star in front
     of a static background.
 
     Attributes
+    ----------
+    background : `PhysicalModel`
+        A source of background flux such as a host galaxy.
+    effects : `list`
+        A list of effects to apply to an observations.
+
+    Parameters
     ----------
     ra : `float`
         The object's right ascension (in degrees)
@@ -27,8 +36,8 @@ class PhysicalModel(ParameterizedNode):
         the redshift and the cosmology.
     background : `PhysicalModel`
         A source of background flux such as a host galaxy.
-    effects : `list`
-        A list of effects to apply to an observations.
+    **kwargs : `dict`, optional
+        Any additional keyword arguments.
     """
 
     def __init__(self, ra=None, dec=None, redshift=None, distance=None, background=None, **kwargs):
@@ -70,7 +79,7 @@ class PhysicalModel(ParameterizedNode):
         Raises
         ------
         Raises a ``AttributeError`` if the PhysicalModel does not have all of the
-        required attributes.
+        required model parameters.
         """
         # Check that we have not added this effect before.
         if not allow_dups:

--- a/src/tdastro/sources/sncomso_models.py
+++ b/src/tdastro/sources/sncomso_models.py
@@ -38,7 +38,7 @@ class SncosmoWrapperModel(PhysicalModel):
         return self.source.param_names
 
     @property
-    def parameters(self):
+    def parameter_values(self):
         """Return a list of the model's parameter values."""
         return self.source.parameters
 

--- a/src/tdastro/sources/sncomso_models.py
+++ b/src/tdastro/sources/sncomso_models.py
@@ -18,6 +18,8 @@ class SncosmoWrapperModel(PhysicalModel):
         The underlying source model.
     source_name : `str`
         The name used to set the source.
+    source_param_names : `list`
+        A list of the source model's parameters that we need to set.
 
     Parameters
     ----------
@@ -32,6 +34,15 @@ class SncosmoWrapperModel(PhysicalModel):
         self.source_name = source_name
         self.source = get_source(source_name)
 
+        # Use the kwargs to initialize the sncosmo model's parameters.
+        self.source_param_names = []
+        for key, value in kwargs.items():
+            if key not in self.parameters:
+                self.add_parameter(key, value)
+            if key in self.source.param_names:
+                self.source_param_names.append(key)
+        self._update_sncosmo_model_parameters()
+
     @property
     def param_names(self):
         """Return a list of the model's parameter names."""
@@ -41,6 +52,13 @@ class SncosmoWrapperModel(PhysicalModel):
     def parameter_values(self):
         """Return a list of the model's parameter values."""
         return self.source.parameters
+
+    def _update_sncosmo_model_parameters(self):
+        """Update the parameters for the wrapped sncosmo model."""
+        params = {}
+        for name in self.source_param_names:
+            params[name] = self.parameters[name]
+        self.source.set(**params)
 
     def get(self, name):
         """Get the value of a specific parameter.
@@ -66,12 +84,41 @@ class SncosmoWrapperModel(PhysicalModel):
         **kwargs : `dict`
             The parameters to set and their values.
         """
-        self.source.set(**kwargs)
         for key, value in kwargs.items():
             if hasattr(self, key):
                 self.set_parameter(key, value)
             else:
                 self.add_parameter(key, value)
+            if key not in self.source_param_names:
+                self.source_param_names.append(key)
+        self._update_sncosmo_model_parameters()
+
+    def _sample_helper(self, depth, seen_nodes, **kwargs):
+        """Internal recursive function to sample the model's underlying parameters
+        if they are provided by a function or ParameterizedNode.
+
+        Calls ParameterNode's _sample_helper() then updates the parameters
+        for the sncosmo model.
+
+        Parameters
+        ----------
+        depth : `int`
+            The recursive depth remaining. Used to prevent infinite loops.
+            Users should not need to set this manually.
+        seen_nodes : `dict`
+            A dictionary mapping nodes seen during this sampling run to their ID.
+            Used to avoid sampling nodes multiple times and to validity check the graph.
+        **kwargs : `dict`, optional
+            All the keyword arguments, including the values needed to sample
+            parameters.
+
+        Raises
+        ------
+        Raise a ``ValueError`` the depth of the sampling encounters a problem
+        with the order of dependencies.
+        """
+        super()._sample_helper(depth, seen_nodes, **kwargs)
+        self._update_sncosmo_model_parameters()
 
     def _evaluate(self, times, wavelengths, **kwargs):
         """Draw effect-free observations for this object.

--- a/src/tdastro/sources/spline_model.py
+++ b/src/tdastro/sources/spline_model.py
@@ -25,8 +25,6 @@ class SplineModel(PhysicalModel):
         The spline object for predicting the flux from a given (time, wavelength).
     name : `str`
         The name of the model being used.
-    amplitude : `float`
-        A unitless scaling parameter for the flux density values.
 
     Parameters
     ----------

--- a/src/tdastro/sources/spline_model.py
+++ b/src/tdastro/sources/spline_model.py
@@ -88,4 +88,4 @@ class SplineModel(PhysicalModel):
         flux_density : `numpy.ndarray`
             A length T x N matrix of SED values.
         """
-        return self.amplitude * self._spline(times, wavelengths, grid=True)
+        return self.parameters["amplitude"] * self._spline(times, wavelengths, grid=True)

--- a/src/tdastro/sources/static_source.py
+++ b/src/tdastro/sources/static_source.py
@@ -6,10 +6,12 @@ from tdastro.sources.physical_model import PhysicalModel
 class StaticSource(PhysicalModel):
     """A static source.
 
-    Attributes
+    Parameters
     ----------
     brightness : `float`
         The inherent brightness
+    **kwargs : `dict`, optional
+        Any additional keyword arguments.
     """
 
     def __init__(self, brightness, **kwargs):
@@ -26,7 +28,7 @@ class StaticSource(PhysicalModel):
         wavelengths : `numpy.ndarray`, optional
             A length N array of wavelengths.
         **kwargs : `dict`, optional
-           Any additional keyword arguments.
+            Any additional keyword arguments.
 
         Returns
         -------

--- a/src/tdastro/sources/static_source.py
+++ b/src/tdastro/sources/static_source.py
@@ -33,4 +33,4 @@ class StaticSource(PhysicalModel):
         flux_density : `numpy.ndarray`
             A length T x N matrix of SED values.
         """
-        return np.full((len(times), len(wavelengths)), self.brightness)
+        return np.full((len(times), len(wavelengths)), self.parameters["brightness"])

--- a/src/tdastro/sources/step_source.py
+++ b/src/tdastro/sources/step_source.py
@@ -6,7 +6,7 @@ from tdastro.sources.static_source import StaticSource
 class StepSource(StaticSource):
     """A static source that is on for a fixed amount of time
 
-    Attributes
+    Parameters
     ----------
     brightness : `float`
         The inherent brightness
@@ -14,6 +14,8 @@ class StepSource(StaticSource):
         The time the step function starts
     t1 : `float`
         The time the step function ends
+    **kwargs : `dict`, optional
+        Any additional keyword arguments.
     """
 
     def __init__(self, brightness, t0, t1, **kwargs):

--- a/src/tdastro/sources/step_source.py
+++ b/src/tdastro/sources/step_source.py
@@ -40,6 +40,6 @@ class StepSource(StaticSource):
         """
         flux_density = np.zeros((len(times), len(wavelengths)))
 
-        time_mask = (times >= self.t0) & (times <= self.t1)
-        flux_density[time_mask] = self.brightness
+        time_mask = (times >= self.parameters["t0"]) & (times <= self.parameters["t1"])
+        flux_density[time_mask] = self.parameters["brightness"]
         return flux_density

--- a/src/tdastro/util_nodes/jax_random.py
+++ b/src/tdastro/util_nodes/jax_random.py
@@ -86,12 +86,14 @@ class JaxRandomNormal(JaxRandomFunc):
     """A wrapper for the JAX normal function that takes
     a mean and std.
 
-    Attributes
+    Parameters
     ----------
     loc : `float`
         The mean of the distribution.
     scale : `float`
         The std of the distribution.
+    **kwargs : `dict`, optional
+        Any additional keyword arguments.
     """
 
     def __init__(self, loc, scale, **kwargs):

--- a/src/tdastro/util_nodes/jax_random.py
+++ b/src/tdastro/util_nodes/jax_random.py
@@ -111,6 +111,6 @@ class JaxRandomNormal(JaxRandomFunc):
             Additional function arguments.
         """
         initial_value = super().compute(**kwargs)
-        local_mean = kwargs.get("loc", self.loc)
-        local_std = kwargs.get("scale", self.scale)
+        local_mean = kwargs.get("loc", self.parameters["loc"])
+        local_std = kwargs.get("scale", self.parameters["scale"])
         return local_std * initial_value + local_mean

--- a/tests/tdastro/effects/test_white_noise.py
+++ b/tests/tdastro/effects/test_white_noise.py
@@ -22,13 +22,13 @@ def test_white_noise_random() -> None:
     """Test that we can resample effects to change their parameters."""
     rand_generator = NumpyRandomFunc("uniform", low=1.0, high=2.0)
     wn_effect = WhiteNoise(scale=rand_generator)
-    scale = wn_effect.scale
+    scale = wn_effect["scale"]
     wn_effect.sample_parameters()
-    assert scale != wn_effect.scale
+    assert scale != wn_effect["scale"]
 
     # We can resample when it is added to a PhysicalObject.
     model = StaticSource(brightness=10.0)
     model.add_effect(WhiteNoise(scale=rand_generator))
-    scale = model.effects[0].scale
+    scale = model.effects[0]["scale"]
     model.sample_parameters()
-    assert model.effects[0].scale != scale
+    assert model.effects[0]["scale"] != scale

--- a/tests/tdastro/populations/test_fixed_population.py
+++ b/tests/tdastro/populations/test_fixed_population.py
@@ -72,7 +72,7 @@ def test_fixed_population_sample_sources():
     counts = [0.0, 0.0, 0.0]
     for _ in range(itr):
         model = population.draw_source()
-        counts[int(model.brightness)] += 1.0
+        counts[int(model["brightness"])] += 1.0
     assert np.allclose(counts, [0.25 * itr, 0.25 * itr, 0.5 * itr], rtol=0.05)
 
     # Check the we can change a rate.
@@ -81,7 +81,7 @@ def test_fixed_population_sample_sources():
     counts = [0.0, 0.0, 0.0]
     for _ in range(itr):
         model = population.draw_source()
-        counts[int(model.brightness)] += 1.0
+        counts[int(model["brightness"])] += 1.0
     assert np.allclose(counts, [0.4 * itr, 0.2 * itr, 0.4 * itr], rtol=0.05)
 
 

--- a/tests/tdastro/sources/test_galaxy_models.py
+++ b/tests/tdastro/sources/test_galaxy_models.py
@@ -13,22 +13,22 @@ def test_gaussian_galaxy() -> None:
         brightness=10.0,
         radius=1.0 / 3600.0,
     )
-    host_ra = host.ra
-    host_dec = host.dec
+    host_ra = host["ra"]
+    host_dec = host["dec"]
 
     # We define the position of the source using Gaussian noise from the center of the host galaxy.
     source = StaticSource(
-        ra=NumpyRandomFunc("normal", loc=(host, "ra"), scale=host.galaxy_radius_std),
-        dec=NumpyRandomFunc("normal", loc=(host, "dec"), scale=host.galaxy_radius_std),
+        ra=NumpyRandomFunc("normal", loc=host.ra, scale=host.galaxy_radius_std),
+        dec=NumpyRandomFunc("normal", loc=host.dec, scale=host.galaxy_radius_std),
         background=host,
         brightness=100.0,
     )
 
     # Both RA and dec should be "close" to (but not exactly at) the center of the galaxy.
-    source_ra_offset = source.ra - host_ra
+    source_ra_offset = source["ra"] - host_ra
     assert 0.0 < np.abs(source_ra_offset) < 100.0 / 3600.0
 
-    source_dec_offset = source.dec - host_dec
+    source_dec_offset = source["dec"] - host_dec
     assert 0.0 < np.abs(source_dec_offset) < 100.0 / 3600.0
 
     times = np.array([1, 2, 3, 4, 5, 10])
@@ -43,13 +43,13 @@ def test_gaussian_galaxy() -> None:
     # Check that if we resample the source it will propagate and correctly resample the host.
     # the host's (RA, dec) should change and the source's should still be close.
     source.sample_parameters()
-    assert host_ra != host.ra
-    assert host_dec != host.dec
+    assert host_ra != host["ra"]
+    assert host_dec != host["dec"]
 
-    source_ra_offset2 = source.ra - host.ra
+    source_ra_offset2 = source["ra"] - host["ra"]
     assert source_ra_offset != source_ra_offset2
     assert 0.0 < np.abs(source_ra_offset2) < 100.0 / 3600.0
 
-    source_dec_offset2 = source.dec - host.dec
+    source_dec_offset2 = source["dec"] - host["dec"]
     assert source_dec_offset != source_dec_offset2
     assert 0.0 < np.abs(source_ra_offset2) < 100.0 / 3600.0

--- a/tests/tdastro/sources/test_physical_models.py
+++ b/tests/tdastro/sources/test_physical_models.py
@@ -6,24 +6,24 @@ def test_physical_model():
     """Test that we can create a PhysicalModel."""
     # Everything is specified.
     model1 = PhysicalModel(ra=1.0, dec=2.0, distance=3.0, redshift=0.0)
-    assert model1.ra == 1.0
-    assert model1.dec == 2.0
-    assert model1.distance == 3.0
-    assert model1.redshift == 0.0
+    assert model1["ra"] == 1.0
+    assert model1["dec"] == 2.0
+    assert model1["distance"] == 3.0
+    assert model1["redshift"] == 0.0
 
     # Derive the distance from the redshift:
     model2 = PhysicalModel(ra=1.0, dec=2.0, redshift=1100.0, cosmology=Planck18)
-    assert model2.ra == 1.0
-    assert model2.dec == 2.0
-    assert model2.redshift == 1100.0
-    assert 13.0 * 1e12 < model2.distance < 16.0 * 1e12
+    assert model2["ra"] == 1.0
+    assert model2["dec"] == 2.0
+    assert model2["redshift"] == 1100.0
+    assert 13.0 * 1e12 < model2["distance"] < 16.0 * 1e12
 
     # Neither distance nor redshift are specified.
     model3 = PhysicalModel(ra=1.0, dec=2.0)
-    assert model3.redshift is None
-    assert model3.distance is None
+    assert model3["redshift"] is None
+    assert model3["distance"] is None
 
     # Redshift is specified but cosmology is not.
     model4 = PhysicalModel(ra=1.0, dec=2.0, redshift=1100.0)
-    assert model4.redshift == 1100.0
-    assert model4.distance is None
+    assert model4["redshift"] == 1100.0
+    assert model4["distance"] is None

--- a/tests/tdastro/sources/test_sncosmo_models.py
+++ b/tests/tdastro/sources/test_sncosmo_models.py
@@ -1,12 +1,12 @@
 import numpy as np
 from tdastro.sources.sncomso_models import SncosmoWrapperModel
+from tdastro.util_nodes.np_random import NumpyRandomFunc
 
 
 def test_sncomso_models_hsiao() -> None:
     """Test that we can create and evalue a 'hsiao' model."""
-    model = SncosmoWrapperModel("hsiao")
-    model.set(amplitude=1.0e-10)
-    assert model.get_parameter("amplitude") == 1.0e-10
+    model = SncosmoWrapperModel("hsiao", amplitude=1.0e-10)
+    assert model["amplitude"] == 1.0e-10
     assert str(model) == "tdastro.sources.sncomso_models.SncosmoWrapperModel"
 
     assert np.array_equal(model.param_names, ["amplitude"])
@@ -15,3 +15,40 @@ def test_sncomso_models_hsiao() -> None:
     # Test with the example from: https://sncosmo.readthedocs.io/en/stable/models.html
     fluxes = model.evaluate([54990.0], [4000.0, 4100.0, 4200.0])
     assert np.allclose(fluxes, [4.31210900e-20, 7.46619962e-20, 1.42182787e-19])
+
+
+def test_sncomso_models_set() -> None:
+    """Test that we can create and evalue a 'hsiao' model and set parameter."""
+    model = SncosmoWrapperModel("hsiao")
+
+    # sncosmo parameters exist at default values.
+    assert np.array_equal(model.param_names, ["amplitude"])
+    assert np.array_equal(model.parameter_values, [1.0])
+
+    model.set(amplitude=100.0)
+    assert model["amplitude"] == 100.0
+    assert np.array_equal(model.param_names, ["amplitude"])
+    assert np.array_equal(model.parameter_values, [100.0])
+
+
+def test_sncomso_models_chained() -> None:
+    """Test that we can create and evalue a 'hsiao' model using randomized parameters."""
+    model = SncosmoWrapperModel(
+        "hsiao",
+        amplitude=NumpyRandomFunc("uniform", low=2.0, high=12.0),
+    )
+    assert np.array_equal(model.param_names, ["amplitude"])
+    assert 2.0 <= model.parameter_values[0] <= 12.0
+
+    # When we resample, we get different model parameters. Create a histogram
+    # of 10,000 samples.
+    hist = [0] * 10
+    source_model = model.source
+    for _ in range(10_000):
+        model.sample_parameters()
+        bin = int(source_model.parameters[0] - 2.0)
+        hist[bin] += 1
+
+    # Each bin should have around 1,000 samples.
+    for i in range(10):
+        assert 800 < hist[i] < 1200

--- a/tests/tdastro/sources/test_sncosmo_models.py
+++ b/tests/tdastro/sources/test_sncosmo_models.py
@@ -6,11 +6,11 @@ def test_sncomso_models_hsiao() -> None:
     """Test that we can create and evalue a 'hsiao' model."""
     model = SncosmoWrapperModel("hsiao")
     model.set(amplitude=1.0e-10)
-    assert model.amplitude == 1.0e-10
+    assert model.get_parameter("amplitude") == 1.0e-10
     assert str(model) == "tdastro.sources.sncomso_models.SncosmoWrapperModel"
 
     assert np.array_equal(model.param_names, ["amplitude"])
-    assert np.array_equal(model.parameters, [1.0e-10])
+    assert np.array_equal(model.parameter_values, [1.0e-10])
 
     # Test with the example from: https://sncosmo.readthedocs.io/en/stable/models.html
     fluxes = model.evaluate([54990.0], [4000.0, 4100.0, 4200.0])

--- a/tests/tdastro/sources/test_static_source.py
+++ b/tests/tdastro/sources/test_static_source.py
@@ -20,10 +20,10 @@ def _sampler_fun(magnitude, **kwargs):
 def test_static_source() -> None:
     """Test that we can sample and create a StaticSource object."""
     model = StaticSource(brightness=10.0, node_identifier="my_static_source")
-    assert model.brightness == 10.0
-    assert model.ra is None
-    assert model.dec is None
-    assert model.distance is None
+    assert model.get_parameter("brightness") == 10.0
+    assert model.get_parameter("ra") is None
+    assert model.get_parameter("dec") is None
+    assert model.get_parameter("distance") is None
     assert str(model) == "my_static_source=tdastro.sources.static_source.StaticSource"
 
     times = np.array([1, 2, 3, 4, 5, 10])
@@ -44,11 +44,11 @@ def test_static_source_host() -> None:
     """Test that we can sample and create a StaticSource object with properties
     derived from the host object."""
     host = StaticSource(brightness=15.0, ra=1.0, dec=2.0, distance=3.0)
-    model = StaticSource(brightness=10.0, ra=host, dec=host, distance=host)
-    assert model.brightness == 10.0
-    assert model.ra == 1.0
-    assert model.dec == 2.0
-    assert model.distance == 3.0
+    model = StaticSource(brightness=10.0, ra=host.ra, dec=host.dec, distance=host.distance)
+    assert model.get_parameter("brightness") == 10.0
+    assert model.get_parameter("ra") == 1.0
+    assert model.get_parameter("dec") == 2.0
+    assert model.get_parameter("distance") == 3.0
     assert str(model) == "tdastro.sources.static_source.StaticSource"
 
 
@@ -60,7 +60,7 @@ def test_static_source_resample() -> None:
     values = np.zeros((num_samples, 1))
     for i in range(num_samples):
         model.sample_parameters(magnitude=100.0)
-        values[i] = model.brightness
+        values[i] = model.get_parameter("brightness")
 
     # Check that the values fall within the expected bounds.
     assert np.all(values >= 0.0)

--- a/tests/tdastro/sources/test_step_source.py
+++ b/tests/tdastro/sources/test_step_source.py
@@ -36,12 +36,12 @@ def test_step_source() -> None:
     """Test that we can sample and create a StepSource object."""
     host = StaticSource(brightness=150.0, ra=1.0, dec=2.0, distance=3.0)
     model = StepSource(brightness=15.0, t0=1.0, t1=2.0, ra=host, dec=host, distance=host)
-    assert model.brightness == 15.0
-    assert model.t0 == 1.0
-    assert model.t1 == 2.0
-    assert model.ra == 1.0
-    assert model.dec == 2.0
-    assert model.distance == 3.0
+    assert model.get_parameter("brightness") == 15.0
+    assert model.get_parameter("t0") == 1.0
+    assert model.get_parameter("t1") == 2.0
+    assert model.get_parameter("ra") == 1.0
+    assert model.get_parameter("dec") == 2.0
+    assert model.get_parameter("distance") == 3.0
 
     times = np.array([0.0, 1.0, 2.0, 3.0])
     wavelengths = np.array([100.0, 200.0])
@@ -68,9 +68,9 @@ def test_step_source_resample() -> None:
     t_start_vals = np.zeros((num_samples, 1))
     for i in range(num_samples):
         model.sample_parameters()
-        brightness_vals[i] = model.brightness
-        t_end_vals[i] = model.t1
-        t_start_vals[i] = model.t0
+        brightness_vals[i] = model.get_parameter("brightness")
+        t_end_vals[i] = model.get_parameter("t1")
+        t_start_vals[i] = model.get_parameter("t0")
 
     # Check that the values fall within the expected bounds.
     assert np.all(brightness_vals >= 0.0)

--- a/tests/tdastro/test_base_models.py
+++ b/tests/tdastro/test_base_models.py
@@ -32,7 +32,7 @@ def _test_func(value1, value2):
 class PairModel(ParameterizedNode):
     """A test class for the ParameterizedNode.
 
-    Attributes
+    Parameters
     ----------
     value1 : `float`
         The first value.
@@ -40,6 +40,8 @@ class PairModel(ParameterizedNode):
         The second value.
     value_sum : `float`
         The sum of the two values.
+    **kwargs : `dict`, optional
+        Any additional keyword arguments.
     """
 
     def __init__(self, value1, value2, **kwargs):
@@ -128,7 +130,7 @@ def test_parameterized_node():
 
 
 def test_parameterized_node_overwrite():
-    """Test that we can overwrite attributes in a PairModel."""
+    """Test that we can overwrite parameters in a PairModel."""
     model1 = PairModel(value1=0.5, value2=0.5)
     assert model1["value1"] == 0.5
     assert model1["value2"] == 0.5
@@ -144,8 +146,8 @@ def test_parameterized_node_overwrite():
     assert model1["value1"] == 1.0
 
 
-def test_parameterized_node_attributes():
-    """Test that we can extract the attributes of a graph of ParameterizedNode."""
+def test_parameterized_node_parameters():
+    """Test that we can extract the parameters of a graph of ParameterizedNode."""
     model1 = PairModel(value1=0.5, value2=1.5, node_identifier="1")
     settings = model1.get_all_parameter_values(False)
     assert len(settings) == 3
@@ -153,7 +155,7 @@ def test_parameterized_node_attributes():
     assert settings["value2"] == 1.5
     assert settings["value_sum"] == 2.0
 
-    # The model has 5 attributes in the graph: 3 in model1 and 2
+    # The model has 5 parameters in the graph: 3 in model1 and 2
     # in its summation FunctionNode. Note Node ID's are -1 until
     # reset or sample is called for the first time.
     settings = model1.get_all_parameter_values(True)
@@ -181,7 +183,7 @@ def test_parameterized_node_attributes():
 
 
 def test_parameterized_node_get_dependencies():
-    """Test that we can extract the attributes of a graph of ParameterizedNode."""
+    """Test that we can extract the parameters of a graph of ParameterizedNode."""
     model1 = PairModel(value1=0.5, value2=1.5, node_identifier="1")
     assert len(model1.direct_dependencies) == 0
 
@@ -331,13 +333,13 @@ def test_function_node_obj():
     model = PairModel(value1=10.0, value2=func)
     assert model.result() == 21.0
 
-    # Function depends on the model's value2 attribute.
+    # Function depends on the model's value2 parameter.
     model = PairModel(value1=-10.0, value2=17.5)
     func = FunctionNode(_test_func, value1=5.0, value2=model.value2)
     assert model.result() == 7.5
     assert func.compute() == 22.5
 
-    # We can always override the attributes with kwargs.
+    # We can always override the node's parameters with kwargs.
     assert func.compute(value1=1.0, value2=4.0) == 5.0
 
 


### PR DESCRIPTION
Change how both node's parameters are stored in the `ParameterizedNode` objects and how they are access. Instead of storing each parameter as an object attribute (and using `getattr()` and `setattr()`), we now store the parameter values in a dictionary called `parameters`.

**Why?** Being able to access the parameter's directly could lead to confusion during chaining and accidental setting of attributes. For example doing something like `source.ra = 10.0` could cause a problem is the source's RA is supposed to be set from the host. Similarly saying `x1=HostmassX1Func(host.hostmass)` would set `x1` as the current value of the hostmass instead of linking to the object's parameter.

Practically this means that now parameters are referenced via the `parameter` dictionary within a node

**OLD**:
```
return np.full((len(times), len(wavelengths)), self.brightness)
```
becomes.

**NEW**:
```
return np.full((len(times), len(wavelengths)), self.parameters["brightness"])
```

while this is more verbose, it is a lot less accident prone.

A `__getitem__()` function is also provided so the parameters can be accessed from outside the object as if it were a dictionary.

**OLD**:
```
assert source.brightness == 10.0
```
becomes.

**NEW**:
```
assert source["brightness"] == 10.0
```

Finally we create an accessor function with the same name as the parameter so
```
node.add_parameter("x", 10)
```
automatically creates a function `node.x()` which will access the value. This allows us to use a natural short hand when chaining attributes, such as:
```
new_obj = SomeComplexObjectType(value1=old_object.value1, value2=other_object.sum_of_values)
```
where `old_object` has a parameter `value1` and `other_object` has a parameter `sum_of_values`. The code will now do the correct thing and link the objects instead of capturing only those parameter's current values.