### PR TITLE
Fix parameter setting for sncosmo models

### DIFF
--- a/src/tdastro/sources/sncomso_models.py
+++ b/src/tdastro/sources/sncomso_models.py
@@ -18,6 +18,8 @@ class SncosmoWrapperModel(PhysicalModel):
         The underlying source model.
     source_name : `str`
         The name used to set the source.
+    source_param_names : `list`
+        A list of the source model's parameters that we need to set.
 
     Parameters
     ----------
@@ -32,15 +34,31 @@ class SncosmoWrapperModel(PhysicalModel):
         self.source_name = source_name
         self.source = get_source(source_name)
 
+        # Use the kwargs to initialize the sncosmo model's parameters.
+        self.source_param_names = []
+        for key, value in kwargs.items():
+            if not hasattr(self, key):
+                self.add_parameter(key, value)
+            if key in self.source.param_names:
+                self.source_param_names.append(key)
+        self._update_sncosmo_model_parameters()
+
     @property
     def param_names(self):
         """Return a list of the model's parameter names."""
         return self.source.param_names
 
     @property
-    def parameters(self):
+    def parameter_values(self):
         """Return a list of the model's parameter values."""
         return self.source.parameters
+
+    def _update_sncosmo_model_parameters(self):
+        """Update the parameters for the wrapped sncosmo model."""
+        params = {}
+        for name in self.source_param_names:
+            params[name] = getattr(self, name)
+        self.source.set(**params)
 
     def get(self, name):
         """Get the value of a specific parameter.
@@ -66,12 +84,41 @@ class SncosmoWrapperModel(PhysicalModel):
         **kwargs : `dict`
             The parameters to set and their values.
         """
-        self.source.set(**kwargs)
         for key, value in kwargs.items():
             if hasattr(self, key):
                 self.set_parameter(key, value)
             else:
                 self.add_parameter(key, value)
+            if key not in self.source_param_names:
+                self.source_param_names.append(key)
+        self._update_sncosmo_model_parameters()
+
+    def _sample_helper(self, depth, seen_nodes, **kwargs):
+        """Internal recursive function to sample the model's underlying parameters
+        if they are provided by a function or ParameterizedNode.
+
+        Calls ParameterNode's _sample_helper() then updates the parameters
+        for the sncosmo model.
+
+        Parameters
+        ----------
+        depth : `int`
+            The recursive depth remaining. Used to prevent infinite loops.
+            Users should not need to set this manually.
+        seen_nodes : `dict`
+            A dictionary mapping nodes seen during this sampling run to their ID.
+            Used to avoid sampling nodes multiple times and to validity check the graph.
+        **kwargs : `dict`, optional
+            All the keyword arguments, including the values needed to sample
+            parameters.
+
+        Raises
+        ------
+        Raise a ``ValueError`` the depth of the sampling encounters a problem
+        with the order of dependencies.
+        """
+        super()._sample_helper(depth, seen_nodes, **kwargs)
+        self._update_sncosmo_model_parameters()
 
     def _evaluate(self, times, wavelengths, **kwargs):
         """Draw effect-free observations for this object.

--- a/tests/tdastro/sources/test_sncosmo_models.py
+++ b/tests/tdastro/sources/test_sncosmo_models.py
@@ -1,17 +1,54 @@
 import numpy as np
 from tdastro.sources.sncomso_models import SncosmoWrapperModel
+from tdastro.util_nodes.np_random import NumpyRandomFunc
 
 
 def test_sncomso_models_hsiao() -> None:
     """Test that we can create and evalue a 'hsiao' model."""
-    model = SncosmoWrapperModel("hsiao")
-    model.set(amplitude=1.0e-10)
+    model = SncosmoWrapperModel("hsiao", amplitude=1.0e-10)
     assert model.amplitude == 1.0e-10
     assert str(model) == "tdastro.sources.sncomso_models.SncosmoWrapperModel"
 
     assert np.array_equal(model.param_names, ["amplitude"])
-    assert np.array_equal(model.parameters, [1.0e-10])
+    assert np.array_equal(model.parameter_values, [1.0e-10])
 
     # Test with the example from: https://sncosmo.readthedocs.io/en/stable/models.html
     fluxes = model.evaluate([54990.0], [4000.0, 4100.0, 4200.0])
     assert np.allclose(fluxes, [4.31210900e-20, 7.46619962e-20, 1.42182787e-19])
+
+
+def test_sncomso_models_set() -> None:
+    """Test that we can create and evalue a 'hsiao' model and set parameter."""
+    model = SncosmoWrapperModel("hsiao")
+
+    # sncosmo parameters exist at default values.
+    assert np.array_equal(model.param_names, ["amplitude"])
+    assert np.array_equal(model.parameter_values, [1.0])
+
+    model.set(amplitude=100.0)
+    assert model.amplitude == 100.0
+    assert np.array_equal(model.param_names, ["amplitude"])
+    assert np.array_equal(model.parameter_values, [100.0])
+
+
+def test_sncomso_models_chained() -> None:
+    """Test that we can create and evalue a 'hsiao' model using randomized parameters."""
+    model = SncosmoWrapperModel(
+        "hsiao",
+        amplitude=NumpyRandomFunc("uniform", low=2.0, high=12.0),
+    )
+    assert np.array_equal(model.param_names, ["amplitude"])
+    assert 2.0 <= model.parameter_values[0] <= 12.0
+
+    # When we resample, we get different model parameters. Create a histogram
+    # of 10,000 samples.
+    hist = [0] * 10
+    source_model = model.source
+    for _ in range(10_000):
+        model.sample_parameters()
+        bin = int(source_model.parameters[0] - 2.0)
+        hist[bin] += 1
+
+    # Each bin should have around 1,000 samples.
+    for i in range(10):
+        assert 800 < hist[i] < 1200

--- a/tests/tdastro/sources/test_sncosmo_models.py
+++ b/tests/tdastro/sources/test_sncosmo_models.py
@@ -33,9 +33,11 @@ def test_sncomso_models_set() -> None:
 
 def test_sncomso_models_chained() -> None:
     """Test that we can create and evalue a 'hsiao' model using randomized parameters."""
+    # Generate the amplitude from a uniform distribution, but use a fixed seed so we have
+    # reproducible tests.
     model = SncosmoWrapperModel(
         "hsiao",
-        amplitude=NumpyRandomFunc("uniform", low=2.0, high=12.0),
+        amplitude=NumpyRandomFunc("uniform", low=2.0, high=12.0, seed=100),
     )
     assert np.array_equal(model.param_names, ["amplitude"])
     assert 2.0 <= model.parameter_values[0] <= 12.0


### PR DESCRIPTION
Fix a problem where the parameter setting to a `SncosmoWrapperModel` were not be propagated to the underlying model. We need to call `self.source.set()` with the correct parameters each time the wrapper model itself is updated. This PR makes that automatic.