### PR TITLE
Remove unused get_parameter() function

### DIFF
--- a/tests/tdastro/sources/test_static_source.py
+++ b/tests/tdastro/sources/test_static_source.py
@@ -20,10 +20,10 @@ def _sampler_fun(magnitude, **kwargs):
 def test_static_source() -> None:
     """Test that we can sample and create a StaticSource object."""
     model = StaticSource(brightness=10.0, node_identifier="my_static_source")
-    assert model.get_parameter("brightness") == 10.0
-    assert model.get_parameter("ra") is None
-    assert model.get_parameter("dec") is None
-    assert model.get_parameter("distance") is None
+    assert model["brightness"] == 10.0
+    assert model["ra"] is None
+    assert model["dec"] is None
+    assert model["distance"] is None
     assert str(model) == "my_static_source=tdastro.sources.static_source.StaticSource"
 
     times = np.array([1, 2, 3, 4, 5, 10])
@@ -45,10 +45,10 @@ def test_static_source_host() -> None:
     derived from the host object."""
     host = StaticSource(brightness=15.0, ra=1.0, dec=2.0, distance=3.0)
     model = StaticSource(brightness=10.0, ra=host.ra, dec=host.dec, distance=host.distance)
-    assert model.get_parameter("brightness") == 10.0
-    assert model.get_parameter("ra") == 1.0
-    assert model.get_parameter("dec") == 2.0
-    assert model.get_parameter("distance") == 3.0
+    assert model["brightness"] == 10.0
+    assert model["ra"] == 1.0
+    assert model["dec"] == 2.0
+    assert model["distance"] == 3.0
     assert str(model) == "tdastro.sources.static_source.StaticSource"
 
 
@@ -60,7 +60,7 @@ def test_static_source_resample() -> None:
     values = np.zeros((num_samples, 1))
     for i in range(num_samples):
         model.sample_parameters(magnitude=100.0)
-        values[i] = model.get_parameter("brightness")
+        values[i] = model["brightness"]
 
     # Check that the values fall within the expected bounds.
     assert np.all(values >= 0.0)

--- a/tests/tdastro/sources/test_step_source.py
+++ b/tests/tdastro/sources/test_step_source.py
@@ -36,12 +36,12 @@ def test_step_source() -> None:
     """Test that we can sample and create a StepSource object."""
     host = StaticSource(brightness=150.0, ra=1.0, dec=2.0, distance=3.0)
     model = StepSource(brightness=15.0, t0=1.0, t1=2.0, ra=host, dec=host, distance=host)
-    assert model.get_parameter("brightness") == 15.0
-    assert model.get_parameter("t0") == 1.0
-    assert model.get_parameter("t1") == 2.0
-    assert model.get_parameter("ra") == 1.0
-    assert model.get_parameter("dec") == 2.0
-    assert model.get_parameter("distance") == 3.0
+    assert model["brightness"] == 15.0
+    assert model["t0"] == 1.0
+    assert model["t1"] == 2.0
+    assert model["ra"] == 1.0
+    assert model["dec"] == 2.0
+    assert model["distance"] == 3.0
 
     times = np.array([0.0, 1.0, 2.0, 3.0])
     wavelengths = np.array([100.0, 200.0])
@@ -68,9 +68,9 @@ def test_step_source_resample() -> None:
     t_start_vals = np.zeros((num_samples, 1))
     for i in range(num_samples):
         model.sample_parameters()
-        brightness_vals[i] = model.get_parameter("brightness")
-        t_end_vals[i] = model.get_parameter("t1")
-        t_start_vals[i] = model.get_parameter("t0")
+        brightness_vals[i] = model["brightness"]
+        t_end_vals[i] = model["t1"]
+        t_start_vals[i] = model["t0"]
 
     # Check that the values fall within the expected bounds.
     assert np.all(brightness_vals >= 0.0)

--- a/tests/tdastro/test_base_models.py
+++ b/tests/tdastro/test_base_models.py
@@ -50,10 +50,6 @@ class PairModel(ParameterizedNode):
         self.add_parameter("value2", value2, required=True, **kwargs)
         self.add_parameter("value_sum", self.result, required=True, **kwargs)
 
-    def get_value1(self):
-        """Get the value of value1."""
-        return self["value1"]
-
     def result(self, **kwargs):
         """Add the pair of values together
 


### PR DESCRIPTION
Replace uses of `get_parameter()` in testing with the `[]` access.