### PR TITLE
Update the core logic for updating parameters

### DIFF
--- a/src/tdastro/base_models.py
+++ b/src/tdastro/base_models.py
@@ -64,7 +64,7 @@ class ParameterSource:
         The type of source as defined by the class variables.
         Default = 0
     value : any
-        The information that actuall sets the parameter. Either a constant
+        The information that actually sets the parameter. Either a constant
         or the attribute name of a dependency node.
     dependency : `ParameterizedNode` or None
         The node on which this parameter is dependent

--- a/src/tdastro/base_models.py
+++ b/src/tdastro/base_models.py
@@ -156,7 +156,7 @@ class ParameterizedNode:
         A dictionary mapping the parameters' names to information about the setters
         (ParameterSource). The model parameters are stored in the order in which they
         need to be set.
-    values : `dict`
+    parameters : `dict`
         A dictionary mapping the parameter's name to its current value.
     direct_dependencies : `dict`
         A dictionary with keys of other ParameterizedNodes on that this node needs to

--- a/src/tdastro/base_models.py
+++ b/src/tdastro/base_models.py
@@ -15,7 +15,6 @@ sources:
 3) The result of evaluating a FunctionNode, which provides a computation using other
    parameters in the graph.
 4) The parameters of another ParameterizedNode.
-5) The method of another ParameterizedNode.
 
 We say that parameter X is dependent on parameter Y if the value of Y is necessary
 to compute the value of X. For example if X is set by evaluating a FunctionNode that
@@ -49,22 +48,100 @@ graph because they have no dependencies.  Such parameters are set by constants o
 static functions.
 """
 
-from enum import Enum
 from hashlib import md5
 from os import urandom
 
 import numpy as np
 
 
-class ParameterSource(Enum):
-    """ParameterSource specifies where a ParameterizedNode should get the value
-    for a given parameter: a constant value or from another ParameterizedNode.
+class ParameterSource:
+    """ParameterSource specifies the information about where a ParameterizedNode should
+    get the value for a given parameter.
+
+    Attributes
+    ----------
+    source_type : `int`
+        The type of source as defined by the class variables.
+        Default = 0
+    value : any
+        The information that actuall sets the parameter. Either a constant
+        or the attribute name of a dependency node.
+    dependency : `ParameterizedNode` or None
+        The node on which this parameter is dependent
+    fixed : `bool`
+        The attribute cannot be changed during resampling.
+        Default = ``False``
+    required : `bool`
+        The attribute must exist and be non-None.
+        Default = ``False``
     """
 
+    # Class variables for the source enum.
+    UNDEFINED = 0
     CONSTANT = 1
     MODEL_PARAMETER = 2
-    MODEL_METHOD = 3
-    FUNCTION_NODE = 4
+    FUNCTION_NODE = 3
+
+    def __init__(self, source_type=0, fixed=False, required=False):
+        self.source_type = source_type
+        self.fixed = fixed
+        self.required = required
+        self.value = None
+        self.dependency = None
+
+    def get_value(self, **kwargs):
+        """Get the parameter's value."""
+        if self.source_type == ParameterSource.CONSTANT:
+            return self.value
+        elif self.source_type == ParameterSource.MODEL_PARAMETER:
+            return self.dependency.parameters[self.value]
+        elif self.source_type == ParameterSource.FUNCTION_NODE:
+            return self.dependency.parameters[self.value]
+        else:
+            raise ValueError(f"Invalid ParameterSource type {self.source_type}")
+
+    def set_as_constant(self, value):
+        """Set the parameter as a constant value.
+
+        Parameters
+        ----------
+        value : any
+            The constant value to use.
+        """
+        if callable(value):
+            raise ValueError(f"Using set_as_constant on callable {value}")
+
+        self.source_type = ParameterSource.CONSTANT
+        self.dependency = None
+        self.value = value
+
+    def set_as_parameter(self, dependency, param_name):
+        """Set the parameter as a model parameter of another node.
+
+        Parameters
+        ----------
+        dependency : `ParameterizedNode`
+            The node in which to access the attribute.
+        param_name : `str`
+            The name of the parameter to access.
+        """
+        self.source_type = ParameterSource.MODEL_PARAMETER
+        self.dependency = dependency
+        self.value = param_name
+
+    def set_as_function(self, dependency, param_name="function_node_result"):
+        """Set the parameter as a model parameter of another node.
+
+        Parameters
+        ----------
+        dependency : `ParameterizedNode`
+            The node in which to access the attribute.
+        param_name : `str`
+            The name of where the result is stored in the FunctionNode.
+        """
+        self.source_type = ParameterSource.FUNCTION_NODE
+        self.dependency = dependency
+        self.value = param_name
 
 
 class ParameterizedNode:
@@ -76,9 +153,9 @@ class ParameterizedNode:
     node_identifier : `str`
         An optional identifier (name) for the current node.
     setters : `dict` of `tuple`
-        A dictionary to information about the setters for the parameters in the form:
-        (ParameterSource, setter information, required). The model parameters are
-        stored in the order in which they need to be set.
+        A dictionary mapping the parameters' names to information about the setters
+        (ParameterSource). The model parameters are stored in the order in which they
+        need to be set.
     values : `dict`
         A dictionary mapping the parameter's name to its current value.
     direct_dependencies : `dict`
@@ -196,21 +273,6 @@ class ParameterizedNode:
         for dep in self.direct_dependencies:
             dep.update_graph_information(new_graph_base_seed, seen_nodes, reset_variables)
 
-    def _update_dependencies(self):
-        """Update the set of direct dependencies."""
-        self.direct_dependencies = {}
-        for source_type, setter, _ in self.setters.values():
-            current = None
-            if source_type == ParameterSource.MODEL_PARAMETER:
-                current = setter[0]
-            elif source_type == ParameterSource.MODEL_METHOD:
-                current = setter.__self__
-            elif source_type == ParameterSource.FUNCTION_NODE:
-                current = setter
-
-            if current is not None and current is not self:
-                self.direct_dependencies[current] = True
-
     def __getitem__(self, key):
         return self.parameters[key]
 
@@ -263,38 +325,31 @@ class ParameterizedNode:
         # Check for parameter has been added and if so, find the index.
         if name not in self.setters:
             raise KeyError(f"Tried to set parameter {name} that has not been added.") from None
-        required = self.setters[name][2]
 
         if value is None and name in kwargs:
             # The value wasn't set, but the name is in kwargs.
             value = kwargs[name]
 
-        sampled_value = None
         if callable(value):
             if "__self__" in value.__dir__() and isinstance(value.__self__, ParameterizedNode):
                 # Case 1a: This is a method attached to another ParameterizedNode.
-
                 # Check if this is a getter method. If so, we access the parameter directly
                 # to save a function call.
                 method_name = value.__name__
                 parent = value.__self__
                 if method_name in parent.parameters:
-                    self.setters[name] = (ParameterSource.MODEL_PARAMETER, (parent, method_name), required)
-                    sampled_value = parent.parameters[method_name]
+                    self.setters[name].set_as_parameter(parent, method_name)
                 else:
-                    self.setters[name] = (ParameterSource.MODEL_METHOD, value, required)
-                    sampled_value = value(**kwargs)
+                    raise ValueError(f"Trying to set parameter to method {method_name}")
             else:
                 # Case 1b: This is a general function or callable method from another object.
                 # We treat it as static (we don't resample the other object) and
                 # wrap it in a FunctionNode.
                 func_node = FunctionNode(value, **kwargs)
-                self.setters[name] = (ParameterSource.FUNCTION_NODE, func_node, required)
-                sampled_value = func_node.compute()
+                self.setters[name].set_as_function(func_node)
         elif isinstance(value, FunctionNode):
             # Case 2: We are using the result of a computation of the function node.
-            self.setters[name] = (ParameterSource.FUNCTION_NODE, value, required)
-            sampled_value = value.compute(**kwargs)
+            self.setters[name].set_as_function(value)
         elif isinstance(value, ParameterizedNode):
             # Case 3: We are trying to access a parameter of a ParameterizedNode
             # with the same name.
@@ -302,25 +357,24 @@ class ParameterizedNode:
                 raise ValueError(f"Parameter {name} is recursively assigned to self.{name}.")
             if name not in value.parameters:
                 raise ValueError(f"Parameter {name} missing from {str(value)}.")
-
-            # We store MODEL_PARAMETER setters as a tuple of (object, parameter_name).
-            setter = (value, name)
-            self.setters[name] = (ParameterSource.MODEL_PARAMETER, setter, required)
-            sampled_value = value.parameters[name]
+            self.setters[name].set_as_parameter(value, name)
         else:
             # Case 4: The value is constant (including None).
-            self.setters[name] = (ParameterSource.CONSTANT, value, required)
-            sampled_value = value
+            self.setters[name].set_as_constant(value)
 
         # Check that we did get a parameter.
-        if required and sampled_value is None:
+        sampled_value = self.setters[name].get_value(**kwargs)
+        if self.setters[name].required and sampled_value is None:
             raise ValueError(f"Missing required parameter {name}")
         self.parameters[name] = sampled_value
 
         # Update the dependencies to account for any new nodes in the graph.
-        self._update_dependencies()
+        self.direct_dependencies = {}
+        for setter_info in self.setters.values():
+            if setter_info.dependency is not None and setter_info.dependency is not self:
+                self.direct_dependencies[setter_info.dependency] = True
 
-    def add_parameter(self, name, value=None, required=False, allow_overwrite=False, **kwargs):
+    def add_parameter(self, name, value=None, required=False, allow_overwrite=False, fixed=False, **kwargs):
         """Add a single *new* parameter to the ParameterizedNode.
 
         Notes
@@ -344,6 +398,9 @@ class ParameterizedNode:
             Allow a subclass to overwrite the definition of the parameter
             used in the superclass.
             Default = ``False``
+        fixed : `bool`
+            The attribute cannot be changed during resampling.
+            Default = ``False``
         **kwargs : `dict`, optional
            All other keyword arguments, possibly including the parameter setters.
 
@@ -362,7 +419,7 @@ class ParameterizedNode:
 
         # Add an entry for the setter function and fill in the remaining
         # information using set_parameter().
-        self.setters[name] = (None, None, required)
+        self.setters[name] = ParameterSource(ParameterSource.UNDEFINED, fixed, required)
         self.set_parameter(name, value, **kwargs)
 
         # Create a callable getter function using. We override the __self__ and __name__
@@ -405,29 +462,10 @@ class ParameterizedNode:
         # Run through each parameter and sample it based on the given recipe.
         # As of Python 3.7 dictionaries are guaranteed to preserve insertion ordering,
         # so this will iterate through model parameters in the order they were inserted.
-        for name, (source_type, setter, _) in self.setters.items():
-            sampled_value = None
-            if source_type == ParameterSource.CONSTANT:
-                sampled_value = setter
-            elif source_type == ParameterSource.MODEL_PARAMETER:
-                # Check if we need to resample the parent (before accessing the model parameter).
-                if setter[0] not in seen_nodes:
-                    setter[0]._sample_helper(depth - 1, seen_nodes, **kwargs)
-                sampled_value = setter[0].parameters[setter[1]]
-            elif source_type == ParameterSource.MODEL_METHOD:
-                # Check if we need to resample the parent (before calling the method).
-                parent_node = setter.__self__
-                if parent_node not in seen_nodes:
-                    parent_node._sample_helper(depth - 1, seen_nodes, **kwargs)
-                sampled_value = setter(**kwargs)
-            elif source_type == ParameterSource.FUNCTION_NODE:
-                # Check if we need to resample the parent function (before calling compute).
-                if setter not in seen_nodes:
-                    setter._sample_helper(depth - 1, seen_nodes, **kwargs)
-                sampled_value = setter.compute(**kwargs)
-            else:
-                raise ValueError(f"Unknown ParameterSource type {source_type} for {name}")
-            self.parameters[name] = sampled_value
+        for name, setter_info in self.setters.items():
+            if setter_info.dependency is not None:
+                setter_info.dependency._sample_helper(depth - 1, seen_nodes, **kwargs)
+            self.parameters[name] = setter_info.get_value(**kwargs)
 
     def sample_parameters(self, **kwargs):
         """Sample the model's underlying parameters if they are provided by a function
@@ -493,15 +531,10 @@ class ParameterizedNode:
         seen.add(self)
 
         all_values = {}
-        for name, (source_type, setter, _) in self.setters.items():
+        for name, setter_info in self.setters.items():
             if recursive:
-                if source_type == ParameterSource.MODEL_PARAMETER:
-                    all_values.update(setter[0].get_all_parameter_values(True, seen))
-                elif source_type == ParameterSource.MODEL_METHOD:
-                    all_values.update(setter.__self__.get_all_parameter_values(True, seen))
-                elif source_type == ParameterSource.FUNCTION_NODE:
-                    all_values.update(setter.get_all_parameter_values(True, seen))
-
+                if setter_info.dependency is not None:
+                    all_values.update(setter_info.dependency.get_all_parameter_values(True, seen))
                 full_name = f"{str(self)}.{name}"
             else:
                 full_name = name
@@ -598,7 +631,14 @@ class FunctionNode(ParameterizedNode):
         self.outputs = outputs
         self.num_outputs = len(outputs)
         for name in outputs:
+            # For output parameters we add a placeholder of None to set up the basic data, such as
+            # the getter function and the entry in parameters. Then we change the
+            # type to point to own result.
             self.add_parameter(name, None)
+            self.setters[name].set_as_function(self, param_name=name)
+
+        # Fill in the outputs.
+        self.compute()
 
     def __str__(self):
         """Return the string representation of the function."""
@@ -619,6 +659,25 @@ class FunctionNode(ParameterizedNode):
             else:
                 args[key] = self.parameters[key]
         return args
+
+    def _save_result_parameters(self, results):
+        """Save the results as model parameters.
+
+        Parameters
+        ----------
+        results : any
+            The results of the function.
+        """
+        if self.num_outputs == 1:
+            self.parameters[self.outputs[0]] = results
+        else:
+            if len(results) != self.num_outputs:
+                raise ValueError(
+                    f"Incorrect number of results returned by {self.func.__name__}. "
+                    f"Expected {self.outputs}, but got {results}."
+                )
+            for i in range(self.num_outputs):
+                self.parameters[self.outputs[i]] = results[i]
 
     def _sample_helper(self, depth, seen_nodes, **kwargs):
         """Internal recursive function to sample the model's underlying parameters
@@ -641,8 +700,9 @@ class FunctionNode(ParameterizedNode):
         Raise a ``ValueError`` the depth of the sampling encounters a problem
         with the order of dependencies.
         """
-        super()._sample_helper(depth, seen_nodes, **kwargs)
-        _ = self.compute(**kwargs)
+        if self not in seen_nodes:
+            super()._sample_helper(depth, seen_nodes, **kwargs)
+            _ = self.compute(**kwargs)
 
     def compute(self, **kwargs):
         """Execute the wrapped function.
@@ -664,15 +724,5 @@ class FunctionNode(ParameterizedNode):
 
         args = self._build_args_dict(**kwargs)
         results = self.func(**args)
-        if self.num_outputs == 1:
-            self.parameters[self.outputs[0]] = results
-        else:
-            if len(results) != self.num_outputs:
-                raise ValueError(
-                    f"Incorrect number of results returned by {self.func.__name__}. "
-                    f"Expected {self.outputs}, but got {results}."
-                )
-            for i in range(self.num_outputs):
-                self.parameters[self.outputs[i]] = results[i]
-
+        self._save_result_parameters(results)
         return results

--- a/src/tdastro/util_nodes/np_random.py
+++ b/src/tdastro/util_nodes/np_random.py
@@ -48,11 +48,7 @@ class NumpyRandomFunc(FunctionNode):
         super().__init__(func, **kwargs)
 
         # Overwrite the func attribute using the new seed.
-        if seed is not None:
-            self.set_seed(new_seed=seed)
-        else:
-            self._rng = np.random.default_rng(self._object_seed)
-            self.func = getattr(self._rng, func_name)
+        self.set_seed(new_seed=seed)
 
     def set_seed(self, new_seed=None, graph_base_seed=None, force_update=False):
         """Update the object seed to the new value based.
@@ -77,16 +73,5 @@ class NumpyRandomFunc(FunctionNode):
         old_seed = self._object_seed
         super().set_seed(new_seed, graph_base_seed)
         if old_seed != self._object_seed or force_update:
-            self._rng = np.random.default_rng(self._object_seed)
+            self._rng = np.random.default_rng(seed=self._object_seed)
             self.func = getattr(self._rng, self.func_name)
-
-    def compute(self, **kwargs):
-        """Execute the wrapped numpy random number generator method.
-
-        Parameters
-        ----------
-        **kwargs : `dict`, optional
-            Additional function arguments.
-        """
-        args = self._build_args_dict(**kwargs)
-        return self.func(**args)

--- a/tests/tdastro/effects/test_redshift.py
+++ b/tests/tdastro/effects/test_redshift.py
@@ -61,7 +61,7 @@ def test_other_redshift_values() -> None:
 
     for redshift in [0.0, 0.5, 2.0, 3.0, 30.0]:
         model_redshift = StepSource(brightness=brightness, t0=t0, t1=t1, redshift=redshift)
-        model_redshift.add_effect(Redshift(redshift=model_redshift, t0=model_redshift))
+        model_redshift.add_effect(Redshift(redshift=model_redshift.redshift, t0=model_redshift.t0))
         values_redshift = model_redshift.evaluate(times, wavelengths)
 
         for i, time in enumerate(times):

--- a/tests/tdastro/sources/test_step_source.py
+++ b/tests/tdastro/sources/test_step_source.py
@@ -35,7 +35,7 @@ def _sample_end(duration):
 def test_step_source() -> None:
     """Test that we can sample and create a StepSource object."""
     host = StaticSource(brightness=150.0, ra=1.0, dec=2.0, distance=3.0)
-    model = StepSource(brightness=15.0, t0=1.0, t1=2.0, ra=host, dec=host, distance=host)
+    model = StepSource(brightness=15.0, t0=1.0, t1=2.0, ra=host.ra, dec=host.dec, distance=host.distance)
     assert model["brightness"] == 15.0
     assert model["t0"] == 1.0
     assert model["t1"] == 2.0

--- a/tests/tdastro/test_base_models.py
+++ b/tests/tdastro/test_base_models.py
@@ -349,7 +349,7 @@ def test_function_node_chain():
 
 
 def test_no_resample_functions():
-    """Test that is we use the same node a dependencies in two other nodes, we do not resample it."""
+    """Test that if we use the same node as dependencies in two other nodes, we do not resample it."""
     rand_val = FunctionNode(_sampler_fun)
     init_val = rand_val.compute()
 

--- a/tests/tdastro/util_nodes/test_jax_random.py
+++ b/tests/tdastro/util_nodes/test_jax_random.py
@@ -14,6 +14,9 @@ def test_jax_random_uniform():
     assert np.all(values >= 0.0)
     assert np.abs(np.mean(values) - 0.5) < 0.01
 
+    # Test that we also save the result to the function_node_result parameter.
+    assert 0.0 <= jax_node["function_node_result"] <= 1.0
+
     # If we reuse the seed, we get the same numbers.
     jax_node2 = JaxRandomFunc(jax.random.uniform, seed=100)
     values2 = np.array([jax_node2.compute() for _ in range(10_000)])
@@ -54,11 +57,11 @@ def test_jax_random_normal():
     """Test that we can generate numbers from a normal distribution."""
     jax_node = JaxRandomNormal(loc=100.0, scale=10.0, seed=100)
 
-    values = np.array([jax_node.compute() for _ in range(10_000)])
+    values = np.array([jax_node.resample_and_compute() for _ in range(1000)])
     assert np.abs(np.mean(values) - 100.0) < 0.5
     assert np.abs(np.std(values) - 10.0) < 0.5
 
     # If we reuse the seed, we get the same number.
     jax_node2 = JaxRandomNormal(loc=100.0, scale=10.0, seed=100)
-    values2 = np.array([jax_node2.compute() for _ in range(10_000)])
+    values2 = np.array([jax_node2.resample_and_compute() for _ in range(1000)])
     assert np.allclose(values, values2)

--- a/tests/tdastro/util_nodes/test_np_random.py
+++ b/tests/tdastro/util_nodes/test_np_random.py
@@ -12,6 +12,9 @@ def test_numpy_random_uniform():
     assert np.all(values >= 0.0)
     assert np.abs(np.mean(values) - 0.5) < 0.01
 
+    # Test that we also save the result to the function_node_result parameter.
+    assert 0.0 <= np_node["function_node_result"] <= 1.0
+
     # If we reuse the seed, we get the same numbers.
     np_node2 = NumpyRandomFunc("uniform", seed=100)
     values2 = np.array([np_node2.compute() for _ in range(10_000)])


### PR DESCRIPTION
This is a prefactoring PR for some JAX related changes. The goal is to modularize how the parameters are set. The changes should not impact current users and (mostly) be behind the scenes.

What is changing:

1) `ParameterSource` classes is extended to track named information like `source_type` or `fixed`. Previously this was tracked in an array entry and accessed with a magic index number. This should make it easier to see what the code is doing and add new attributes to the setters.

2) `ParameterizedNode` attributes can no longer be set by arbitrary methods of other `ParameterizedNode`s. This was preventing us from easily checking that the evaluation graph was a DAG.

3) The results of a `FunctionNode` are now accessed through their attributes. This prevents problems where the same parameter is fed into multiple nodes and resampled each time (in the `compute()` call). Previously this could lead to inconsistent results.

4) Results of a `FunctionNode` are collected via a function `_save_result_parameters()` to make overloading `compute()` easier.

5) Fixed the seed setting logic in the numpy and Jax function modules to account for the changes above.