### PR TITLE
Node name cleanup

### DIFF
--- a/src/tdastro/base_models.py
+++ b/src/tdastro/base_models.py
@@ -73,8 +73,11 @@ class ParameterizedNode:
 
     Attributes
     ----------
-    node_identifier : `str`
-        An optional identifier (name) for the current node.
+    node_label : `str`
+        An optional human readable identifier (name) for the current node.
+    node_string : `str`
+        The full string used to identify a node. This is a combination of the nodes position
+        in the graph (if known), node_label (if provided), and class information.
     setters : `dict` of `tuple`
         A dictionary to information about the setters for the parameters in the form:
         (ParameterSource, setter information, required). The model parameters are
@@ -95,20 +98,21 @@ class ParameterizedNode:
 
     Parameters
     ----------
-    node_identifier : `str`, optional
+    node_label : `str`, optional
         An identifier (or name) for the current node.
     **kwargs : `dict`, optional
         Any additional keyword arguments.
     """
 
-    def __init__(self, node_identifier=None, **kwargs):
+    def __init__(self, node_label=None, **kwargs):
         self.setters = {}
         self.parameters = {}
         self.direct_dependencies = {}
-        self.node_identifier = node_identifier
+        self.node_label = node_label
         self._node_pos = None
         self._object_seed = None  # A default until set is called.
         self._graph_base_seed = None
+        self.node_string = None
 
         # We start all nodes with a completely random base seed.
         base_seed = int.from_bytes(urandom(4), "big")
@@ -116,9 +120,33 @@ class ParameterizedNode:
 
     def __str__(self):
         """Return the string representation of the node."""
-        name = f"{self.node_identifier}=" if self.node_identifier else ""
-        id_str = f"{self._node_pos}: " if self._node_pos is not None else ""
-        return f"{id_str}{name}{self.__class__.__module__}.{self.__class__.__qualname__}"
+        if self.node_string is None:
+            # Create and cache the node string.
+            self._update_node_string()
+        return self.node_string
+
+    def _update_node_string(self):
+        """Update the node's string."""
+        pos_string = f"{self._node_pos}:" if self._node_pos is not None else ""
+        if self.node_label is not None:
+            self.node_string = f"{pos_string}{self.node_label}"
+        else:
+            self.node_string = f"{pos_string}{self.__class__.__module__}.{self.__class__.__qualname__}"
+
+    def full_param_name(self, param_name):
+        """Get the full parameter name within a graph.
+
+        Parameters
+        ----------
+        param_name : `str`
+            The 'local' name of the parameter.
+
+        Returns
+        -------
+        full_name : `str`
+            The name of the parameter within the context of the graph.
+        """
+        return f"{self.node_string}.{param_name}"
 
     def set_seed(self, new_seed=None, graph_base_seed=None):
         """Update the object seed to the new value based.
@@ -146,7 +174,10 @@ class ParameterizedNode:
         if graph_base_seed is not None:
             self._graph_base_seed = graph_base_seed
 
+        # Force an update of the node string to make sure we have the most recent.
+        self._update_node_string()
         hashed_object_name = md5(str(self).encode())
+
         seed_offset = int(hashed_object_name.hexdigest(), base=16)
         new_seed = (self._graph_base_seed + seed_offset) % (2**32)
         self._object_seed = new_seed
@@ -185,6 +216,7 @@ class ParameterizedNode:
 
         # Update the graph ID and (possibly) the seed.
         self._node_pos = len(seen_nodes) - 1
+        self._update_node_string()
         self.set_seed(graph_base_seed=new_graph_base_seed)
 
         # Reset the variables if needed.
@@ -502,7 +534,7 @@ class ParameterizedNode:
                 elif source_type == ParameterSource.FUNCTION_NODE:
                     all_values.update(setter.get_all_parameter_values(True, seen))
 
-                full_name = f"{str(self)}.{name}"
+                full_name = self.full_param_name(name)
             else:
                 full_name = name
             all_values[full_name] = self.parameters[name]
@@ -554,7 +586,7 @@ class FunctionNode(ParameterizedNode):
     ----------
     func : `function` or `method`
         The function to call during an evaluation.
-    node_identifier : `str`, optional
+    node_label : `str`, optional
         An identifier (or name) for the current node.
     outputs : `list` of `str`, optional
         The output model parameters of this function. If ``None`` uses
@@ -580,11 +612,11 @@ class FunctionNode(ParameterizedNode):
     value1 = my_func(b=10.0)
     """
 
-    def __init__(self, func, node_identifier=None, outputs=None, **kwargs):
+    def __init__(self, func, node_label=None, outputs=None, **kwargs):
         # We set the function before calling the parent class so we can use
         # the function's name (if needed).
         self.func = func
-        super().__init__(node_identifier=node_identifier, **kwargs)
+        super().__init__(node_label=node_label, **kwargs)
 
         # Add all of the parameters from default_args or the kwargs.
         self.arg_names = []

--- a/src/tdastro/base_models.py
+++ b/src/tdastro/base_models.py
@@ -155,7 +155,7 @@ class ParameterizedNode:
     node_string : `str`
         The full string used to identify a node. This is a combination of the nodes position
         in the graph (if known), node_label (if provided), and class information.
-    setters : `dict` of `tuple`
+    setters : `dict`
         A dictionary mapping the parameters' names to information about the setters
         (ParameterSource). The model parameters are stored in the order in which they
         need to be set.
@@ -210,21 +210,6 @@ class ParameterizedNode:
         else:
             self.node_string = f"{pos_string}{self.__class__.__module__}.{self.__class__.__qualname__}"
 
-    def full_param_name(self, param_name):
-        """Get the full parameter name within a graph.
-
-        Parameters
-        ----------
-        param_name : `str`
-            The 'local' name of the parameter.
-
-        Returns
-        -------
-        full_name : `str`
-            The name of the parameter within the context of the graph.
-        """
-        return f"{self.node_string}.{param_name}"
-
     def set_seed(self, new_seed=None, graph_base_seed=None):
         """Update the object seed to the new value based.
 
@@ -253,7 +238,7 @@ class ParameterizedNode:
 
         # Force an update of the node string to make sure we have the most recent.
         self._update_node_string()
-        hashed_object_name = md5(str(self).encode())
+        hashed_object_name = md5(self.node_string.encode())
 
         seed_offset = int(hashed_object_name.hexdigest(), base=16)
         new_seed = (self._graph_base_seed + seed_offset) % (2**32)

--- a/tests/tdastro/sources/test_spline_source.py
+++ b/tests/tdastro/sources/test_spline_source.py
@@ -18,8 +18,8 @@ def test_spline_model_flat() -> None:
     expected = np.full_like(values, 1.0)
     np.testing.assert_array_almost_equal(values, expected)
 
-    model2 = SplineModel(times, wavelengths, fluxes, amplitude=5.0, node_identifier="test")
-    assert str(model2) == "test=tdastro.sources.spline_model.SplineModel"
+    model2 = SplineModel(times, wavelengths, fluxes, amplitude=5.0, node_label="test")
+    assert str(model2) == "test"
 
     values2 = model2.evaluate(test_times, test_waves)
     assert values2.shape == (5, 4)

--- a/tests/tdastro/sources/test_static_source.py
+++ b/tests/tdastro/sources/test_static_source.py
@@ -19,12 +19,12 @@ def _sampler_fun(magnitude, **kwargs):
 
 def test_static_source() -> None:
     """Test that we can sample and create a StaticSource object."""
-    model = StaticSource(brightness=10.0, node_identifier="my_static_source")
+    model = StaticSource(brightness=10.0, node_label="my_static_source")
     assert model["brightness"] == 10.0
     assert model["ra"] is None
     assert model["dec"] is None
     assert model["distance"] is None
-    assert str(model) == "my_static_source=tdastro.sources.static_source.StaticSource"
+    assert str(model) == "my_static_source"
 
     times = np.array([1, 2, 3, 4, 5, 10])
     wavelengths = np.array([100.0, 200.0, 300.0])

--- a/tests/tdastro/test_base_models.py
+++ b/tests/tdastro/test_base_models.py
@@ -197,11 +197,11 @@ def test_parameterized_node_parameters():
     assert settings["value2"] == 1.5
     assert settings["value_sum"] == 2.0
 
-    # The model has 5 parameters in the graph: 3 in model1 and 2
+    # The model has 6 parameters in the graph: 3 in model1 and 3
     # in its summation FunctionNode. Note Node ID's are -1 until
     # reset or sample is called for the first time.
     settings = model1.get_all_parameter_values(True)
-    assert len(settings) == 3
+    assert len(settings) == 6
     assert settings["0:A.value1"] == 0.5
     assert settings["0:A.value2"] == 1.5
     assert settings["0:A.value_sum"] == 2.0
@@ -215,7 +215,7 @@ def test_parameterized_node_parameters():
     assert settings["value_sum"] == 3.5
 
     settings = model2.get_all_parameter_values(True)
-    assert len(settings) == 6
+    assert len(settings) == 12
     assert settings["1:A.value1"] == 0.5
     assert settings["1:A.value2"] == 1.5
     assert settings["1:A.value_sum"] == 2.0
@@ -227,14 +227,14 @@ def test_parameterized_node_parameters():
 def test_parameterized_node_get_dependencies():
     """Test that we can extract the parameters of a graph of ParameterizedNode."""
     model1 = PairModel(value1=0.5, value2=1.5, node_identifier="1")
-    assert len(model1.direct_dependencies) == 2
+    assert len(model1.direct_dependencies) == 1
 
     model2 = PairModel(value1=model1.value1, value2=3.0, node_identifier="2")
-    assert len(model2.direct_dependencies) == 4
+    assert len(model2.direct_dependencies) == 2
     assert model1 in model2.direct_dependencies
 
     model3 = PairModel(value1=model1.value1, value2=model2.value_sum, node_identifier="3")
-    assert len(model3.direct_dependencies) == 6
+    assert len(model3.direct_dependencies) == 3
     assert model1 in model3.direct_dependencies
     assert model2 in model3.direct_dependencies
 

--- a/tests/tdastro/test_base_models.py
+++ b/tests/tdastro/test_base_models.py
@@ -77,16 +77,17 @@ def test_parameterized_node():
     assert str(model1) == "test_base_models.PairModel"
 
     # Use value1=model.value and value2=1.0
-    model2 = PairModel(value1=model1.value1, value2=1.0, node_identifier="test")
+    model2 = PairModel(value1=model1.value1, value2=1.0, node_label="test")
     assert model2["value1"] == 0.5
     assert model2["value2"] == 1.0
     assert model2.result() == 1.5
     assert model2["value_sum"] == 1.5
-    assert str(model2) == "test=test_base_models.PairModel"
+    assert str(model2) == "test"
 
     # If we set an ID it shows up in the name.
     model2._node_pos = 100
-    assert str(model2) == "100: test=test_base_models.PairModel"
+    model2._update_node_string()
+    assert str(model2) == "100:test"
 
     # Compute value1 from model2's result and value2 from the sampler function.
     # The sampler function is auto-wrapped in a FunctionNode.
@@ -144,7 +145,7 @@ def test_parameterized_node_overwrite():
 
 def test_parameterized_node_parameters():
     """Test that we can extract the parameters of a graph of ParameterizedNode."""
-    model1 = PairModel(value1=0.5, value2=1.5, node_identifier="1")
+    model1 = PairModel(value1=0.5, value2=1.5, node_label="A")
     settings = model1.get_all_parameter_values(False)
     assert len(settings) == 3
     assert settings["value1"] == 0.5
@@ -156,12 +157,12 @@ def test_parameterized_node_parameters():
     # reset or sample is called for the first time.
     settings = model1.get_all_parameter_values(True)
     assert len(settings) == 3
-    assert settings["0: 1=test_base_models.PairModel.value1"] == 0.5
-    assert settings["0: 1=test_base_models.PairModel.value2"] == 1.5
-    assert settings["0: 1=test_base_models.PairModel.value_sum"] == 2.0
+    assert settings["0:A.value1"] == 0.5
+    assert settings["0:A.value2"] == 1.5
+    assert settings["0:A.value_sum"] == 2.0
 
     # Use value1=model.value1 and value2=3.0
-    model2 = PairModel(value1=model1.value1, value2=3.0, node_identifier="2")
+    model2 = PairModel(value1=model1.value1, value2=3.0, node_label="B")
     settings = model2.get_all_parameter_values(False)
     assert len(settings) == 3
     assert settings["value1"] == 0.5
@@ -170,24 +171,24 @@ def test_parameterized_node_parameters():
 
     settings = model2.get_all_parameter_values(True)
     assert len(settings) == 6
-    assert settings["1: 1=test_base_models.PairModel.value1"] == 0.5
-    assert settings["1: 1=test_base_models.PairModel.value2"] == 1.5
-    assert settings["1: 1=test_base_models.PairModel.value_sum"] == 2.0
-    assert settings["0: 2=test_base_models.PairModel.value1"] == 0.5
-    assert settings["0: 2=test_base_models.PairModel.value2"] == 3.0
-    assert settings["0: 2=test_base_models.PairModel.value_sum"] == 3.5
+    assert settings["1:A.value1"] == 0.5
+    assert settings["1:A.value2"] == 1.5
+    assert settings["1:A.value_sum"] == 2.0
+    assert settings["0:B.value1"] == 0.5
+    assert settings["0:B.value2"] == 3.0
+    assert settings["0:B.value_sum"] == 3.5
 
 
 def test_parameterized_node_get_dependencies():
     """Test that we can extract the parameters of a graph of ParameterizedNode."""
-    model1 = PairModel(value1=0.5, value2=1.5, node_identifier="1")
+    model1 = PairModel(value1=0.5, value2=1.5, node_label="1")
     assert len(model1.direct_dependencies) == 0
 
-    model2 = PairModel(value1=model1.value1, value2=3.0, node_identifier="2")
+    model2 = PairModel(value1=model1.value1, value2=3.0, node_label="2")
     assert len(model2.direct_dependencies) == 1
     assert model1 in model2.direct_dependencies
 
-    model3 = PairModel(value1=model1.value1, value2=model2.value_sum, node_identifier="3")
+    model3 = PairModel(value1=model1.value1, value2=model2.value_sum, node_label="3")
     assert len(model3.direct_dependencies) == 2
     assert model1 in model3.direct_dependencies
     assert model2 in model3.direct_dependencies
@@ -221,33 +222,39 @@ def test_parameterized_node_seed():
     assert model_a._object_seed != model_b._object_seed
 
     # If we specify a seed, the results are the same objects with
-    # the same name (class + node_id + node_identifier) and different
+    # the same name (class + node_id + node_label) and different
     # otherwise. Everything starts with a default node_id = None.
-    model_a = PairModel(value1=0.5, value2=0.5, node_identifier="A")
-    model_b = PairModel(value1=0.5, value2=0.5, node_identifier="B")
-    model_c = PairModel(value1=0.5, value2=0.5, node_identifier="A")
-    model_d = SingleVariableNode("value1", 0.5, node_identifier="A")
+    model_a = PairModel(value1=0.5, value2=0.5, node_label="A")
+    model_b = PairModel(value1=0.5, value2=0.5, node_label="B")
+    model_c = PairModel(value1=0.5, value2=0.5, node_label="A")
+    model_d = SingleVariableNode("value1", 0.5, node_label="A")
+    model_e = SingleVariableNode("value1", 0.5, node_label="C")
 
     model_a.set_seed(graph_base_seed=10)
     model_b.set_seed(graph_base_seed=10)
     model_c.set_seed(graph_base_seed=10)
     model_d.set_seed(graph_base_seed=10)
+    model_e.set_seed(graph_base_seed=10)
 
     assert model_a._object_seed != model_b._object_seed
     assert model_a._object_seed == model_c._object_seed
-    assert model_a._object_seed != model_d._object_seed
+    assert model_a._object_seed == model_d._object_seed
+    assert model_a._object_seed != model_e._object_seed
 
     assert model_b._object_seed != model_a._object_seed
     assert model_b._object_seed != model_c._object_seed
     assert model_b._object_seed != model_d._object_seed
+    assert model_b._object_seed != model_e._object_seed
 
     assert model_c._object_seed == model_a._object_seed
     assert model_c._object_seed != model_b._object_seed
-    assert model_c._object_seed != model_d._object_seed
+    assert model_c._object_seed == model_d._object_seed
+    assert model_c._object_seed != model_e._object_seed
 
-    assert model_d._object_seed != model_a._object_seed
+    assert model_d._object_seed == model_a._object_seed
     assert model_d._object_seed != model_b._object_seed
-    assert model_d._object_seed != model_c._object_seed
+    assert model_d._object_seed == model_c._object_seed
+    assert model_d._object_seed != model_e._object_seed
 
 
 def test_parameterized_node_base_seed_fail():


### PR DESCRIPTION
Make a few changes to clean up the logic behind node strings:
1) Rename `node_indentifier` to `node_label` to make it clearer it is a human generated label.
2) Cache the node string (`node_string`) and only regenerate it if something has changed. We do this because the node string is increasingly being used to access information (such as variable names).
3) Don't output the module + class if a user provided label is present.
