### PR TITLE
JAX Compatibility Step 1: Allow Nodes to generate and use PyTrees

### DIFF
--- a/src/tdastro/base_models.py
+++ b/src/tdastro/base_models.py
@@ -494,7 +494,6 @@ class ParameterizedNode:
                     setter_info.dependency._sample_helper(seen_nodes, given_args)
                 self.parameters[name] = setter_info.get_value(**given_args)
 
-
     def sample_parameters(self, given_args=None, **kwargs):
         """Sample the model's underlying parameters if they are provided by a function
         or ParameterizedNode.
@@ -793,7 +792,7 @@ class FunctionNode(ParameterizedNode):
 
         Parameters
         ----------
-         given_args : `dict`, optional
+        given_args : `dict`, optional
             A dictionary representing the given arguments for this sample run.
             This can be used as the JAX PyTree for differentiation.
         **kwargs : `dict`, optional

--- a/src/tdastro/sources/sncomso_models.py
+++ b/src/tdastro/sources/sncomso_models.py
@@ -93,7 +93,7 @@ class SncosmoWrapperModel(PhysicalModel):
                 self.source_param_names.append(key)
         self._update_sncosmo_model_parameters()
 
-    def _sample_helper(self, depth, seen_nodes, **kwargs):
+    def _sample_helper(self, seen_nodes, **kwargs):
         """Internal recursive function to sample the model's underlying parameters
         if they are provided by a function or ParameterizedNode.
 
@@ -102,9 +102,6 @@ class SncosmoWrapperModel(PhysicalModel):
 
         Parameters
         ----------
-        depth : `int`
-            The recursive depth remaining. Used to prevent infinite loops.
-            Users should not need to set this manually.
         seen_nodes : `dict`
             A dictionary mapping nodes seen during this sampling run to their ID.
             Used to avoid sampling nodes multiple times and to validity check the graph.
@@ -114,10 +111,9 @@ class SncosmoWrapperModel(PhysicalModel):
 
         Raises
         ------
-        Raise a ``ValueError`` the depth of the sampling encounters a problem
-        with the order of dependencies.
+        Raise a ``ValueError`` the sampling encounters a problem with the order of dependencies.
         """
-        super()._sample_helper(depth, seen_nodes, **kwargs)
+        super()._sample_helper(seen_nodes, **kwargs)
         self._update_sncosmo_model_parameters()
 
     def _evaluate(self, times, wavelengths, **kwargs):

--- a/tests/tdastro/test_base_models.py
+++ b/tests/tdastro/test_base_models.py
@@ -1,6 +1,6 @@
-import jax
 import random
 
+import jax
 import numpy as np
 import pytest
 from tdastro.base_models import FunctionNode, ParameterizedNode, ParameterSource, SingleVariableNode

--- a/tests/tdastro/test_base_models.py
+++ b/tests/tdastro/test_base_models.py
@@ -1,3 +1,4 @@
+import jax
 import random
 
 import numpy as np
@@ -331,6 +332,27 @@ def test_parameterized_node_base_seed_fail():
     model_b.sample_parameters()
 
 
+def test_parameterized_node_build_pytree():
+    """Test that we can extract the PyTree of a graph."""
+    model1 = PairModel(value1=0.5, value2=1.5, node_label="A")
+    model2 = PairModel(value1=model1.value1, value2=3.0, node_label="B")
+    model2.update_graph_information()
+    pytree = model2.build_pytree()
+
+    assert len(pytree) == 3
+    assert pytree["1:A.value1"] == 0.5
+    assert pytree["1:A.value2"] == 1.5
+    assert pytree["0:B.value2"] == 3.0
+
+    # Manually set value2 to fixed and check that it no longer appears in the pytree.
+    model1.setters["value2"].fixed = True
+
+    pytree = model2.build_pytree()
+    assert len(pytree) == 2
+    assert pytree["1:A.value1"] == 0.5
+    assert pytree["0:B.value2"] == 3.0
+
+
 def test_single_variable_node():
     """Test that we can create and query a SingleVariableNode."""
     node = SingleVariableNode("A", 10.0)
@@ -423,3 +445,27 @@ def test_function_node_multi():
     assert model["value1"] == 11.0
     assert model["value2"] == -1.0
     assert model["value_sum"] == 10.0
+
+
+def test_function_node_jax():
+    """Test that we can perform a JAX grad computation on a graph of function nodes."""
+
+    def _test_func2(value1, value2):
+        return value1 / value2
+
+    # Create a function of a / b + c
+    div_node = FunctionNode(_test_func2, value1=4.0, value2=0.5, node_label="div")
+    sum_node = FunctionNode(_test_func, value1=1.0, value2=div_node, node_label="sum")
+    sum_node.sample_parameters()
+
+    pytree = sum_node.build_pytree()
+    assert len(pytree) == 3
+
+    gr_func = jax.value_and_grad(sum_node.resample_and_compute)
+    values, gradients = gr_func(pytree)
+    assert len(gradients) == 3
+    print(gradients)
+    assert values == 9.0
+    assert gradients["0:sum:_test_func.value1"] == 1.0
+    assert gradients["1:div:_test_func2.value1"] == 2.0
+    assert gradients["1:div:_test_func2.value2"] == -16.0


### PR DESCRIPTION
Nodes can generate PyTrees with new `build_pytree()` function which will generate a pytree dictionary for the current tree of nodes. The same dictionary can be passed through the sampling functions as `given_args` to override any of the internal settings.