### PR TITLE
Cache the parameter's full name in the setter_info

### DIFF
--- a/tests/tdastro/test_base_models.py
+++ b/tests/tdastro/test_base_models.py
@@ -73,7 +73,9 @@ class PairModel(ParameterizedNode):
 
 def test_parameter_source():
     """Test the ParameterSource creation and setter functions."""
-    source = ParameterSource()
+    source = ParameterSource("test")
+    assert source.parameter_name == "test"
+    assert source.full_name == "test"
     assert source.source_type == ParameterSource.UNDEFINED
     assert source.dependency is None
     assert source.value is None
@@ -83,12 +85,18 @@ def test_parameter_source():
         _ = source.get_value()
 
     source.set_as_constant(10.0)
+    assert source.parameter_name == "test"
+    assert source.full_name == "test"
     assert source.source_type == ParameterSource.CONSTANT
     assert source.dependency is None
     assert source.value == 10.0
     assert not source.fixed
     assert not source.required
     assert source.get_value() == 10.0
+
+    source.set_name("my_var", "my_node")
+    assert source.parameter_name == "my_var"
+    assert source.full_name == "my_node.my_var"
 
     with pytest.raises(ValueError):
         source.set_as_constant(_test_func)


### PR DESCRIPTION
Cache the parameter's full name in the setter_info. This will allow us to efficiently look it up from a dictionary in other PRs such as #60.

This PR also cleans up how the overloading of the name works with `FunctionNode` so that it caches the node's name correctly (which I broke in #58).