### PR TITLE
Make TDAstro's sampling stateless

### DIFF
--- a/src/tdastro/base_models.py
+++ b/src/tdastro/base_models.py
@@ -51,8 +51,6 @@ static functions.
 from hashlib import md5
 from os import urandom
 
-import numpy as np
-
 
 class ParameterSource:
     """ParameterSource specifies the information about where a ParameterizedNode should
@@ -85,6 +83,7 @@ class ParameterSource:
     CONSTANT = 1
     MODEL_PARAMETER = 2
     FUNCTION_NODE = 3
+    COMPUTE_OUTPUT = 4
 
     def __init__(self, parameter_name, source_type=0, fixed=False, required=False, node_name=""):
         self.source_type = source_type
@@ -93,17 +92,6 @@ class ParameterSource:
         self.value = None
         self.dependency = None
         self.set_name(parameter_name, node_name)
-
-    def get_value(self, **kwargs):
-        """Get the parameter's value."""
-        if self.source_type == ParameterSource.CONSTANT:
-            return self.value
-        elif self.source_type == ParameterSource.MODEL_PARAMETER:
-            return self.dependency.parameters[self.value]
-        elif self.source_type == ParameterSource.FUNCTION_NODE:
-            return self.dependency.parameters[self.value]
-        else:
-            raise ValueError(f"Invalid ParameterSource type {self.source_type}")
 
     def set_name(self, parameter_name="", node_name=""):
         """Set the name of the parameter field.
@@ -167,6 +155,19 @@ class ParameterSource:
         self.dependency = dependency
         self.value = param_name
 
+    def set_as_compute_output(self, param_name="function_node_result"):
+        """Set the parameter the output of this current node's compute() method.
+
+        Parameters
+        ----------
+        dependency : `ParameterizedNode`
+            The node in which to access the attribute.
+        param_name : `str`
+            The name of where the result is stored in the FunctionNode.
+        """
+        self.source_type = ParameterSource.COMPUTE_OUTPUT
+        self.value = param_name
+
 
 class ParameterizedNode:
     """Any model that uses parameters that can be set by constants,
@@ -179,12 +180,12 @@ class ParameterizedNode:
     node_string : `str`
         The full string used to identify a node. This is a combination of the nodes position
         in the graph (if known), node_label (if provided), and class information.
+    node_hash : `int`
+        A hashed version of ``node_string`` used for fast lookups.
     setters : `dict`
         A dictionary mapping the parameters' names to information about the setters
         (ParameterSource). The model parameters are stored in the order in which they
         need to be set.
-    parameters : `dict`
-        A dictionary mapping the parameter's name to its current value.
     direct_dependencies : `dict`
         A dictionary with keys of other ParameterizedNodes on that this node needs to
         directly access. We use a dictionary to preserve ordering.
@@ -207,13 +208,13 @@ class ParameterizedNode:
 
     def __init__(self, node_label=None, **kwargs):
         self.setters = {}
-        self.parameters = {}
         self.direct_dependencies = {}
         self.node_label = node_label
         self._node_pos = None
         self._object_seed = None  # A default until set is called.
         self._graph_base_seed = None
         self.node_string = None
+        self.node_hash = None
 
         # We start all nodes with a completely random base seed.
         base_seed = int.from_bytes(urandom(4), "big")
@@ -237,6 +238,10 @@ class ParameterizedNode:
         # Allow for the appending of an extra tag.
         if extra_tag is not None:
             self.node_string = f"{self.node_string}:{extra_tag}"
+
+        # Save the hashed value of the node string.
+        hashed_object_name = md5(self.node_string.encode()).hexdigest()
+        self.node_hash = int(hashed_object_name, base=16)
 
         # Update the full_name of all node's parameter setters.
         for name, setter_info in self.setters.items():
@@ -269,18 +274,15 @@ class ParameterizedNode:
             self._graph_base_seed = graph_base_seed
 
         # Force an update of the node string to make sure we have the most recent.
+        # This recomputes node_hash as well.
         self._update_node_string()
-        hashed_object_name = md5(self.node_string.encode())
-
-        seed_offset = int(hashed_object_name.hexdigest(), base=16)
-        new_seed = (self._graph_base_seed + seed_offset) % (2**32)
+        new_seed = (self._graph_base_seed + self.node_hash) % (2**32)
         self._object_seed = new_seed
 
     def update_graph_information(
         self,
         new_graph_base_seed=None,
         seen_nodes=None,
-        reset_variables=False,
     ):
         """Force an update of the graph structure and the seeds.
 
@@ -297,9 +299,6 @@ class ParameterizedNode:
         seen_nodes : `set`, optional
             A set of nodes that have already been processed to prevent infinite loops.
             Caller should not set.
-        reset_variables : `bool`
-            Force all variables to ``None`` so that the code will check their
-            dependency order when resampling.
         """
         # Make sure that we do not process the same nodes multiple times.
         if seen_nodes is None:
@@ -313,24 +312,38 @@ class ParameterizedNode:
         self._update_node_string()
         self.set_seed(graph_base_seed=new_graph_base_seed)
 
-        # Reset the variables if needed.
-        if reset_variables:
-            for name in self.setters:
-                self.parameters[name] = None
-
         # Recursively update any direct dependencies.
         for dep in self.direct_dependencies:
-            dep.update_graph_information(new_graph_base_seed, seen_nodes, reset_variables)
+            dep.update_graph_information(new_graph_base_seed, seen_nodes)
 
-    def __getitem__(self, key):
-        return self.parameters[key]
+    def get_param(self, graph_state, name):
+        """Get the value of a parameter stored in this node.
+
+        Parameters
+        ----------
+        graph_state : `dict`
+            The dictionary of graph state information.
+        name : `str`
+            The parameter name to query.
+
+        Returns
+        -------
+        any
+            The parameter value.
+
+        Raises
+        ------
+        ``KeyError`` if this parameter has not be set.
+        """
+        return graph_state[self.node_hash][name]
 
     def set_parameter(self, name, value=None, **kwargs):
         """Set a single *existing* parameter to the ParameterizedNode.
 
         Notes
         -----
-        * Sets an initial value for the model parameter based on the given information.
+        * Does NOT set an initial value for the model parameter based. The user must
+          sample the parameters for this to be set.
         * The model parameters are stored in the order in which they are added.
 
         Parameters
@@ -366,7 +379,7 @@ class ParameterizedNode:
                 # to save a function call.
                 method_name = value.__name__
                 parent = value.__self__
-                if method_name in parent.parameters:
+                if method_name in parent.setters:
                     self.setters[name].set_as_parameter(parent, method_name)
                 else:
                     raise ValueError(f"Trying to set parameter to method {method_name}")
@@ -384,18 +397,14 @@ class ParameterizedNode:
             # with the same name.
             if value == self:
                 raise ValueError(f"Parameter {name} is recursively assigned to self.{name}.")
-            if name not in value.parameters:
+            if name not in value.setters:
                 raise ValueError(f"Parameter {name} missing from {str(value)}.")
             self.setters[name].set_as_parameter(value, name)
         else:
             # Case 4: The value is constant (including None).
             self.setters[name].set_as_constant(value)
-
-        # Check that we did get a parameter.
-        sampled_value = self.setters[name].get_value(**kwargs)
-        if self.setters[name].required and sampled_value is None:
-            raise ValueError(f"Missing required parameter {name}")
-        self.parameters[name] = sampled_value
+            if self.setters[name].required and value is None:
+                raise ValueError(f"Missing required parameter {name}")
 
         # Update the dependencies to account for any new nodes in the graph.
         self.direct_dependencies = {}
@@ -410,7 +419,8 @@ class ParameterizedNode:
         -----
         * Checks multiple sources in the following order: Manually specified ``value``,
           an entry in ``kwargs``, or ``None``.
-        * Sets an initial value for the model parameter based on the given information.
+        * Does NOT set an initial value for the model parameter based. The user must
+          sample the parameters for this to be set.
         * The model parameters are stored in the order in which they are added.
 
         Parameters
@@ -436,11 +446,10 @@ class ParameterizedNode:
         Raise a ``ValueError`` if the parameter is required, but set to None.
         """
         # Check for parameter collision and add a place holder value.
-        if hasattr(self, name) and name not in self.parameters:
+        if hasattr(self, name) and name not in self.setters:
             raise KeyError(f"Parameter name {name} conflicts with a predefined model parameter.")
-        if self.parameters.get(name, None) is not None:
+        if self.setters.get(name, None) is not None:
             raise KeyError(f"Duplicate parameter set: {name}")
-        self.parameters[name] = None
 
         # Add an entry for the setter function and fill in the remaining information using
         # set_parameter(). We add an initial (dummy) value here to indicate that this parameter
@@ -458,56 +467,86 @@ class ParameterizedNode:
         # attributes so it looks like method of this object.
         # This allows us to reference the parameter as object.parameter_name for chaining.
         def getter():
-            return self.parameters[name]
+            return None
 
         getter.__self__ = self
         getter.__name__ = name
         setattr(self, name, getter)
 
-    def _sample_helper(self, depth, seen_nodes, **kwargs):
+    def compute(self, graph_state, **kwargs):
+        """Placeholder for a general compute function.
+
+        Parameters
+        ----------
+        graph_state : `dict`
+            A dictionary of dictionaries mapping node->hash, variable_name to value.
+            This data structure is modified in place to represent the current state.
+        **kwargs : `dict`, optional
+            Additional function arguments.
+        """
+        return None
+
+    def _sample_helper(self, graph_state, seen_nodes):
         """Internal recursive function to sample the model's underlying parameters
         if they are provided by a function or ParameterizedNode.
 
         Parameters
         ----------
-        depth : `int`
-            The recursive depth remaining. Used to prevent infinite loops.
-            Users should not need to set this manually.
+        graph_state : `dict`
+            A dictionary of dictionaries mapping node->hash, variable_name to value.
+            This data structure is modified in place to represent the current state.
         seen_nodes : `dict`
             A dictionary mapping nodes seen during this sampling run to their ID.
             Used to avoid sampling nodes multiple times and to validity check the graph.
-        **kwargs : `dict`, optional
-            All the keyword arguments, including the values needed to sample
-            parameters.
 
         Raises
         ------
-        Raise a ``ValueError`` the depth of the sampling encounters a problem
-        with the order of dependencies.
+        Raise a ``KeyError`` if the sampling encounters an error with the order of dependencies.
         """
-        if depth == 0:
-            raise ValueError(f"Maximum sampling depth exceeded at {self}. Potential infinite loop.")
         if self in seen_nodes:
             return  # Nothing to do
         seen_nodes[self] = self._node_pos
 
+        if self.node_hash in graph_state:
+            raise KeyError(
+                f"Node name {self.node_string} for current node has already been seen. "
+                "This indicates a problem with node naming."
+            )
+        graph_state[self.node_hash] = {}
+
         # Run through each parameter and sample it based on the given recipe.
         # As of Python 3.7 dictionaries are guaranteed to preserve insertion ordering,
         # so this will iterate through model parameters in the order they were inserted.
-        for name, setter_info in self.setters.items():
-            if setter_info.dependency is not None:
-                setter_info.dependency._sample_helper(depth - 1, seen_nodes, **kwargs)
-            self.parameters[name] = setter_info.get_value(**kwargs)
+        any_compute = False
+        for name, setter in self.setters.items():
+            if setter.dependency is not None and setter.dependency != self:
+                setter.dependency._sample_helper(graph_state, seen_nodes)
 
-    def sample_parameters(self, **kwargs):
+            if setter.source_type == ParameterSource.CONSTANT:
+                graph_state[self.node_hash][name] = setter.value
+            elif setter.source_type == ParameterSource.MODEL_PARAMETER:
+                graph_state[self.node_hash][name] = graph_state[setter.dependency.node_hash][setter.value]
+            elif setter.source_type == ParameterSource.FUNCTION_NODE:
+                graph_state[self.node_hash][name] = graph_state[setter.dependency.node_hash][setter.value]
+            elif setter.source_type == ParameterSource.COMPUTE_OUTPUT:
+                any_compute = True
+            else:
+                raise ValueError(f"Invalid ParameterSource type {setter.source_type}")
+
+        # If this is a function node and the parameters depend on the result of its own computation
+        # call the compute function to fill them in.
+        if any_compute:
+            self.compute(graph_state)
+
+    def sample_parameters(self):
         """Sample the model's underlying parameters if they are provided by a function
         or ParameterizedNode.
 
-        Parameters
-        ----------
-        **kwargs : `dict`, optional
-            All the keyword arguments, including the values needed to sample
-            parameters.
+        Returns
+        -------
+        graph_state : `dict`
+            A dictionary of dictionaries mapping node->hash, variable_name to value.
+            This data structure is modified in place to represent the current state.
 
         Raises
         ------
@@ -517,61 +556,13 @@ class ParameterizedNode:
         # If the graph structure has never been set, do that now.
         if self._node_pos is None:
             nodes = set()
-            self.update_graph_information(seen_nodes=nodes, reset_variables=True)
+            self.update_graph_information(seen_nodes=nodes)
 
         # Resample the nodes.
         seen_nodes = {}
-        self._sample_helper(50, seen_nodes, **kwargs)
-
-        # Validity check that we do not see duplicate IDs.
-        seen_ids = np.array(list(seen_nodes.values()))
-        if len(seen_ids) != len(np.unique(seen_ids)):
-            raise ValueError(
-                "The graph nodes do not have unique IDs, which can indicate the graph "
-                "structure has changed. Please use update_graph_information()."
-            )
-
-    def get_all_parameter_values(self, recursive=True, seen=None):
-        """Get the values of the current parameters and (optionally) those of
-        all their dependencies.
-
-        Effectively snapshots the state of the execution graph.
-
-        Parameters
-        ----------
-        seen : `set`
-            A set of objects that have already been processed.
-        recursive : `bool`
-            Recursively extract the model parameter settings of this object's dependencies.
-
-        Returns
-        -------
-        values : `dict`
-            The dictionary mapping the combination of the object identifier and
-            model parameter name to its value.
-        """
-        # If we haven't processed the nodes yet, do that.
-        if self._node_pos is None:
-            nodes = set()
-            self.update_graph_information(seen_nodes=nodes)
-
-        # Make sure that we do not process the same nodes multiple times.
-        if seen is None:
-            seen = set()
-        if self in seen:
-            return {}
-        seen.add(self)
-
-        all_values = {}
-        for name, setter_info in self.setters.items():
-            if recursive:
-                if setter_info.dependency is not None:
-                    all_values.update(setter_info.dependency.get_all_parameter_values(True, seen))
-                full_name = setter_info.full_name
-            else:
-                full_name = name
-            all_values[full_name] = self.parameters[name]
-        return all_values
+        results = {}
+        self._sample_helper(results, seen_nodes)
+        return results
 
 
 class SingleVariableNode(ParameterizedNode):
@@ -664,10 +655,7 @@ class FunctionNode(ParameterizedNode):
             # the getter function and the entry in parameters. Then we change the
             # type to point to own result.
             self.add_parameter(name, None)
-            self.setters[name].set_as_function(self, param_name=name)
-
-        # Fill in the outputs.
-        self.compute()
+            self.setters[name].set_as_compute_output(param_name=name)
 
     def _update_node_string(self, extra_tag=None):
         """Update the node's string."""
@@ -678,68 +666,14 @@ class FunctionNode(ParameterizedNode):
         else:
             super()._update_node_string()
 
-    def _build_args_dict(self, **kwargs):
-        """Build a dictionary of arguments for the function."""
-        args = {}
-        for key in self.arg_names:
-            # Override with the kwarg if the parameter is there.
-            if key in kwargs:
-                args[key] = kwargs[key]
-            else:
-                args[key] = self.parameters[key]
-        return args
-
-    def _save_result_parameters(self, results):
-        """Save the results as model parameters.
-
-        Parameters
-        ----------
-        results : any
-            The results of the function.
-        """
-        if len(self.outputs) == 1:
-            self.parameters[self.outputs[0]] = results
-        else:
-            if len(results) != len(self.outputs):
-                raise ValueError(
-                    f"Incorrect number of results returned by {self.func.__name__}. "
-                    f"Expected {len(self.outputs)}, but got {results}."
-                )
-            for i in range(len(self.outputs)):
-                self.parameters[self.outputs[i]] = results[i]
-
-    def _sample_helper(self, depth, seen_nodes, **kwargs):
-        """Internal recursive function to sample the model's underlying parameters
-        if they are provided by a function or ParameterizedNode.
-
-        Parameters
-        ----------
-        depth : `int`
-            The recursive depth remaining. Used to prevent infinite loops.
-            Users should not need to set this manually.
-        seen_nodes : `dict`
-            A dictionary mapping nodes seen during this sampling run to their ID.
-            Used to avoid sampling nodes multiple times and to validity check the graph.
-        **kwargs : `dict`, optional
-            All the keyword arguments, including the values needed to sample
-            parameters.
-
-        Raises
-        ------
-        Raise a ``ValueError`` the depth of the sampling encounters a problem
-        with the order of dependencies.
-        """
-        if self not in seen_nodes:
-            # First use _sample_helper() to update the function node's inputs (dependencies).
-            # Then use compute() to update the function node's outputs.
-            super()._sample_helper(depth, seen_nodes, **kwargs)
-            _ = self.compute(**kwargs)
-
-    def compute(self, **kwargs):
+    def compute(self, graph_state, **kwargs):
         """Execute the wrapped function.
 
         Parameters
         ----------
+        graph_state : `dict`
+            A dictionary of dictionaries mapping node->hash, variable_name to value.
+            This data structure is modified in place to represent the current state.
         **kwargs : `dict`, optional
             Additional function arguments.
 
@@ -753,7 +687,26 @@ class FunctionNode(ParameterizedNode):
                 "set func or override compute()."
             )
 
-        args = self._build_args_dict(**kwargs)
+        # Build a dictionary of arguments for the function."""
+        args = {}
+        for key in self.arg_names:
+            # Override with the kwarg if the parameter is there.
+            if key in kwargs:
+                args[key] = kwargs[key]
+            else:
+                args[key] = graph_state[self.node_hash][key]
+
+        # Call the function and save the results in the graph_state
         results = self.func(**args)
-        self._save_result_parameters(results)
+        if len(self.outputs) == 1:
+            graph_state[self.node_hash][self.outputs[0]] = results
+        else:
+            if len(results) != len(self.outputs):
+                raise ValueError(
+                    f"Incorrect number of results returned by {self.func.__name__}. "
+                    f"Expected {len(self.outputs)}, but got {results}."
+                )
+            for i in range(len(self.outputs)):
+                graph_state[self.node_hash][self.outputs[i]] = results[i]
+
         return results

--- a/src/tdastro/base_models.py
+++ b/src/tdastro/base_models.py
@@ -337,6 +337,25 @@ class ParameterizedNode:
         """
         return graph_state[self.node_hash][name]
 
+    def get_local_params(self, graph_state):
+        """Get a dictionary of all parameters local to this node.
+
+        Parameters
+        ----------
+        graph_state : `dict`
+            The dictionary of graph state information.
+
+        Returns
+        -------
+        result : `dict`
+            A dictionary mapping the parameter name to its value.
+
+        Raises
+        ------
+        ``KeyError`` if no parameters have been set for this node.
+        """
+        return graph_state[self.node_hash]
+
     def set_parameter(self, name, value=None, **kwargs):
         """Set a single *existing* parameter to the ParameterizedNode.
 
@@ -687,7 +706,7 @@ class FunctionNode(ParameterizedNode):
                 "set func or override compute()."
             )
 
-        # Build a dictionary of arguments for the function."""
+        # Build a dictionary of arguments for the function.
         args = {}
         for key in self.arg_names:
             # Override with the kwarg if the parameter is there.

--- a/src/tdastro/base_models.py
+++ b/src/tdastro/base_models.py
@@ -334,7 +334,10 @@ class ParameterizedNode:
         Raises
         ------
         ``KeyError`` if this parameter has not be set.
+        ``ValueError`` if graph_state is None.
         """
+        if graph_state is None:
+            raise ValueError(f"Unable to look ip parameter={name}. No graph_state given.")
         return graph_state[self.node_hash][name]
 
     def get_local_params(self, graph_state):
@@ -353,7 +356,10 @@ class ParameterizedNode:
         Raises
         ------
         ``KeyError`` if no parameters have been set for this node.
+        ``ValueError`` if graph_state is None.
         """
+        if graph_state is None:
+            raise ValueError("No graph_state given.")
         return graph_state[self.node_hash]
 
     def set_parameter(self, name, value=None, **kwargs):

--- a/src/tdastro/base_models.py
+++ b/src/tdastro/base_models.py
@@ -378,7 +378,7 @@ class ParameterizedNode:
 
         Notes
         -----
-        * Does NOT set an initial value for the model parameter based. The user must
+        * Does NOT set an initial value for the model parameter. The user must
           sample the parameters for this to be set.
         * The model parameters are stored in the order in which they are added.
 

--- a/src/tdastro/base_models.py
+++ b/src/tdastro/base_models.py
@@ -455,7 +455,7 @@ class ParameterizedNode:
         -----
         * Checks multiple sources in the following order: Manually specified ``value``,
           an entry in ``kwargs``, or ``None``.
-        * Does NOT set an initial value for the model parameter based. The user must
+        * Does NOT set an initial value for the model parameter. The user must
           sample the parameters for this to be set.
         * The model parameters are stored in the order in which they are added.
 

--- a/src/tdastro/effects/effect_model.py
+++ b/src/tdastro/effects/effect_model.py
@@ -9,7 +9,7 @@ class EffectModel(ParameterizedNode):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
-    def apply(self, flux_density, wavelengths=None, physical_model=None, **kwargs):
+    def apply(self, flux_density, wavelengths=None, graph_state=None, **kwargs):
         """Apply the effect to observations (flux_density values)
 
         Parameters
@@ -18,9 +18,8 @@ class EffectModel(ParameterizedNode):
             A length T X N matrix of flux density values.
         wavelengths : `numpy.ndarray`, optional
             A length N array of wavelengths.
-        physical_model : `PhysicalModel`
-            A PhysicalModel from which the effect may query parameters
-            such as redshift, position, or distance.
+        graph_state : `dict`
+            A dictionary mapping graph parameters to their values.
         **kwargs : `dict`, optional
            Any additional keyword arguments.
 

--- a/src/tdastro/effects/white_noise.py
+++ b/src/tdastro/effects/white_noise.py
@@ -27,7 +27,7 @@ class WhiteNoise(EffectModel):
         super()._update_object_seed()
         self._rng = np.random.default_rng()
 
-    def apply(self, flux_density, wavelengths=None, physical_model=None, **kwargs):
+    def apply(self, flux_density, wavelengths=None, graph_state=None, **kwargs):
         """Apply the effect to observations (flux_density values)
 
         Parameters
@@ -36,9 +36,8 @@ class WhiteNoise(EffectModel):
             An array of flux density values.
         wavelengths : `numpy.ndarray`, optional
             An array of wavelengths.
-        physical_model : `PhysicalModel`
-            A PhysicalModel from which the effect may query parameters
-            such as redshift, position, or distance.
+        graph_state : `dict`
+            A dictionary mapping graph parameters to their values.
         **kwargs : `dict`, optional
            Any additional keyword arguments.
 
@@ -47,4 +46,5 @@ class WhiteNoise(EffectModel):
         flux_density : `numpy.ndarray`
             The results.
         """
-        return np.random.normal(loc=flux_density, scale=self.parameters["scale"])
+        scale = self.get_param(graph_state, "scale")
+        return np.random.normal(loc=flux_density, scale=scale)

--- a/src/tdastro/populations/population_model.py
+++ b/src/tdastro/populations/population_model.py
@@ -69,7 +69,7 @@ class PopulationModel(ParameterizedNode):
         for source in self.sources:
             source.add_effect(effect, allow_dups=allow_dups, **kwargs)
 
-    def evaluate(self, samples, times, wavelengths, resample_parameters=False, **kwargs):
+    def evaluate(self, samples, times, wavelengths, **kwargs):
         """Draw observations from a single (randomly sampled) source.
 
         Parameters
@@ -80,9 +80,6 @@ class PopulationModel(ParameterizedNode):
             A length T array of timestamps.
         wavelengths : `numpy.ndarray`, optional
             A length N array of wavelengths.
-        resample_parameters : `bool`
-            Treat this evaluation as a completely new object, resampling the
-            parameters from the original provided functions.
         **kwargs : `dict`, optional
            Any additional keyword arguments.
 
@@ -97,6 +94,7 @@ class PopulationModel(ParameterizedNode):
         results = []
         for _ in range(samples):
             source = self.draw_source()
-            object_fluxes = source.evaluate(times, wavelengths, resample_parameters, **kwargs)
+            state = source.sample_parameters()
+            object_fluxes = source.evaluate(times, wavelengths, state, **kwargs)
             results.append(object_fluxes)
         return np.array(results)

--- a/src/tdastro/sources/galaxy_models.py
+++ b/src/tdastro/sources/galaxy_models.py
@@ -23,7 +23,7 @@ class GaussianGalaxy(PhysicalModel):
         self.add_parameter("galaxy_radius_std", radius, required=True, **kwargs)
         self.add_parameter("brightness", brightness, required=True, **kwargs)
 
-    def _evaluate(self, times, wavelengths, ra=None, dec=None, **kwargs):
+    def _evaluate(self, times, wavelengths, graph_state, ra=None, dec=None, **kwargs):
         """Draw effect-free observations for this object.
 
         Parameters
@@ -32,6 +32,8 @@ class GaussianGalaxy(PhysicalModel):
             A length T array of timestamps.
         wavelengths : `numpy.ndarray`, optional
             A length N array of wavelengths.
+        graph_state : `dict`, optional
+            A given setting of all the parameters and their values.
         ra : `float`, optional
             The right ascension of the observations in degrees.
         dec : `float`, optional
@@ -44,17 +46,19 @@ class GaussianGalaxy(PhysicalModel):
         flux_density : `numpy.ndarray`
             A length T x N matrix of SED values.
         """
+        params = self.get_local_params(graph_state)
+
         dist = 0.0
         if ra is not None and dec is not None:
             dist = angular_separation(
-                self.parameters["ra"] * np.pi / 180.0,
-                self.parameters["dec"] * np.pi / 180.0,
+                params["ra"] * np.pi / 180.0,
+                params["dec"] * np.pi / 180.0,
                 ra * np.pi / 180.0,
                 dec * np.pi / 180.0,
             )
 
         # Scale the brightness as a Guassian function centered on the object's RA and Dec.
-        std = self.parameters["galaxy_radius_std"]
+        std = params["galaxy_radius_std"]
         scale = np.exp(-(dist * dist) / (2.0 * std * std))
 
-        return np.full((len(times), len(wavelengths)), self.parameters["brightness"] * scale)
+        return np.full((len(times), len(wavelengths)), params["brightness"] * scale)

--- a/src/tdastro/sources/periodic_source.py
+++ b/src/tdastro/sources/periodic_source.py
@@ -23,7 +23,7 @@ class PeriodicSource(PhysicalModel, ABC):
         self.add_parameter("t0", t0, required=True, **kwargs)
 
     @abstractmethod
-    def _evaluate_phases(self, phases, wavelengths, **kwargs):
+    def _evaluate_phases(self, phases, wavelengths, graph_state, **kwargs):
         """Draw effect-free observations for this object, as a function of phase.
 
         Parameters
@@ -32,6 +32,8 @@ class PeriodicSource(PhysicalModel, ABC):
             A length T array of phases, in the range [0, 1].
         wavelengths : `numpy.ndarray`, optional
             A length N array of wavelengths.
+        graph_state : `dict`, optional
+            A given setting of all the parameters and their values.
         **kwargs : `dict`, optional
               Any additional keyword arguments.
 
@@ -42,7 +44,7 @@ class PeriodicSource(PhysicalModel, ABC):
         """
         raise NotImplementedError()
 
-    def _evaluate(self, times, wavelengths, **kwargs):
+    def _evaluate(self, times, wavelengths, graph_state, **kwargs):
         """Draw effect-free observations for this object.
 
         Parameters
@@ -51,6 +53,8 @@ class PeriodicSource(PhysicalModel, ABC):
             A length T array of timestamps.
         wavelengths : `numpy.ndarray`, optional
             A length N array of wavelengths.
+        graph_state : `dict`, optional
+            A given setting of all the parameters and their values.
         **kwargs : `dict`, optional
            Any additional keyword arguments.
 
@@ -59,8 +63,9 @@ class PeriodicSource(PhysicalModel, ABC):
         flux_density : `numpy.ndarray`
             A length T x N matrix of SED values.
         """
-        period = self.parameters["period"]
-        phases = (times - self.parameters["t0"]) % period / period
-        flux_density = self._evaluate_phases(phases, wavelengths, **kwargs)
+        params = self.get_local_params(graph_state)
+        period = params["period"]
+        phases = (times - params["t0"]) % period / period
+        flux_density = self._evaluate_phases(phases, wavelengths, graph_state, **kwargs)
 
         return flux_density

--- a/src/tdastro/sources/physical_model.py
+++ b/src/tdastro/sources/physical_model.py
@@ -9,9 +9,9 @@ class PhysicalModel(ParameterizedNode):
 
     Physical models can have fixed attributes (where you need to create a new model or use
     a setter function to change them) and settable model parameters that can be passed functions
-    or constants and are automatically updated by resampling the model parameters.
+    or constants and are stored in the graph's (external) graph_state dictionary.
 
-    Physical models  can also have special background pointers that link to another PhysicalModel
+    Physical models can also have special background pointers that link to another PhysicalModel
     producing flux. We can chain these to have a supernova in front of a star in front
     of a static background.
 

--- a/src/tdastro/sources/sncomso_models.py
+++ b/src/tdastro/sources/sncomso_models.py
@@ -93,7 +93,7 @@ class SncosmoWrapperModel(PhysicalModel):
                 self.source_param_names.append(key)
         self.source.set(**kwargs)
 
-    def _sample_helper(self, graph_state, seen_nodes):
+    def _sample_helper(self, graph_state, seen_nodes, given_args=None):
         """Internal recursive function to sample the model's underlying parameters
         if they are provided by a function or ParameterizedNode.
 
@@ -108,12 +108,15 @@ class SncosmoWrapperModel(PhysicalModel):
         seen_nodes : `dict`
             A dictionary mapping nodes seen during this sampling run to their ID.
             Used to avoid sampling nodes multiple times and to validity check the graph.
+        given_args : `dict`, optional
+            A dictionary representing the given arguments for this sample run.
+            This can be used as the JAX PyTree for differentiation.
 
         Raises
         ------
         Raise a ``ValueError`` the sampling encounters a problem with the order of dependencies.
         """
-        super()._sample_helper(graph_state, seen_nodes)
+        super()._sample_helper(graph_state, seen_nodes, given_args)
         self._update_sncosmo_model_parameters(graph_state)
 
     def _evaluate(self, times, wavelengths, graph_state=None, **kwargs):

--- a/src/tdastro/sources/spline_model.py
+++ b/src/tdastro/sources/spline_model.py
@@ -69,7 +69,7 @@ class SplineModel(PhysicalModel):
         self._wavelengths = wavelengths
         self._spline = RectBivariateSpline(times, wavelengths, flux, kx=time_degree, ky=wave_degree)
 
-    def _evaluate(self, times, wavelengths, **kwargs):
+    def _evaluate(self, times, wavelengths, graph_state, **kwargs):
         """Draw effect-free observations for this object.
 
         Parameters
@@ -78,6 +78,8 @@ class SplineModel(PhysicalModel):
             A length T array of timestamps.
         wavelengths : `numpy.ndarray`, optional
             A length N array of wavelengths.
+        graph_state : `dict`, optional
+            A dictionary mapping graph parameters to their values.
         **kwargs : `dict`, optional
            Any additional keyword arguments.
 
@@ -86,4 +88,5 @@ class SplineModel(PhysicalModel):
         flux_density : `numpy.ndarray`
             A length T x N matrix of SED values.
         """
-        return self.parameters["amplitude"] * self._spline(times, wavelengths, grid=True)
+        params = self.get_local_params(graph_state)
+        return params["amplitude"] * self._spline(times, wavelengths, grid=True)

--- a/src/tdastro/sources/static_source.py
+++ b/src/tdastro/sources/static_source.py
@@ -18,7 +18,7 @@ class StaticSource(PhysicalModel):
         super().__init__(**kwargs)
         self.add_parameter("brightness", brightness, required=True, **kwargs)
 
-    def _evaluate(self, times, wavelengths, **kwargs):
+    def _evaluate(self, times, wavelengths, graph_state, **kwargs):
         """Draw effect-free observations for this object.
 
         Parameters
@@ -27,6 +27,8 @@ class StaticSource(PhysicalModel):
             A length T array of timestamps.
         wavelengths : `numpy.ndarray`, optional
             A length N array of wavelengths.
+        graph_state : `dict`
+            A dictionary mapping graph parameters to their values.
         **kwargs : `dict`, optional
             Any additional keyword arguments.
 
@@ -35,4 +37,5 @@ class StaticSource(PhysicalModel):
         flux_density : `numpy.ndarray`
             A length T x N matrix of SED values.
         """
-        return np.full((len(times), len(wavelengths)), self.parameters["brightness"])
+        brightness = graph_state[self.node_hash]["brightness"]
+        return np.full((len(times), len(wavelengths)), brightness)

--- a/src/tdastro/sources/static_source.py
+++ b/src/tdastro/sources/static_source.py
@@ -37,5 +37,5 @@ class StaticSource(PhysicalModel):
         flux_density : `numpy.ndarray`
             A length T x N matrix of SED values.
         """
-        brightness = graph_state[self.node_hash]["brightness"]
+        brightness = self.get_param(graph_state, "brightness")
         return np.full((len(times), len(wavelengths)), brightness)

--- a/src/tdastro/sources/step_source.py
+++ b/src/tdastro/sources/step_source.py
@@ -32,6 +32,8 @@ class StepSource(StaticSource):
             A length T array of timestamps.
         wavelengths : `numpy.ndarray`, optional
             A length N array of wavelengths.
+        graph_state : `dict`
+            A dictionary of all the current parameter settings.
         **kwargs : `dict`, optional
            Any additional keyword arguments.
 

--- a/src/tdastro/sources/step_source.py
+++ b/src/tdastro/sources/step_source.py
@@ -23,7 +23,7 @@ class StepSource(StaticSource):
         self.add_parameter("t0", t0, required=True, **kwargs)
         self.add_parameter("t1", t1, required=True, **kwargs)
 
-    def _evaluate(self, times, wavelengths, **kwargs):
+    def _evaluate(self, times, wavelengths, graph_state, **kwargs):
         """Draw effect-free observations for this object.
 
         Parameters
@@ -41,7 +41,8 @@ class StepSource(StaticSource):
             A length T x N matrix of SED values.
         """
         flux_density = np.zeros((len(times), len(wavelengths)))
+        params = self.get_local_params(graph_state)
 
-        time_mask = (times >= self.parameters["t0"]) & (times <= self.parameters["t1"])
-        flux_density[time_mask] = self.parameters["brightness"]
+        time_mask = (times >= params["t0"]) & (times <= params["t1"])
+        flux_density[time_mask] = params["brightness"]
         return flux_density

--- a/src/tdastro/util_nodes/jax_random.py
+++ b/src/tdastro/util_nodes/jax_random.py
@@ -26,6 +26,7 @@ class JaxRandomFunc(FunctionNode):
     """
 
     def __init__(self, func, seed=None, **kwargs):
+        self._fixed_seed = seed
         super().__init__(func, **kwargs)
 
         # Overwrite the func attribute using the new seed.
@@ -51,16 +52,23 @@ class JaxRandomFunc(FunctionNode):
             Reset the random number generator even if the seed has not change.
             This should only be set to ``True`` for testing.
         """
+        # If we have set a fixed seed for this node, use that.
+        if new_seed is None and self._fixed_seed is not None:
+            new_seed = self._fixed_seed
+
         old_seed = self._object_seed
         super().set_seed(new_seed, graph_base_seed)
         if old_seed != self._object_seed or force_update:
             self._key = jax.random.key(self._object_seed)
 
-    def compute(self, **kwargs):
+    def compute(self, graph_state, **kwargs):
         """Execute the wrapped JAX sampling function.
 
         Parameters
         ----------
+        graph_state : `dict`
+            A dictionary of dictionaries mapping node->hash, variable_name to value.
+            This data structure is modified in place to represent the current state.
         **kwargs : `dict`, optional
             Additional function arguments.
 
@@ -74,16 +82,24 @@ class JaxRandomFunc(FunctionNode):
                 "set func or override compute()."
             )
 
-        args = self._build_args_dict(**kwargs)
+        # Build a dictionary of arguments for the function.
+        args = {}
+        for key in self.arg_names:
+            # Override with the kwarg if the parameter is there.
+            if key in kwargs:
+                args[key] = kwargs[key]
+            else:
+                args[key] = graph_state[self.node_hash][key]
         self._key, subkey = jax.random.split(self._key)
+
         results = float(self.func(subkey, **args))
-        self._save_result_parameters(results)
+        graph_state[self.node_hash][self.outputs[0]] = results
         return results
 
-    def resample_and_compute(self, **kwargs):
-        """Compute the value, forcing a resampling of the random variables."""
-        self.sample_parameters(**kwargs)
-        return self.compute(**kwargs)
+    def generate(self, **kwargs):
+        """A helper function for testing that regenerates the parameters."""
+        state = self.sample_parameters()
+        return self.compute(state, **kwargs)
 
 
 class JaxRandomNormal(FunctionNode):
@@ -115,7 +131,7 @@ class JaxRandomNormal(FunctionNode):
         if seed is not None:
             self.update_graph_information(new_graph_base_seed=seed)
 
-    def resample_and_compute(self, **kwargs):
-        """Compute the value, forcing a resampling of the random variables."""
-        self.sample_parameters(**kwargs)
-        return self.compute(**kwargs)
+    def generate(self, **kwargs):
+        """A helper function for testing that regenerates the parameters."""
+        state = self.sample_parameters()
+        return self.compute(state, **kwargs)

--- a/tests/tdastro/astro_utils/test_cosmology.py
+++ b/tests/tdastro/astro_utils/test_cosmology.py
@@ -15,4 +15,5 @@ def test_redshift_to_distance():
 def test_redshift_dist_func_node():
     """Test the RedshiftDistFunc node."""
     node = RedshiftDistFunc(redshift=1100, cosmology=Planck18)
-    assert 13.0 * 1e12 < node["function_node_result"] < 16.0 * 1e12
+    state = node.sample_parameters()
+    assert 13.0 * 1e12 < node.get_param(state, "function_node_result") < 16.0 * 1e12

--- a/tests/tdastro/astro_utils/test_passbands.py
+++ b/tests/tdastro/astro_utils/test_passbands.py
@@ -93,8 +93,9 @@ def test_passbands_load_all_transmission_tables(tmp_path):
         passbands.data_path = os.path.join(tmp_path, "band_data/")
 
         # Mock the _download_transmission_table and _load_transmission_table methods
-        with patch.object(passbands, "_download_transmission_table", return_value=True), patch.object(
-            passbands, "_load_transmission_table", return_value=True
+        with (
+            patch.object(passbands, "_download_transmission_table", return_value=True),
+            patch.object(passbands, "_load_transmission_table", return_value=True),
         ):
             passbands.load_all_transmission_tables()
 

--- a/tests/tdastro/effects/test_white_noise.py
+++ b/tests/tdastro/effects/test_white_noise.py
@@ -21,14 +21,9 @@ def test_white_noise() -> None:
 def test_white_noise_random() -> None:
     """Test that we can resample effects to change their parameters."""
     rand_generator = NumpyRandomFunc("uniform", low=1.0, high=2.0)
-    wn_effect = WhiteNoise(scale=rand_generator)
-    scale = wn_effect["scale"]
-    wn_effect.sample_parameters()
-    assert scale != wn_effect["scale"]
-
-    # We can resample when it is added to a PhysicalObject.
     model = StaticSource(brightness=10.0)
     model.add_effect(WhiteNoise(scale=rand_generator))
-    scale = model.effects[0]["scale"]
-    model.sample_parameters()
-    assert model.effects[0]["scale"] != scale
+    state1 = model.sample_parameters()
+    scale = model.effects[0].get_param(state1, "scale")
+    state2 = model.sample_parameters()
+    assert model.effects[0].get_param(state2, "scale") != scale

--- a/tests/tdastro/populations/test_fixed_population.py
+++ b/tests/tdastro/populations/test_fixed_population.py
@@ -72,7 +72,8 @@ def test_fixed_population_sample_sources():
     counts = [0.0, 0.0, 0.0]
     for _ in range(itr):
         model = population.draw_source()
-        counts[int(model["brightness"])] += 1.0
+        state = model.sample_parameters()
+        counts[int(model.get_param(state, "brightness"))] += 1.0
     assert np.allclose(counts, [0.25 * itr, 0.25 * itr, 0.5 * itr], rtol=0.05)
 
     # Check the we can change a rate.
@@ -81,7 +82,8 @@ def test_fixed_population_sample_sources():
     counts = [0.0, 0.0, 0.0]
     for _ in range(itr):
         model = population.draw_source()
-        counts[int(model["brightness"])] += 1.0
+        state = model.sample_parameters()
+        counts[int(model.get_param(state, "brightness"))] += 1.0
     assert np.allclose(counts, [0.4 * itr, 0.2 * itr, 0.4 * itr], rtol=0.05)
 
 
@@ -100,7 +102,7 @@ def test_fixed_population_sample_fluxes():
     num_samples = 10_000
     times = np.array([1, 2, 3, 4, 5])
     wavelengths = np.array([100.0, 200.0, 300.0])
-    fluxes = population.evaluate(num_samples, times, wavelengths, resample_parameters=True)
+    fluxes = population.evaluate(num_samples, times, wavelengths)
 
     # Check that the fluxes are constant within a sample. Also check that we have
     # More than 4 values (since we are resampling a model with a random parameter).

--- a/tests/tdastro/sources/test_galaxy_models.py
+++ b/tests/tdastro/sources/test_galaxy_models.py
@@ -13,8 +13,6 @@ def test_gaussian_galaxy() -> None:
         brightness=10.0,
         radius=1.0 / 3600.0,
     )
-    host_ra = host["ra"]
-    host_dec = host["dec"]
 
     # We define the position of the source using Gaussian noise from the center of the host galaxy.
     source = StaticSource(
@@ -25,10 +23,13 @@ def test_gaussian_galaxy() -> None:
     )
 
     # Both RA and dec should be "close" to (but not exactly at) the center of the galaxy.
-    source_ra_offset = source["ra"] - host_ra
+    state = source.sample_parameters()
+    host_ra = host.get_param(state, "ra")
+    host_dec = host.get_param(state, "dec")
+    source_ra_offset = source.get_param(state, "ra") - host_ra
     assert 0.0 < np.abs(source_ra_offset) < 100.0 / 3600.0
 
-    source_dec_offset = source["dec"] - host_dec
+    source_dec_offset = source.get_param(state, "dec") - host_dec
     assert 0.0 < np.abs(source_dec_offset) < 100.0 / 3600.0
 
     times = np.array([1, 2, 3, 4, 5, 10])
@@ -42,14 +43,14 @@ def test_gaussian_galaxy() -> None:
 
     # Check that if we resample the source it will propagate and correctly resample the host.
     # the host's (RA, dec) should change and the source's should still be close.
-    source.sample_parameters()
-    assert host_ra != host["ra"]
-    assert host_dec != host["dec"]
+    state2 = source.sample_parameters()
+    assert host_ra != host.get_param(state2, "ra")
+    assert host_dec != host.get_param(state2, "dec")
 
-    source_ra_offset2 = source["ra"] - host["ra"]
+    source_ra_offset2 = host.get_param(state2, "ra") - source.get_param(state2, "ra")
     assert source_ra_offset != source_ra_offset2
     assert 0.0 < np.abs(source_ra_offset2) < 100.0 / 3600.0
 
-    source_dec_offset2 = source["dec"] - host["dec"]
+    source_dec_offset2 = host.get_param(state2, "dec") - source.get_param(state2, "dec")
     assert source_dec_offset != source_dec_offset2
     assert 0.0 < np.abs(source_ra_offset2) < 100.0 / 3600.0

--- a/tests/tdastro/sources/test_periodic_source.py
+++ b/tests/tdastro/sources/test_periodic_source.py
@@ -6,7 +6,7 @@ from tdastro.sources.periodic_source import PeriodicSource
 class SineSource(PeriodicSource):
     """A simple sine source with power (Rayleigh–Jeans) spectrum."""
 
-    def _evaluate_phases(self, phases, wavelengths, **kwargs):
+    def _evaluate_phases(self, phases, wavelengths, graph_state, **kwargs):
         del kwargs
 
         amplitude = 2 + np.sin(2 * np.pi * phases[:, None])

--- a/tests/tdastro/sources/test_physical_models.py
+++ b/tests/tdastro/sources/test_physical_models.py
@@ -6,28 +6,35 @@ def test_physical_model():
     """Test that we can create a PhysicalModel."""
     # Everything is specified.
     model1 = PhysicalModel(ra=1.0, dec=2.0, distance=3.0, redshift=0.0)
-    assert model1["ra"] == 1.0
-    assert model1["dec"] == 2.0
-    assert model1["distance"] == 3.0
-    assert model1["redshift"] == 0.0
+    state = model1.sample_parameters()
+
+    assert model1.get_param(state, "ra") == 1.0
+    assert model1.get_param(state, "dec") == 2.0
+    assert model1.get_param(state, "distance") == 3.0
+    assert model1.get_param(state, "redshift") == 0.0
 
     # Derive the distance from the redshift.
     model2 = PhysicalModel(ra=1.0, dec=2.0, redshift=1100.0, cosmology=Planck18)
-    assert model2["ra"] == 1.0
-    assert model2["dec"] == 2.0
-    assert model2["redshift"] == 1100.0
-    assert 13.0 * 1e12 < model2["distance"] < 16.0 * 1e12
+    state = model2.sample_parameters()
+    assert model2.get_param(state, "ra") == 1.0
+    assert model2.get_param(state, "dec") == 2.0
+    assert model2.get_param(state, "redshift") == 1100.0
+    assert 13.0 * 1e12 < model2.get_param(state, "distance") < 16.0 * 1e12
 
     # Check that the RedshiftDistFunc node has the same computed value.
     # The syntax is a bit ugly because we are checking internal state.
-    assert model2["distance"] == model2.setters["distance"].dependency["function_node_result"]
+    model2_val = model2.get_param(state, "distance")
+    func_val = model2.setters["distance"].dependency.get_param(state, "function_node_result")
+    assert model2_val == func_val
 
     # Neither distance nor redshift are specified.
     model3 = PhysicalModel(ra=1.0, dec=2.0)
-    assert model3["redshift"] is None
-    assert model3["distance"] is None
+    state = model3.sample_parameters()
+    assert model3.get_param(state, "redshift") is None
+    assert model3.get_param(state, "distance") is None
 
     # Redshift is specified but cosmology is not.
     model4 = PhysicalModel(ra=1.0, dec=2.0, redshift=1100.0)
-    assert model4["redshift"] == 1100.0
-    assert model4["distance"] is None
+    state = model4.sample_parameters()
+    assert model4.get_param(state, "redshift") == 1100.0
+    assert model4.get_param(state, "distance") is None

--- a/tests/tdastro/sources/test_sncosmo_models.py
+++ b/tests/tdastro/sources/test_sncosmo_models.py
@@ -6,8 +6,9 @@ from tdastro.util_nodes.np_random import NumpyRandomFunc
 def test_sncomso_models_hsiao() -> None:
     """Test that we can create and evalue a 'hsiao' model."""
     model = SncosmoWrapperModel("hsiao", amplitude=1.0e-10)
-    assert model["amplitude"] == 1.0e-10
-    assert str(model) == "tdastro.sources.sncomso_models.SncosmoWrapperModel"
+    state = model.sample_parameters()
+    assert model.get_param(state, "amplitude") == 1.0e-10
+    assert str(model) == "0:tdastro.sources.sncomso_models.SncosmoWrapperModel"
 
     assert np.array_equal(model.param_names, ["amplitude"])
     assert np.array_equal(model.parameter_values, [1.0e-10])
@@ -26,7 +27,9 @@ def test_sncomso_models_set() -> None:
     assert np.array_equal(model.parameter_values, [1.0])
 
     model.set(amplitude=100.0)
-    assert model["amplitude"] == 100.0
+    state = model.sample_parameters()
+
+    assert model.get_param(state, "amplitude") == 100.0
     assert np.array_equal(model.param_names, ["amplitude"])
     assert np.array_equal(model.parameter_values, [100.0])
 
@@ -39,6 +42,8 @@ def test_sncomso_models_chained() -> None:
         "hsiao",
         amplitude=NumpyRandomFunc("uniform", low=2.0, high=12.0, seed=100),
     )
+    _ = model.sample_parameters()
+
     assert np.array_equal(model.param_names, ["amplitude"])
     assert 2.0 <= model.parameter_values[0] <= 12.0
 
@@ -47,7 +52,7 @@ def test_sncomso_models_chained() -> None:
     hist = [0] * 10
     source_model = model.source
     for _ in range(10_000):
-        model.sample_parameters()
+        _ = model.sample_parameters()
         bin = int(source_model.parameters[0] - 2.0)
         hist[bin] += 1
 

--- a/tests/tdastro/sources/test_spline_source.py
+++ b/tests/tdastro/sources/test_spline_source.py
@@ -22,7 +22,7 @@ def test_spline_model_flat() -> None:
     model2 = SplineModel(times, wavelengths, fluxes, amplitude=5.0, node_label="test")
     assert str(model2) == "test"
 
-    state2 = model.sample_parameters()
+    state2 = model2.sample_parameters()
     values2 = model2.evaluate(test_times, test_waves, state2)
     assert values2.shape == (5, 4)
     expected2 = np.full_like(values2, 5.0)

--- a/tests/tdastro/sources/test_spline_source.py
+++ b/tests/tdastro/sources/test_spline_source.py
@@ -13,7 +13,8 @@ def test_spline_model_flat() -> None:
     test_times = np.array([0.0, 1.0, 2.0, 3.0, 10.0])
     test_waves = np.array([0.0, 100.0, 200.0, 1000.0])
 
-    values = model.evaluate(test_times, test_waves)
+    state = model.sample_parameters()
+    values = model.evaluate(test_times, test_waves, state)
     assert values.shape == (5, 4)
     expected = np.full_like(values, 1.0)
     np.testing.assert_array_almost_equal(values, expected)
@@ -21,7 +22,8 @@ def test_spline_model_flat() -> None:
     model2 = SplineModel(times, wavelengths, fluxes, amplitude=5.0, node_label="test")
     assert str(model2) == "test"
 
-    values2 = model2.evaluate(test_times, test_waves)
+    state2 = model.sample_parameters()
+    values2 = model2.evaluate(test_times, test_waves, state2)
     assert values2.shape == (5, 4)
     expected2 = np.full_like(values2, 5.0)
     np.testing.assert_array_almost_equal(values2, expected2)
@@ -33,10 +35,11 @@ def test_spline_model_interesting() -> None:
     wavelengths = np.array([10.0, 20.0, 30.0])
     fluxes = np.array([[1.0, 5.0, 1.0], [5.0, 10.0, 5.0], [1.0, 5.0, 3.0]])
     model = SplineModel(times, wavelengths, fluxes, time_degree=1, wave_degree=1)
+    state = model.sample_parameters()
 
     test_times = np.array([1.0, 1.5, 2.0, 3.0])
     test_waves = np.array([10.0, 15.0, 20.0, 30.0])
-    values = model.evaluate(test_times, test_waves)
+    values = model.evaluate(test_times, test_waves, state)
     assert values.shape == (4, 4)
 
     expected = np.array(

--- a/tests/tdastro/sources/test_static_source.py
+++ b/tests/tdastro/sources/test_static_source.py
@@ -20,22 +20,24 @@ def _sampler_fun(magnitude, **kwargs):
 def test_static_source() -> None:
     """Test that we can sample and create a StaticSource object."""
     model = StaticSource(brightness=10.0, node_label="my_static_source")
-    assert model["brightness"] == 10.0
-    assert model["ra"] is None
-    assert model["dec"] is None
-    assert model["distance"] is None
-    assert str(model) == "my_static_source"
+    state = model.sample_parameters()
+    assert model.get_param(state, "brightness") == 10.0
+    assert model.get_param(state, "ra") is None
+    assert model.get_param(state, "dec") is None
+    assert model.get_param(state, "distance") is None
+    assert str(model) == "0:my_static_source"
 
     times = np.array([1, 2, 3, 4, 5, 10])
     wavelengths = np.array([100.0, 200.0, 300.0])
 
-    values = model.evaluate(times, wavelengths)
+    values = model.evaluate(times, wavelengths, state)
     assert values.shape == (6, 3)
     assert np.all(values == 10.0)
 
     # We can set a value we have already added.
     model.set_parameter("brightness", 5.0)
-    values = model.evaluate(times, wavelengths)
+    state = model.sample_parameters()
+    values = model.evaluate(times, wavelengths, state)
     assert values.shape == (6, 3)
     assert np.all(values == 5.0)
 
@@ -45,11 +47,16 @@ def test_static_source_host() -> None:
     derived from the host object."""
     host = StaticSource(brightness=15.0, ra=1.0, dec=2.0, distance=3.0)
     model = StaticSource(brightness=10.0, ra=host.ra, dec=host.dec, distance=host.distance)
-    assert model["brightness"] == 10.0
-    assert model["ra"] == 1.0
-    assert model["dec"] == 2.0
-    assert model["distance"] == 3.0
-    assert str(model) == "tdastro.sources.static_source.StaticSource"
+    state = model.sample_parameters()
+
+    assert model.get_param(state, "brightness") == 10.0
+    assert model.get_param(state, "ra") == 1.0
+    assert model.get_param(state, "dec") == 2.0
+    assert model.get_param(state, "distance") == 3.0
+    assert str(model) == "0:tdastro.sources.static_source.StaticSource"
+
+    # Test that we have given a different name to the host.
+    assert str(host) == "1:tdastro.sources.static_source.StaticSource"
 
 
 def test_static_source_resample() -> None:
@@ -59,8 +66,8 @@ def test_static_source_resample() -> None:
     num_samples = 100
     values = np.zeros((num_samples, 1))
     for i in range(num_samples):
-        model.sample_parameters(magnitude=100.0)
-        values[i] = model["brightness"]
+        state = model.sample_parameters()
+        values[i] = model.get_param(state, "brightness")
 
     # Check that the values fall within the expected bounds.
     assert np.all(values >= 0.0)

--- a/tests/tdastro/sources/test_static_source.py
+++ b/tests/tdastro/sources/test_static_source.py
@@ -36,8 +36,7 @@ def test_static_source() -> None:
 
     # We can set a value we have already added.
     model.set_parameter("brightness", 5.0)
-    state = model.sample_parameters()
-    values = model.evaluate(times, wavelengths, state)
+    values = model.evaluate(times, wavelengths)
     assert values.shape == (6, 3)
     assert np.all(values == 5.0)
 

--- a/tests/tdastro/sources/test_step_source.py
+++ b/tests/tdastro/sources/test_step_source.py
@@ -36,18 +36,21 @@ def test_step_source() -> None:
     """Test that we can sample and create a StepSource object."""
     host = StaticSource(brightness=150.0, ra=1.0, dec=2.0, distance=3.0)
     model = StepSource(brightness=15.0, t0=1.0, t1=2.0, ra=host.ra, dec=host.dec, distance=host.distance)
-    assert model["brightness"] == 15.0
-    assert model["t0"] == 1.0
-    assert model["t1"] == 2.0
-    assert model["ra"] == 1.0
-    assert model["dec"] == 2.0
-    assert model["distance"] == 3.0
+    state = model.sample_parameters()
+
+    param_values = model.get_local_params(state)
+    assert param_values["brightness"] == 15.0
+    assert param_values["t0"] == 1.0
+    assert param_values["t1"] == 2.0
+    assert param_values["ra"] == 1.0
+    assert param_values["dec"] == 2.0
+    assert param_values["distance"] == 3.0
 
     times = np.array([0.0, 1.0, 2.0, 3.0])
     wavelengths = np.array([100.0, 200.0])
     expected = np.array([[0.0, 0.0], [15.0, 15.0], [15.0, 15.0], [0.0, 0.0]])
 
-    values = model.evaluate(times, wavelengths)
+    values = model.evaluate(times, wavelengths, state)
     assert values.shape == (4, 2)
     assert np.array_equal(values, expected)
 
@@ -67,10 +70,10 @@ def test_step_source_resample() -> None:
     t_end_vals = np.zeros((num_samples, 1))
     t_start_vals = np.zeros((num_samples, 1))
     for i in range(num_samples):
-        model.sample_parameters()
-        brightness_vals[i] = model["brightness"]
-        t_end_vals[i] = model["t1"]
-        t_start_vals[i] = model["t0"]
+        state = model.sample_parameters()
+        brightness_vals[i] = model.get_param(state, "brightness")
+        t_end_vals[i] = model.get_param(state, "t1")
+        t_start_vals[i] = model.get_param(state, "t0")
 
     # Check that the values fall within the expected bounds.
     assert np.all(brightness_vals >= 0.0)

--- a/tests/tdastro/test_base_models.py
+++ b/tests/tdastro/test_base_models.py
@@ -264,8 +264,8 @@ def test_parameterized_node_build_pytree():
     """Test that we can extract the PyTree of a graph."""
     model1 = PairModel(value1=0.5, value2=1.5, node_label="A")
     model2 = PairModel(value1=model1.value1, value2=3.0, node_label="B")
-    model2.update_graph_information()
-    pytree = model2.build_pytree()
+    graph_state = model2.sample_parameters()
+    pytree = model2.build_pytree(graph_state)
 
     assert len(pytree) == 3
     assert pytree["1:A.value1"] == 0.5
@@ -275,7 +275,7 @@ def test_parameterized_node_build_pytree():
     # Manually set value2 to fixed and check that it no longer appears in the pytree.
     model1.setters["value2"].fixed = True
 
-    pytree = model2.build_pytree()
+    pytree = model2.build_pytree(graph_state)
     assert len(pytree) == 2
     assert pytree["1:A.value1"] == 0.5
     assert pytree["0:B.value2"] == 3.0
@@ -392,8 +392,9 @@ def test_function_node_jax():
     sum_node = FunctionNode(_test_func, value1=1.0, value2=div_node, node_label="sum")
     graph_state = sum_node.sample_parameters()
 
-    pytree = sum_node.build_pytree()
+    pytree = sum_node.build_pytree(graph_state)
     assert len(pytree) == 3
+    print(pytree)
 
     gr_func = jax.value_and_grad(sum_node.resample_and_compute)
     values, gradients = gr_func(pytree)

--- a/tests/tdastro/test_base_models.py
+++ b/tests/tdastro/test_base_models.py
@@ -55,21 +55,6 @@ class PairModel(ParameterizedNode):
             **kwargs,
         )
 
-    def result(self, **kwargs):
-        """Add the pair of values together
-
-        Parameters
-        ----------
-        **kwargs : `dict`, optional
-            Any additional keyword arguments.
-
-        Returns
-        -------
-        result : `float`
-            The result of the addition.
-        """
-        return self["value1"] + self["value2"]
-
 
 def test_parameter_source():
     """Test the ParameterSource creation and setter functions."""
@@ -81,8 +66,6 @@ def test_parameter_source():
     assert source.value is None
     assert not source.fixed
     assert not source.required
-    with pytest.raises(ValueError):
-        _ = source.get_value()
 
     source.set_as_constant(10.0)
     assert source.parameter_name == "test"
@@ -92,7 +75,6 @@ def test_parameter_source():
     assert source.value == 10.0
     assert not source.fixed
     assert not source.required
-    assert source.get_value() == 10.0
 
     source.set_name("my_var", "my_node")
     assert source.parameter_name == "my_var"
@@ -108,7 +90,6 @@ def test_parameter_source():
     assert source.value == "A"
     assert not source.fixed
     assert not source.required
-    assert source.get_value() == 20.0
 
     func = FunctionNode(_test_func, value1=0.1, value2=0.4)
     source.set_as_function(func)
@@ -116,26 +97,27 @@ def test_parameter_source():
     assert source.dependency is func
     assert not source.fixed
     assert not source.required
-    assert source.get_value() == 0.5
 
 
 def test_parameterized_node():
     """Test that we can sample and create a PairModel object."""
     # Simple addition
     model1 = PairModel(value1=0.5, value2=0.5)
-    assert model1["value1"] == 0.5
-    assert model1["value2"] == 0.5
-    assert model1.result() == 1.0
-    assert model1["value_sum"] == 1.0
     assert str(model1) == "test_base_models.PairModel"
+
+    state = model1.sample_parameters()
+    assert model1.get_param(state, "value1") == 0.5
+    assert model1.get_param(state, "value2") == 0.5
+    assert model1.get_param(state, "value_sum") == 1.0
 
     # Use value1=model.value and value2=1.0
     model2 = PairModel(value1=model1.value1, value2=1.0, node_label="test")
-    assert model2["value1"] == 0.5
-    assert model2["value2"] == 1.0
-    assert model2.result() == 1.5
-    assert model2["value_sum"] == 1.5
     assert str(model2) == "test"
+
+    state = model2.sample_parameters()
+    assert model2.get_param(state, "value1") == 0.5
+    assert model2.get_param(state, "value2") == 1.0
+    assert model2.get_param(state, "value_sum") == 1.5
 
     # If we set an ID it shows up in the name.
     model2._node_pos = 100
@@ -145,74 +127,33 @@ def test_parameterized_node():
     # Compute value1 from model2's result and value2 from the sampler function.
     # The sampler function is auto-wrapped in a FunctionNode.
     model3 = PairModel(value1=model2.value_sum, value2=_sampler_fun)
-    rand_val = model3["value2"]
-    assert model3.result() == pytest.approx(1.5 + rand_val)
-    assert model3["value_sum"] == pytest.approx(1.5 + rand_val)
+    state = model3.sample_parameters()
+    rand_val = model3.get_param(state, "value2")
+    assert model3.get_param(state, "value_sum") == pytest.approx(1.5 + rand_val)
 
     # Compute value1 from model3's result (which is itself the result for model2 +
     # a random value) and value2 = -1.0.
     model4 = PairModel(value1=model3.value_sum, value2=-1.0)
-    assert model4.result() == pytest.approx(0.5 + rand_val)
-    assert model4["value_sum"] == pytest.approx(0.5 + rand_val)
-    final_res = model4.result()
+    state = model4.sample_parameters()
+    rand_val = model3.get_param(state, "value2")
+    assert model4.get_param(state, "value_sum") == pytest.approx(0.5 + rand_val)
 
     # We can resample and it should change the result.
-    while model3["value2"] == rand_val:
-        model4.sample_parameters()
-    rand_val = model3["value2"]
+    new_state = model4.sample_parameters()
+    rand_val = model3.get_param(new_state, "value2")
 
     # Nothing changes in model1 or model2
-    assert model1["value1"] == 0.5
-    assert model1["value2"] == 0.5
-    assert model1.result() == 1.0
-    assert model1["value_sum"] == 1.0
-    assert model2["value1"] == 0.5
-    assert model2["value2"] == 1.0
-    assert model2.result() == 1.5
-    assert model2["value_sum"] == 1.5
+    assert model1.get_param(new_state, "value1") == 0.5
+    assert model1.get_param(new_state, "value2") == 0.5
+    assert model1.get_param(new_state, "value_sum") == 1.0
+    assert model2.get_param(new_state, "value1") == 0.5
+    assert model2.get_param(new_state, "value2") == 1.0
+    assert model2.get_param(new_state, "value_sum") == 1.5
 
     # Models 3 and 4 use the data from the new random value.
-    assert model3.result() == pytest.approx(1.5 + rand_val)
-    assert model4.result() == pytest.approx(0.5 + rand_val)
-    assert model3["value_sum"] == pytest.approx(1.5 + rand_val)
-    assert model4["value_sum"] == pytest.approx(0.5 + rand_val)
-    assert final_res != model4.result()
-
-
-def test_parameterized_node_parameters():
-    """Test that we can extract the parameters of a graph of ParameterizedNode."""
-    model1 = PairModel(value1=0.5, value2=1.5, node_label="A")
-    settings = model1.get_all_parameter_values(False)
-    assert len(settings) == 3
-    assert settings["value1"] == 0.5
-    assert settings["value2"] == 1.5
-    assert settings["value_sum"] == 2.0
-
-    # The model has 6 parameters in the graph: 3 in model1 and 3
-    # in its summation FunctionNode. Note Node ID's are -1 until
-    # reset or sample is called for the first time.
-    settings = model1.get_all_parameter_values(True)
-    assert len(settings) == 6
-    assert settings["0:A.value1"] == 0.5
-    assert settings["0:A.value2"] == 1.5
-    assert settings["0:A.value_sum"] == 2.0
-
-    # Use value1=model.value1 and value2=3.0
-    model2 = PairModel(value1=model1.value1, value2=3.0, node_label="B")
-    settings = model2.get_all_parameter_values(False)
-    assert len(settings) == 3
-    assert settings["value1"] == 0.5
-    assert settings["value2"] == 3.0
-    assert settings["value_sum"] == 3.5
-
-    settings = model2.get_all_parameter_values(True)
-    assert len(settings) == 12
-    assert settings["1:A.value1"] == 0.5
-    assert settings["1:A.value2"] == 1.5
-    assert settings["1:A.value_sum"] == 2.0
-    assert settings["0:B.value1"] == 0.5
-    assert settings["0:B.value2"] == 3.0
-    assert settings["0:B.value_sum"] == 3.5
+    assert model3.get_param(new_state, "value_sum") == pytest.approx(1.5 + rand_val)
+    assert model4.get_param(new_state, "value_sum") == pytest.approx(0.5 + rand_val)
+    assert model4.get_param(state, "value_sum") != model4.get_param(new_state, "value_sum")
 
 
 def test_parameterized_node_get_dependencies():
@@ -233,8 +174,6 @@ def test_parameterized_node_get_dependencies():
 def test_parameterized_node_modify():
     """Test that we can modify the parameters in a node."""
     model = PairModel(value1=0.5, value2=0.5)
-    assert model["value1"] == 0.5
-    assert model["value2"] == 0.5
 
     # We cannot add a parameter a second time.
     with pytest.raises(KeyError):
@@ -242,8 +181,6 @@ def test_parameterized_node_modify():
 
     # We can set the parameter.
     model.set_parameter("value1", 5.0)
-    assert model["value1"] == 5.0
-    assert model["value2"] == 0.5
 
     # We cannot set a value that hasn't been added.
     with pytest.raises(KeyError):
@@ -311,7 +248,7 @@ def test_parameterized_node_base_seed_fail():
     # But if we change the graph to link them, we don't want them
     # to have the same seed.
     model_b.set_parameter("value1", model_a.value_sum)
-    with pytest.raises(ValueError):
+    with pytest.raises(KeyError):
         model_b.sample_parameters()
 
     # We need to reset the node IDs (their positions within the graph)
@@ -325,60 +262,63 @@ def test_parameterized_node_base_seed_fail():
 def test_single_variable_node():
     """Test that we can create and query a SingleVariableNode."""
     node = SingleVariableNode("A", 10.0)
-    assert node["A"] == 10
     assert str(node) == "tdastro.base_models.SingleVariableNode"
+
+    state = node.sample_parameters()
+    assert node.get_param(state, "A") == 10
 
 
 def test_function_node_basic():
     """Test that we can create and query a FunctionNode."""
     my_func = FunctionNode(_test_func, value1=1.0, value2=2.0)
-    assert my_func.compute() == 3.0
-    assert my_func.compute(value2=3.0) == 4.0
-    assert my_func.compute(value2=3.0, unused_param=5.0) == 4.0
-    assert my_func.compute(value2=3.0, value1=1.0) == 4.0
-    assert str(my_func) == "tdastro.base_models.FunctionNode:_test_func"
+    state = my_func.sample_parameters()
+
+    assert my_func.compute(state) == 3.0
+    assert my_func.compute(state, value2=3.0) == 4.0
+    assert my_func.compute(state, value2=3.0, unused_param=5.0) == 4.0
+    assert my_func.compute(state, value2=3.0, value1=1.0) == 4.0
+    assert str(my_func) == "0:tdastro.base_models.FunctionNode:_test_func"
 
 
 def test_function_node_chain():
     """Test that we can create and query a chained FunctionNode."""
     func1 = FunctionNode(_test_func, value1=1.0, value2=1.0)
     func2 = FunctionNode(_test_func, value1=func1, value2=3.0)
-    assert func2.compute() == 5.0
+    state = func2.sample_parameters()
+
+    assert func2.compute(state) == 5.0
 
 
 def test_no_resample_functions():
     """Test that if we use the same node as dependencies in two other nodes, we do not resample it."""
     rand_val = FunctionNode(_sampler_fun)
-    init_val = rand_val.compute()
-
     node_a = SingleVariableNode("A", rand_val)
     node_b = PairModel(value1=node_a.A, value2=rand_val)
-    assert node_a["A"] == init_val
-    assert node_b["value1"] == init_val
-    assert node_b["value2"] == init_val
+    state = node_b.sample_parameters()
+
+    # All the values should be the same (no resampling of A.)
+    assert node_b.get_param(state, "value1") == node_a.get_param(state, "A")
+    assert node_b.get_param(state, "value2") == node_a.get_param(state, "A")
 
     # They should change when we resample.
-    node_b.sample_parameters()
-    new_val = node_a["A"]
-    assert new_val != init_val
-    assert node_b["value1"] == new_val
-    assert node_b["value2"] == new_val
+    new_state = node_b.sample_parameters()
+    assert node_a.get_param(state, "A") != node_a.get_param(new_state, "A")
+    assert node_b.get_param(new_state, "value1") == node_a.get_param(new_state, "A")
+    assert node_b.get_param(new_state, "value2") == node_a.get_param(new_state, "A")
 
 
 def test_np_sampler_method():
     """Test that we can wrap numpy random functions."""
     rng = np.random.default_rng(1001)
-    my_func = FunctionNode(rng.normal, loc=10.0, scale=1.0)
+    my_func = FunctionNode(rng.normal, loc=10.0, scale=1.0, outputs=["val"])
 
     # Sample 1000 times with the default values. Check that we are near
     # the expected mean and not everything is equal.
-    vals = np.array([my_func.compute() for _ in range(1000)])
+    vals = []
+    for _ in range(1000):
+        state = my_func.sample_parameters()
+        vals.append(my_func.get_param(state, "val"))
     assert abs(np.mean(vals) - 10.0) < 1.0
-    assert not np.all(vals == vals[0])
-
-    # Override the mean and resample.
-    vals = np.array([my_func.compute(loc=25.0) for _ in range(1000)])
-    assert abs(np.mean(vals) - 25.0) < 1.0
     assert not np.all(vals == vals[0])
 
 
@@ -389,16 +329,19 @@ def test_function_node_obj():
     # The model depends on the function.
     func = FunctionNode(_test_func, value1=5.0, value2=6.0)
     model = PairModel(value1=10.0, value2=func)
-    assert model.result() == 21.0
+    state = model.sample_parameters()
+    assert model.get_param(state, "value_sum") == 21.0
 
     # Function depends on the model's value2 parameter.
     model = PairModel(value1=-10.0, value2=17.5)
-    func = FunctionNode(_test_func, value1=5.0, value2=model.value2)
-    assert model.result() == 7.5
-    assert func.compute() == 22.5
+    func = FunctionNode(_test_func, value1=5.0, value2=model.value2, outputs=["res"])
+    state = func.sample_parameters()
+
+    assert model.get_param(state, "value_sum") == 7.5
+    assert func.get_param(state, "res") == 22.5
 
     # We can always override the node's parameters with kwargs.
-    assert func.compute(value1=1.0, value2=4.0) == 5.0
+    assert func.compute(state, value1=1.0, value2=4.0) == 5.0
 
 
 def test_function_node_multi():
@@ -408,9 +351,9 @@ def test_function_node_multi():
         return (value1 + value2, value1 - value2)
 
     my_func = FunctionNode(_test_func2, outputs=["sum_res", "diff_res"], value1=5.0, value2=6.0)
-    my_func.compute()
-
     model = PairModel(value1=my_func.sum_res, value2=my_func.diff_res)
-    assert model["value1"] == 11.0
-    assert model["value2"] == -1.0
-    assert model["value_sum"] == 10.0
+    state = model.sample_parameters()
+
+    assert model.get_param(state, "value1") == 11.0
+    assert model.get_param(state, "value2") == -1.0
+    assert model.get_param(state, "value_sum") == 10.0

--- a/tests/tdastro/util_nodes/test_jax_random.py
+++ b/tests/tdastro/util_nodes/test_jax_random.py
@@ -8,45 +8,42 @@ def test_jax_random_uniform():
     jax_node = JaxRandomFunc(jax.random.uniform, seed=100)
     jax_node.set_seed(new_seed=100)
 
-    values = np.array([jax_node.compute() for _ in range(10_000)])
+    values = np.array([jax_node.generate() for _ in range(10_000)])
     assert len(np.unique(values)) > 10
     assert np.all(values <= 1.0)
     assert np.all(values >= 0.0)
     assert np.abs(np.mean(values) - 0.5) < 0.01
 
-    # Test that we also save the result to the function_node_result parameter.
-    assert 0.0 <= jax_node["function_node_result"] <= 1.0
-
     # If we reuse the seed, we get the same numbers.
     jax_node2 = JaxRandomFunc(jax.random.uniform, seed=100)
-    values2 = np.array([jax_node2.compute() for _ in range(10_000)])
+    values2 = np.array([jax_node2.generate() for _ in range(10_000)])
     assert np.allclose(values, values2)
 
     # If we reuse the seed, we get the same numbers.
     jax_node2 = JaxRandomFunc(jax.random.uniform, seed=100)
-    values2 = np.array([jax_node2.compute() for _ in range(10_000)])
+    values2 = np.array([jax_node2.generate() for _ in range(10_000)])
     assert np.allclose(values, values2)
 
     # If we use a different seed, we get different numbers
     jax_node2 = JaxRandomFunc(jax.random.uniform, seed=101)
-    values2 = np.array([jax_node2.compute() for _ in range(10_000)])
+    values2 = np.array([jax_node2.generate() for _ in range(10_000)])
     assert not np.allclose(values, values2)
 
     # We can also set the seed with `set_seed()`
     jax_node2.set_seed(100)
-    values2 = np.array([jax_node2.compute() for _ in range(10_000)])
+    values2 = np.array([jax_node2.generate() for _ in range(10_000)])
     assert np.allclose(values, values2)
 
     # We can change the range.
     jax_node3 = JaxRandomFunc(jax.random.uniform, seed=101, minval=10.0, maxval=20.0)
-    values = np.array([jax_node3.compute() for _ in range(10_000)])
+    values = np.array([jax_node3.generate() for _ in range(10_000)])
     assert len(np.unique(values)) > 10
     assert np.all(values <= 20.0)
     assert np.all(values >= 10.0)
     assert np.abs(np.mean(values) - 15.0) < 0.5
 
     # We can override the range dynamically.
-    values = np.array([jax_node3.compute(minval=2.0) for _ in range(10_000)])
+    values = np.array([jax_node3.generate(minval=2.0) for _ in range(10_000)])
     assert len(np.unique(values)) > 10
     assert np.all(values <= 20.0)
     assert np.all(values >= 2.0)
@@ -57,11 +54,11 @@ def test_jax_random_normal():
     """Test that we can generate numbers from a normal distribution."""
     jax_node = JaxRandomNormal(loc=100.0, scale=10.0, seed=100)
 
-    values = np.array([jax_node.resample_and_compute() for _ in range(1000)])
+    values = np.array([jax_node.generate() for _ in range(1000)])
     assert np.abs(np.mean(values) - 100.0) < 0.5
     assert np.abs(np.std(values) - 10.0) < 0.5
 
     # If we reuse the seed, we get the same number.
     jax_node2 = JaxRandomNormal(loc=100.0, scale=10.0, seed=100)
-    values2 = np.array([jax_node2.resample_and_compute() for _ in range(1000)])
+    values2 = np.array([jax_node2.generate() for _ in range(1000)])
     assert np.allclose(values, values2)

--- a/tests/tdastro/util_nodes/test_np_random.py
+++ b/tests/tdastro/util_nodes/test_np_random.py
@@ -6,40 +6,37 @@ def test_numpy_random_uniform():
     """Test that we can generate numbers from a uniform distribution."""
     np_node = NumpyRandomFunc("uniform", seed=100)
 
-    values = np.array([np_node.compute() for _ in range(10_000)])
+    values = np.array([np_node.generate() for _ in range(10_000)])
     assert len(np.unique(values)) > 10
     assert np.all(values <= 1.0)
     assert np.all(values >= 0.0)
     assert np.abs(np.mean(values) - 0.5) < 0.01
 
-    # Test that we also save the result to the function_node_result parameter.
-    assert 0.0 <= np_node["function_node_result"] <= 1.0
-
     # If we reuse the seed, we get the same numbers.
     np_node2 = NumpyRandomFunc("uniform", seed=100)
-    values2 = np.array([np_node2.compute() for _ in range(10_000)])
+    values2 = np.array([np_node2.generate() for _ in range(10_000)])
     assert np.allclose(values, values2)
 
     # If we use a different seed, we get different numbers
     np_node2 = NumpyRandomFunc("uniform", seed=101)
-    values2 = np.array([np_node2.compute() for _ in range(10_000)])
+    values2 = np.array([np_node2.generate() for _ in range(10_000)])
     assert not np.allclose(values, values2)
 
     # We can also set the seed with `set_seed()`
     np_node2.set_seed(100)
-    values2 = np.array([np_node2.compute() for _ in range(10_000)])
+    values2 = np.array([np_node2.generate() for _ in range(10_000)])
     assert np.allclose(values, values2)
 
     # We can change the range.
     np_node3 = NumpyRandomFunc("uniform", low=10.0, high=20.0)
-    values = np.array([np_node3.compute() for _ in range(10_000)])
+    values = np.array([np_node3.generate() for _ in range(10_000)])
     assert len(np.unique(values)) > 10
     assert np.all(values <= 20.0)
     assert np.all(values >= 10.0)
     assert np.abs(np.mean(values) - 15.0) < 0.5
 
     # We can override the range dynamically.
-    values = np.array([np_node3.compute(low=2.0) for _ in range(10_000)])
+    values = np.array([np_node3.generate(low=2.0) for _ in range(10_000)])
     assert len(np.unique(values)) > 10
     assert np.all(values <= 20.0)
     assert np.all(values >= 2.0)
@@ -50,11 +47,11 @@ def test_numpy_random_normal():
     """Test that we can generate numbers from a normal distribution."""
     np_node = NumpyRandomFunc("normal", loc=100.0, scale=10.0, seed=100)
 
-    values = np.array([np_node.compute() for _ in range(10_000)])
+    values = np.array([np_node.generate() for _ in range(10_000)])
     assert np.abs(np.mean(values) - 100.0) < 0.5
     assert np.abs(np.std(values) - 10.0) < 0.5
 
     # If we reuse the seed, we get the same number.
     np_node2 = NumpyRandomFunc("normal", loc=100.0, scale=10.0, seed=100)
-    values2 = np.array([np_node2.compute() for _ in range(10_000)])
+    values2 = np.array([np_node2.generate() for _ in range(10_000)])
     assert np.allclose(values, values2)


### PR DESCRIPTION
Move the internal state of the model's parameters to an external dictionary `graph_state`. For details about the motivation and implementation, see the design document [here](https://docs.google.com/document/d/12UndUkKDTGjW_S3kVPLmnEEn9l-YeZ_CunjYduBygDI/edit).