### PR TITLE
Make the JAX random number generation stateless

### DIFF
--- a/src/tdastro/base_models.py
+++ b/src/tdastro/base_models.py
@@ -252,7 +252,7 @@ class ParameterizedNode:
             return
         seen_nodes.add(self)
 
-        # Update the graph ID and (possibly) the seed.
+        # Update the node's position in the graph and its string.
         self.node_pos = len(seen_nodes) - 1
         self._update_node_string()
 
@@ -599,6 +599,13 @@ class ParameterizedNode:
         result : `list`
             A list of values for each unique node in the graph.
         """
+        # Check if the node might have incomplete information.
+        if self.node_pos is None and (field == "node_pos" or field == "node_hash"):
+            raise ValueError(
+                f"Node {self.node_string} is missing position. You must call "
+                f"set_graph_positions() before querying {field}."
+            )
+
         # Check if we have already processed this node.
         if seen_nodes is None:
             seen_nodes = set()
@@ -629,6 +636,13 @@ class ParameterizedNode:
             The dictionary mapping the combination of the object identifier and
             model parameter name to its value.
         """
+        # Check if the node might have incomplete information.
+        if self.node_pos is None:
+            raise ValueError(
+                f"Node {self.node_string} is missing position. You must call "
+                "set_graph_positions() before building a pytree."
+            )
+
         # Skip nodes that we have already seen.
         if seen is None:
             seen = set()

--- a/src/tdastro/sources/physical_model.py
+++ b/src/tdastro/sources/physical_model.py
@@ -93,10 +93,6 @@ class PhysicalModel(ParameterizedNode):
         # Reset the node position to indicate the graph has changed.
         self.node_pos = None
 
-    def set_all_graph_positions(self):
-        """Finalize the graph structure by setting the node positions for the current node,
-        its background, and all effects."""
-
     def set_graph_positions(self, seen_nodes=None):
         """Force an update of the graph structure (numbering of each node).
 

--- a/src/tdastro/sources/physical_model.py
+++ b/src/tdastro/sources/physical_model.py
@@ -93,6 +93,29 @@ class PhysicalModel(ParameterizedNode):
         # Reset the node position to indicate the graph has changed.
         self.node_pos = None
 
+    def set_all_graph_positions(self):
+        """Finalize the graph structure by setting the node positions for the current node,
+        its background, and all effects."""
+
+    def set_graph_positions(self, seen_nodes=None):
+        """Force an update of the graph structure (numbering of each node).
+
+        Parameters
+        ----------
+        seen_nodes : `set`, optional
+            A set of nodes that have already been processed to prevent infinite loops.
+            Caller should not set.
+        """
+        if seen_nodes is None:
+            seen_nodes = set()
+
+        # Set the graph positions for each node, its background, and all of its effects.
+        super().set_graph_positions(seen_nodes=seen_nodes)
+        if self.background is not None:
+            self.background.set_graph_positions(seen_nodes=seen_nodes)
+        for effect in self.effects:
+            effect.set_graph_positions(seen_nodes=seen_nodes)
+
     def _evaluate(self, times, wavelengths, graph_state):
         """Draw effect-free observations for this object.
 
@@ -187,12 +210,7 @@ class PhysicalModel(ParameterizedNode):
         # If the graph has not been sampled ever, update the node positions for
         # every node (model, background, effects).
         if self.node_pos is None:
-            nodes = set()
-            self.set_graph_positions(seen_nodes=nodes)
-            if self.background is not None:
-                self.background.set_graph_positions(seen_nodes=nodes)
-            for effect in self.effects:
-                effect.set_graph_positions(seen_nodes=nodes)
+            self.set_graph_positions()
 
         args_to_use = {}
         if given_args is not None:

--- a/src/tdastro/sources/sncomso_models.py
+++ b/src/tdastro/sources/sncomso_models.py
@@ -93,7 +93,7 @@ class SncosmoWrapperModel(PhysicalModel):
                 self.source_param_names.append(key)
         self.source.set(**kwargs)
 
-    def _sample_helper(self, graph_state, seen_nodes, given_args=None):
+    def _sample_helper(self, graph_state, seen_nodes, given_args=None, rng_info=None):
         """Internal recursive function to sample the model's underlying parameters
         if they are provided by a function or ParameterizedNode.
 
@@ -111,12 +111,15 @@ class SncosmoWrapperModel(PhysicalModel):
         given_args : `dict`, optional
             A dictionary representing the given arguments for this sample run.
             This can be used as the JAX PyTree for differentiation.
+        rng_info : `dict`, optional
+            A dictionary of random number generator information for each node, such as
+            the JAX keys or the numpy rngs.
 
         Raises
         ------
         Raise a ``ValueError`` the sampling encounters a problem with the order of dependencies.
         """
-        super()._sample_helper(graph_state, seen_nodes, given_args)
+        super()._sample_helper(graph_state, seen_nodes, given_args, rng_info)
         self._update_sncosmo_model_parameters(graph_state)
 
     def _evaluate(self, times, wavelengths, graph_state=None, **kwargs):

--- a/src/tdastro/util_nodes/jax_random.py
+++ b/src/tdastro/util_nodes/jax_random.py
@@ -13,15 +13,14 @@ from tdastro.base_models import FunctionNode, ParameterizedNode
 
 
 def build_jax_keys_from_hashes(node_hashes, base_seed=None):
-    """Construct a dictionary a list of each node's hash value to a JAX key
-    from the list of hash values.
+    """Construct a dictionary mapping each node's hash value to a unique JAX key.
 
     Parameters
     ----------
     node_hashes : iterable
         All of the node hash values as constructed by hashing the nodes' node_string.
     base_seed : `int`
-        The key on which to base the keys for the individual node's.
+        The key on which to base the keys for the individual nodes.
 
     Returns
     -------
@@ -55,7 +54,7 @@ def build_jax_keys_from_nodes(nodes, base_seed=None):
     nodes : iterable or `ParameterizedNode`
         All of the nodes.
     base_seed : `int`
-        The key on which to base the keys for the individual node's.
+        The key on which to base the keys for the individual nodes.
 
     Returns
     -------

--- a/src/tdastro/util_nodes/np_random.py
+++ b/src/tdastro/util_nodes/np_random.py
@@ -9,14 +9,14 @@ from tdastro.base_models import FunctionNode, ParameterizedNode
 
 def build_rngs_from_hashes(node_hashes, base_seed=None):
     """Construct a dictionary a list of each node's hash value to a
-    numpy random number generator from the list of hash values.
+    numpy random number generator.
 
     Parameters
     ----------
     node_hashes : iterable
         All of the node hash values as constructed by hashing the nodes' node_string.
     base_seed : int
-        The key on which to base the keys for the individual node's.
+        The key on which to base the keys for the individual nodes.
 
     Returns
     -------
@@ -42,20 +42,20 @@ def build_rngs_from_hashes(node_hashes, base_seed=None):
 
 
 def build_rngs_from_nodes(nodes, base_seed=None):
-    """Construct a dictionary a list of each node's hash value to a
-    numpy random number generator from the list of hash values.
+    """Construct a dictionary mapping each node's hash value to a
+    numpy random number generator.
 
     Parameters
     ----------
     nodes : iterable or `ParameterizedNode`
         All of the nodes.
     base_seed : `int`
-        The key on which to base the keys for the individual node's.
+        The key on which to base the keys for the individual nodes.
 
     Returns
     -------
     keys : `dict`
-        A dictionary mapping each node's hash value to a unique JAX key.
+        A dictionary mapping each node's hash value to a numpy random number generator.
     """
     if isinstance(nodes, ParameterizedNode):
         nodes = [nodes]
@@ -116,7 +116,7 @@ class NumpyRandomFunc(FunctionNode):
         super().__init__(func, **kwargs)
 
     def set_seed(self, new_seed):
-        """Update the random number generator's seed a given value.
+        """Update the random number generator's seed to a given value.
 
         Parameters
         ----------

--- a/tests/tdastro/test_base_models.py
+++ b/tests/tdastro/test_base_models.py
@@ -121,7 +121,7 @@ def test_parameterized_node():
     assert model2.get_param(state, "value_sum") == 1.5
 
     # If we set an ID it shows up in the name.
-    model2._node_pos = 100
+    model2.node_pos = 100
     model2._update_node_string()
     assert str(model2) == "100:test"
 
@@ -179,7 +179,7 @@ def test_parameterized_node_get_info():
     model3 = PairModel(value1=model1.value1, value2=model2.value_sum, node_label="node3")
 
     # We need to finalize the model names to include the node's position in the string.
-    model3.update_graph_information()
+    model3.set_graph_positions()
 
     # Get the node strings.
     node_strings = model3.get_all_node_info("node_string")
@@ -193,7 +193,7 @@ def test_parameterized_node_get_info():
     assert len(node_hashes) == len(set(node_hashes))
 
     # Get the node positions. These should be integers [0, 5]
-    node_pos = model3.get_all_node_info("_node_pos")
+    node_pos = model3.get_all_node_info("node_pos")
     for i in range(6):
         assert i in node_pos
 
@@ -212,78 +212,6 @@ def test_parameterized_node_modify():
     # We cannot set a value that hasn't been added.
     with pytest.raises(KeyError):
         model.set_parameter("brightness", 5.0)
-
-
-def test_parameterized_node_seed():
-    """Test that we can set a random seed for the entire graph."""
-    # Left unspecified we use full random seeds.
-    model_a = PairModel(value1=0.5, value2=0.5)
-    model_b = PairModel(value1=0.5, value2=0.5)
-    assert model_a._object_seed != model_b._object_seed
-
-    # If we specify a seed, the results are the same objects with
-    # the same name (class + node_id + node_label) and different
-    # otherwise. Everything starts with a default node_id = None.
-    model_a = PairModel(value1=0.5, value2=0.5, node_label="A")
-    model_b = PairModel(value1=0.5, value2=0.5, node_label="B")
-    model_c = PairModel(value1=0.5, value2=0.5, node_label="A")
-    model_d = SingleVariableNode("value1", 0.5, node_label="A")
-    model_e = SingleVariableNode("value1", 0.5, node_label="C")
-
-    model_a.set_seed(graph_base_seed=10)
-    model_b.set_seed(graph_base_seed=10)
-    model_c.set_seed(graph_base_seed=10)
-    model_d.set_seed(graph_base_seed=10)
-    model_e.set_seed(graph_base_seed=10)
-
-    assert model_a._object_seed != model_b._object_seed
-    assert model_a._object_seed == model_c._object_seed
-    assert model_a._object_seed == model_d._object_seed
-    assert model_a._object_seed != model_e._object_seed
-
-    assert model_b._object_seed != model_a._object_seed
-    assert model_b._object_seed != model_c._object_seed
-    assert model_b._object_seed != model_d._object_seed
-    assert model_b._object_seed != model_e._object_seed
-
-    assert model_c._object_seed == model_a._object_seed
-    assert model_c._object_seed != model_b._object_seed
-    assert model_c._object_seed == model_d._object_seed
-    assert model_c._object_seed != model_e._object_seed
-
-    assert model_d._object_seed == model_a._object_seed
-    assert model_d._object_seed != model_b._object_seed
-    assert model_d._object_seed == model_c._object_seed
-    assert model_d._object_seed != model_e._object_seed
-
-
-def test_parameterized_node_base_seed_fail():
-    """Test that we can set a random seed for the entire graph."""
-    model_a = PairModel(value1=0.5, value2=0.5)
-    model_a.set_seed(graph_base_seed=10)
-    model_a.sample_parameters()
-
-    model_b = PairModel(value1=1.5, value2=0.5)
-    model_b.set_seed(graph_base_seed=10)
-    model_b.sample_parameters()
-
-    # The models have the same string and seed, but that's desired since they
-    # are not in the same graph.
-    assert str(model_a) == str(model_b)
-    assert model_a._object_seed == model_b._object_seed
-
-    # But if we change the graph to link them, we don't want them
-    # to have the same seed.
-    model_b.set_parameter("value1", model_a.value_sum)
-    with pytest.raises(KeyError):
-        model_b.sample_parameters()
-
-    # We need to reset the node IDs (their positions within the graph)
-    # so they have unique identifiers and seeds.
-    model_b.update_graph_information()
-    assert str(model_a) != str(model_b)
-    assert model_a._object_seed != model_b._object_seed
-    model_b.sample_parameters()
 
 
 def test_parameterized_node_build_pytree():

--- a/tests/tdastro/util_nodes/test_jax_random.py
+++ b/tests/tdastro/util_nodes/test_jax_random.py
@@ -1,43 +1,59 @@
 import jax.random
 import numpy as np
-from tdastro.util_nodes.jax_random import JaxRandomFunc, JaxRandomNormal
+import pytest
+from tdastro.util_nodes.jax_random import JaxRandomFunc, JaxRandomNormal, build_jax_keys_from_nodes
 
 
 def test_jax_random_uniform():
     """Test that we can generate numbers from a uniform distribution."""
-    jax_node = JaxRandomFunc(jax.random.uniform, seed=100)
+    jax_node = JaxRandomFunc(jax.random.uniform)
+    jax_node.set_graph_positions()
+    keys = build_jax_keys_from_nodes(jax_node, base_seed=100)
 
-    values = np.array([jax_node.generate() for _ in range(10_000)])
+    values = np.array([jax_node.generate(rng_info=keys) for _ in range(10_000)])
     assert len(np.unique(values)) > 10
     assert np.all(values <= 1.0)
     assert np.all(values >= 0.0)
     assert np.abs(np.mean(values) - 0.5) < 0.01
 
-    # If we reuse the seed, we get the same numbers.
-    jax_node2 = JaxRandomFunc(jax.random.uniform, seed=100)
-    values2 = np.array([jax_node2.generate() for _ in range(10_000)])
-    assert np.allclose(values, values2)
+    # We run into a seeding error if we try to use a second node without
+    # anything to make its seed unique.
+    jax_node2 = JaxRandomFunc(jax.random.uniform)
+    jax_node2.set_graph_positions()
+    assert jax_node.node_hash == jax_node2.node_hash
+    with pytest.raises(ValueError):
+        _ = build_jax_keys_from_nodes([jax_node, jax_node2])
 
-    # If we reuse the seed, we get the same numbers.
-    jax_node2 = JaxRandomFunc(jax.random.uniform, seed=100)
-    values2 = np.array([jax_node2.generate() for _ in range(10_000)])
-    assert np.allclose(values, values2)
+    # If we set the label for the second node, we get a different seed.
+    jax_node2 = JaxRandomFunc(jax.random.uniform, node_label="second")
+    jax_node2.set_graph_positions()
+    assert jax_node.node_hash != jax_node2.node_hash
+    keys = build_jax_keys_from_nodes([jax_node, jax_node2], base_seed=100)
+    assert keys[jax_node.node_hash] != keys[jax_node2.node_hash]
 
-    # If we use a different seed, we get different numbers
-    jax_node2 = JaxRandomFunc(jax.random.uniform, seed=101)
-    values2 = np.array([jax_node2.generate() for _ in range(10_000)])
+    # We should get different numbers from the generators.
+    values2 = np.array([jax_node2.generate(rng_info=keys) for _ in range(10_000)])
     assert not np.allclose(values, values2)
 
+    # If we reuse the seed, we get the same numbers. We force overwrite the keys.
+    keys[jax_node.node_hash] = jax.random.key(100)
+    keys[jax_node2.node_hash] = jax.random.key(100)
+    values = np.array([jax_node.generate(rng_info=keys) for _ in range(10_000)])
+    values2 = np.array([jax_node2.generate(rng_info=keys) for _ in range(10_000)])
+    assert np.allclose(values, values2)
+
     # We can change the range.
-    jax_node3 = JaxRandomFunc(jax.random.uniform, seed=101, minval=10.0, maxval=20.0)
-    values = np.array([jax_node3.generate() for _ in range(10_000)])
+    jax_node3 = JaxRandomFunc(jax.random.uniform, minval=10.0, maxval=20.0)
+    jax_node3.set_graph_positions()
+    keys3 = build_jax_keys_from_nodes(jax_node3, base_seed=100)
+    values = np.array([jax_node3.generate(rng_info=keys3) for _ in range(10_000)])
     assert len(np.unique(values)) > 10
     assert np.all(values <= 20.0)
     assert np.all(values >= 10.0)
     assert np.abs(np.mean(values) - 15.0) < 0.5
 
     # We can override the range dynamically.
-    values = np.array([jax_node3.generate(minval=2.0) for _ in range(10_000)])
+    values = np.array([jax_node3.generate(rng_info=keys3, minval=2.0) for _ in range(10_000)])
     assert len(np.unique(values)) > 10
     assert np.all(values <= 20.0)
     assert np.all(values >= 2.0)
@@ -46,13 +62,19 @@ def test_jax_random_uniform():
 
 def test_jax_random_normal():
     """Test that we can generate numbers from a normal distribution."""
-    jax_node = JaxRandomNormal(loc=100.0, scale=10.0, seed=100)
+    jax_node = JaxRandomNormal(loc=100.0, scale=10.0)
+    jax_node.set_graph_positions()
+    keys = build_jax_keys_from_nodes(jax_node, base_seed=100)
 
-    values = np.array([jax_node.generate() for _ in range(1000)])
+    values = np.array([jax_node.generate(rng_info=keys) for _ in range(1000)])
     assert np.abs(np.mean(values) - 100.0) < 0.5
     assert np.abs(np.std(values) - 10.0) < 0.5
 
-    # If we reuse the seed, we get the same number.
-    jax_node2 = JaxRandomNormal(loc=100.0, scale=10.0, seed=100)
-    values2 = np.array([jax_node2.generate() for _ in range(1000)])
+    # If we reuse the seed, we get the same numbers.
+    jax_node2 = JaxRandomNormal(loc=100.0, scale=10.0)
+    jax_node2.set_graph_positions()
+    keys2 = build_jax_keys_from_nodes(jax_node2, base_seed=100)
+    assert keys[jax_node.node_hash] == keys2[jax_node2.node_hash]
+
+    values2 = np.array([jax_node2.generate(rng_info=keys2) for _ in range(1000)])
     assert np.allclose(values, values2)

--- a/tests/tdastro/util_nodes/test_jax_random.py
+++ b/tests/tdastro/util_nodes/test_jax_random.py
@@ -6,7 +6,6 @@ from tdastro.util_nodes.jax_random import JaxRandomFunc, JaxRandomNormal
 def test_jax_random_uniform():
     """Test that we can generate numbers from a uniform distribution."""
     jax_node = JaxRandomFunc(jax.random.uniform, seed=100)
-    jax_node.set_seed(new_seed=100)
 
     values = np.array([jax_node.generate() for _ in range(10_000)])
     assert len(np.unique(values)) > 10
@@ -28,11 +27,6 @@ def test_jax_random_uniform():
     jax_node2 = JaxRandomFunc(jax.random.uniform, seed=101)
     values2 = np.array([jax_node2.generate() for _ in range(10_000)])
     assert not np.allclose(values, values2)
-
-    # We can also set the seed with `set_seed()`
-    jax_node2.set_seed(100)
-    values2 = np.array([jax_node2.generate() for _ in range(10_000)])
-    assert np.allclose(values, values2)
 
     # We can change the range.
     jax_node3 = JaxRandomFunc(jax.random.uniform, seed=101, minval=10.0, maxval=20.0)

--- a/tests/tdastro/util_nodes/test_np_random.py
+++ b/tests/tdastro/util_nodes/test_np_random.py
@@ -22,11 +22,6 @@ def test_numpy_random_uniform():
     values2 = np.array([np_node2.generate() for _ in range(10_000)])
     assert not np.allclose(values, values2)
 
-    # We can also set the seed with `set_seed()`
-    np_node2.set_seed(100)
-    values2 = np.array([np_node2.generate() for _ in range(10_000)])
-    assert np.allclose(values, values2)
-
     # We can change the range.
     np_node3 = NumpyRandomFunc("uniform", low=10.0, high=20.0)
     values = np.array([np_node3.generate() for _ in range(10_000)])

--- a/tests/tdastro/util_nodes/test_np_random.py
+++ b/tests/tdastro/util_nodes/test_np_random.py
@@ -1,5 +1,27 @@
 import numpy as np
-from tdastro.util_nodes.np_random import NumpyRandomFunc
+import pytest
+from tdastro.util_nodes.np_random import NumpyRandomFunc, build_rngs_from_hashes, build_rngs_from_nodes
+
+
+def test_build_rngs_from_hashes():
+    """Test that we can create seeded random number generators from hash values."""
+    rngs = build_rngs_from_hashes([0, 1, 2, 3, 4, 5, 6, 7], base_seed=0)
+    values = [gen.integers(0, 10000) for gen in rngs.values()]
+    assert len(np.unique(values) == len(rngs))
+
+    # If we reuse a hash id, we get the same values.
+    rngs2 = build_rngs_from_hashes([3, 5], base_seed=0)
+    assert rngs2[3].integers(0, 10000) == values[3]
+    assert rngs2[5].integers(0, 10000) == values[5]
+
+    # But not if we change the base seed.
+    rngs3 = build_rngs_from_hashes([3, 5], base_seed=1)
+    assert rngs3[3].integers(0, 10000) != values[3]
+    assert rngs3[5].integers(0, 10000) != values[5]
+
+    # We fail if we have duplicate hash_values.
+    with pytest.raises(ValueError):
+        _ = build_rngs_from_hashes([1, 2, 1])
 
 
 def test_numpy_random_uniform():
@@ -21,6 +43,11 @@ def test_numpy_random_uniform():
     np_node2 = NumpyRandomFunc("uniform", seed=101)
     values2 = np.array([np_node2.generate() for _ in range(10_000)])
     assert not np.allclose(values, values2)
+
+    # But we can override the seed and get the same results again.
+    np_node2.set_seed(100)
+    values2 = np.array([np_node2.generate() for _ in range(10_000)])
+    assert np.allclose(values, values2)
 
     # We can change the range.
     np_node3 = NumpyRandomFunc("uniform", low=10.0, high=20.0)
@@ -50,3 +77,20 @@ def test_numpy_random_normal():
     np_node2 = NumpyRandomFunc("normal", loc=100.0, scale=10.0, seed=100)
     values2 = np.array([np_node2.generate() for _ in range(10_000)])
     assert np.allclose(values, values2)
+
+
+def test_numpy_random_given_rng():
+    """Test that we can generate numbers from a uniform distribution."""
+    np_node1 = NumpyRandomFunc("uniform", seed=100, node_label="node1")
+    np_node1.set_graph_positions()
+
+    np_node2 = NumpyRandomFunc("uniform", seed=100, node_label="node2")
+    np_node2.set_graph_positions()
+
+    # The first value generated is the same because they are using the node's seed.
+    assert np.abs(np_node1.generate() - np_node2.generate()) < 1e-12
+
+    # But if we use a dictionary of rngs, we will generate different ones
+    # because the hash values are different.
+    rngs = build_rngs_from_nodes([np_node1, np_node2], base_seed=100)
+    assert np.abs(np_node1.generate(rng_info=rngs) - np_node2.generate(rng_info=rngs)) > 1e-12


### PR DESCRIPTION
Remove all the random seed information from the `ParameterizedNode` and instead only maintain it in the numpy and JAX random node classes. This removes a lot of complexity in the base class.

JAX random number generation nodes are stateless and requires the user pass in the current keys each time.

Numpy random number generation nodes can be stateful (with their own stored random number generation) or stateless (with a passed in dictionary of the random number generators).

This PR also adds all the plumbing for passing around the random number generators/keys/state. This adds some complexity to the function signatures, but means that the nodes behave statelessly.