### PR TITLE
Add a t0 parameter to sncosmo models

### DIFF
--- a/src/tdastro/sources/galaxy_models.py
+++ b/src/tdastro/sources/galaxy_models.py
@@ -29,7 +29,7 @@ class GaussianGalaxy(PhysicalModel):
         Parameters
         ----------
         times : `numpy.ndarray`
-            A length T array of timestamps.
+            A length T array of rest frame timestamps.
         wavelengths : `numpy.ndarray`, optional
             A length N array of wavelengths.
         graph_state : `dict`, optional

--- a/src/tdastro/sources/periodic_source.py
+++ b/src/tdastro/sources/periodic_source.py
@@ -50,7 +50,7 @@ class PeriodicSource(PhysicalModel, ABC):
         Parameters
         ----------
         times : `numpy.ndarray`
-            A length T array of timestamps.
+            A length T array of rest frame timestamps.
         wavelengths : `numpy.ndarray`, optional
             A length N array of wavelengths.
         graph_state : `dict`, optional

--- a/src/tdastro/sources/physical_model.py
+++ b/src/tdastro/sources/physical_model.py
@@ -1,5 +1,7 @@
 """The base PhysicalModel used for all sources."""
 
+import numpy as np
+
 from tdastro.astro_utils.cosmology import RedshiftDistFunc
 from tdastro.base_models import ParameterizedNode
 
@@ -118,7 +120,7 @@ class PhysicalModel(ParameterizedNode):
         Parameters
         ----------
         times : `numpy.ndarray`
-            A length T array of timestamps.
+            A length T array of rest frame timestamps.
         wavelengths : `numpy.ndarray`, optional
             A length N array of wavelengths.
         graph_state : `dict`
@@ -137,7 +139,7 @@ class PhysicalModel(ParameterizedNode):
         Parameters
         ----------
         times : `numpy.ndarray`
-            A length T array of timestamps.
+            A length T array of observer frame timestamps.
         wavelengths : `numpy.ndarray`, optional
             A length N array of wavelengths.
         graph_state : `dict`
@@ -156,6 +158,11 @@ class PhysicalModel(ParameterizedNode):
         flux_density : `numpy.ndarray`
             A length T x N matrix of SED values.
         """
+        # Make sure times and wavelengths are numpy arrays.
+        times = np.array(times)
+        wavelengths = np.array(wavelengths)
+
+        # Check if we need to sample the graph.
         if graph_state is None:
             graph_state = self.sample_parameters(given_args=given_args, rng_info=rng_info, **kwargs)
         params = self.get_local_params(graph_state)

--- a/src/tdastro/sources/sncomso_models.py
+++ b/src/tdastro/sources/sncomso_models.py
@@ -29,10 +29,14 @@ class SncosmoWrapperModel(PhysicalModel):
         Any additional keyword arguments.
     """
 
-    def __init__(self, source_name, **kwargs):
+    def __init__(self, source_name, t0=0.0, **kwargs):
         super().__init__(**kwargs)
         self.source_name = source_name
         self.source = get_source(source_name)
+
+        # Set the object's t0 as a parameter for the PhysicalModel, but
+        # not the sncosmo model.
+        self.add_parameter("t0", t0)
 
         # Use the kwargs to initialize the sncosmo model's parameters.
         self.source_param_names = []
@@ -128,7 +132,7 @@ class SncosmoWrapperModel(PhysicalModel):
         Parameters
         ----------
         times : `numpy.ndarray`
-            A length T array of timestamps.
+            A length T array of rest frame timestamps.
         wavelengths : `numpy.ndarray`, optional
             A length N array of wavelengths.
         graph_state : `dict`, optional
@@ -141,5 +145,6 @@ class SncosmoWrapperModel(PhysicalModel):
         flux_density : `numpy.ndarray`
             A length T x N matrix of SED values.
         """
+        t0 = self.get_param(graph_state, "t0")
         self._update_sncosmo_model_parameters(graph_state)
-        return self.source.flux(times, wavelengths)
+        return self.source.flux(times - t0, wavelengths)

--- a/src/tdastro/sources/spline_model.py
+++ b/src/tdastro/sources/spline_model.py
@@ -75,7 +75,7 @@ class SplineModel(PhysicalModel):
         Parameters
         ----------
         times : `numpy.ndarray`
-            A length T array of timestamps.
+            A length T array of rest frame timestamps.
         wavelengths : `numpy.ndarray`, optional
             A length N array of wavelengths.
         graph_state : `dict`, optional

--- a/src/tdastro/sources/static_source.py
+++ b/src/tdastro/sources/static_source.py
@@ -24,7 +24,7 @@ class StaticSource(PhysicalModel):
         Parameters
         ----------
         times : `numpy.ndarray`
-            A length T array of timestamps.
+            A length T array of rest frame timestamps.
         wavelengths : `numpy.ndarray`, optional
             A length N array of wavelengths.
         graph_state : `dict`

--- a/src/tdastro/sources/step_source.py
+++ b/src/tdastro/sources/step_source.py
@@ -29,7 +29,7 @@ class StepSource(StaticSource):
         Parameters
         ----------
         times : `numpy.ndarray`
-            A length T array of timestamps.
+            A length T array of rest frame timestamps.
         wavelengths : `numpy.ndarray`, optional
             A length N array of wavelengths.
         graph_state : `dict`

--- a/tests/tdastro/sources/test_sncosmo_models.py
+++ b/tests/tdastro/sources/test_sncosmo_models.py
@@ -5,35 +5,46 @@ from tdastro.util_nodes.np_random import NumpyRandomFunc
 
 def test_sncomso_models_hsiao() -> None:
     """Test that we can create and evalue a 'hsiao' model."""
-    model = SncosmoWrapperModel("hsiao", amplitude=1.0e-10)
+    model = SncosmoWrapperModel("hsiao", amplitude=2.0e10)
     state = model.sample_parameters()
-    assert model.get_param(state, "amplitude") == 1.0e-10
+    assert model.get_param(state, "amplitude") == 2.0e10
     assert model.get_param(state, "t0") == 0.0
     assert str(model) == "0:tdastro.sources.sncomso_models.SncosmoWrapperModel"
 
     assert np.array_equal(model.param_names, ["amplitude"])
-    assert np.array_equal(model.parameter_values, [1.0e-10])
+    assert np.array_equal(model.parameter_values, [2.0e10])
 
-    # Test with the example from: https://sncosmo.readthedocs.io/en/stable/models.html
-    fluxes = model.evaluate([54990.0], [4000.0, 4100.0, 4200.0])
-    assert np.allclose(fluxes, [4.31210900e-20, 7.46619962e-20, 1.42182787e-19])
+    # Test against a manual query from sncosmo with no redshift and an
+    # unrealistically high amplitude.
+    #     model = sncosmo.Model(source='hsiao')
+    #     model.set(z=0.0, t0=0.0, amplitude=2.0e10)
+    #     model.flux(54990., [4000., 4100., 4200.])
+    fluxes = model.evaluate([5.0], [4000.0, 4100.0, 4200.0])
+    assert np.allclose(fluxes, [133.98143039, 152.74613574, 134.40916824])
 
 
 def test_sncomso_models_hsiao_t0() -> None:
-    """Test that we can create and evalue a 'hsiao' model with a nonzero t0."""
-    model = SncosmoWrapperModel("hsiao", amplitude=1.0e-10, t0=10.0)
+    """Test that we can create and evalue a 'hsiao' model with a t0."""
+    model = SncosmoWrapperModel("hsiao", t0=55000.0, amplitude=2.0e10)
     state = model.sample_parameters()
-    assert model.get_param(state, "amplitude") == 1.0e-10
-    assert model.get_param(state, "t0") == 10.0
+    assert model.get_param(state, "amplitude") == 2.0e10
+    assert model.get_param(state, "t0") == 55000.0
+    assert str(model) == "0:tdastro.sources.sncomso_models.SncosmoWrapperModel"
 
-    # Test with the example from: https://sncosmo.readthedocs.io/en/stable/models.html
-    fluxes = model.evaluate([55000.0], [4000.0, 4100.0, 4200.0])
-    assert np.allclose(fluxes, [4.31210900e-20, 7.46619962e-20, 1.42182787e-19])
+    assert np.array_equal(model.param_names, ["amplitude"])
+    assert np.array_equal(model.parameter_values, [2.0e10])
+
+    # Test against a manual query from sncosmo with no redshift and an unrealistically high amplitude.
+    #     model = sncosmo.Model(source='hsiao')
+    #     model.set(z=0.0, t0=55000., amplitude=2.0e10)
+    #     model.flux(54990., [4000., 4100., 4200.])
+    fluxes = model.evaluate([54990.0], [4000.0, 4100.0, 4200.0])
+    assert np.allclose(fluxes, [67.83696271, 67.98471119, 47.20395186])
 
 
 def test_sncomso_models_set() -> None:
     """Test that we can create and evalue a 'hsiao' model and set parameter."""
-    model = SncosmoWrapperModel("hsiao")
+    model = SncosmoWrapperModel("hsiao", redshift=0.5)
 
     # sncosmo parameters exist at default values.
     assert np.array_equal(model.param_names, ["amplitude"])

--- a/tests/tdastro/sources/test_sncosmo_models.py
+++ b/tests/tdastro/sources/test_sncosmo_models.py
@@ -8,6 +8,7 @@ def test_sncomso_models_hsiao() -> None:
     model = SncosmoWrapperModel("hsiao", amplitude=1.0e-10)
     state = model.sample_parameters()
     assert model.get_param(state, "amplitude") == 1.0e-10
+    assert model.get_param(state, "t0") == 0.0
     assert str(model) == "0:tdastro.sources.sncomso_models.SncosmoWrapperModel"
 
     assert np.array_equal(model.param_names, ["amplitude"])
@@ -15,6 +16,18 @@ def test_sncomso_models_hsiao() -> None:
 
     # Test with the example from: https://sncosmo.readthedocs.io/en/stable/models.html
     fluxes = model.evaluate([54990.0], [4000.0, 4100.0, 4200.0])
+    assert np.allclose(fluxes, [4.31210900e-20, 7.46619962e-20, 1.42182787e-19])
+
+
+def test_sncomso_models_hsiao_t0() -> None:
+    """Test that we can create and evalue a 'hsiao' model with a nonzero t0."""
+    model = SncosmoWrapperModel("hsiao", amplitude=1.0e-10, t0=10.0)
+    state = model.sample_parameters()
+    assert model.get_param(state, "amplitude") == 1.0e-10
+    assert model.get_param(state, "t0") == 10.0
+
+    # Test with the example from: https://sncosmo.readthedocs.io/en/stable/models.html
+    fluxes = model.evaluate([55000.0], [4000.0, 4100.0, 4200.0])
     assert np.allclose(fluxes, [4.31210900e-20, 7.46619962e-20, 1.42182787e-19])
 
 

--- a/tests/tdastro/sources/test_sncosmo_models.py
+++ b/tests/tdastro/sources/test_sncosmo_models.py
@@ -18,7 +18,7 @@ def test_sncomso_models_hsiao() -> None:
     # unrealistically high amplitude.
     #     model = sncosmo.Model(source='hsiao')
     #     model.set(z=0.0, t0=0.0, amplitude=2.0e10)
-    #     model.flux(54990., [4000., 4100., 4200.])
+    #     model.flux(5., [4000., 4100., 4200.])
     fluxes = model.evaluate([5.0], [4000.0, 4100.0, 4200.0])
     assert np.allclose(fluxes, [133.98143039, 152.74613574, 134.40916824])
 


### PR DESCRIPTION
Add a t0 parameter to sncosmo models. Like all parameter this can be sampled if a function is passed in.

Also expands the comments to indicate which times are in rest frame vs observer frame.