### PR TITLE
Pre-factoring and helper functions

### DIFF
--- a/src/tdastro/base_models.py
+++ b/src/tdastro/base_models.py
@@ -765,9 +765,9 @@ class FunctionNode(ParameterizedNode):
         """Build the input arguments for the function.
         Parameters
         ----------
-        graph_state : `GraphState`
-            An object mapping graph parameters to their values. This object is modified
-            in place as it is sampled.
+        graph_state : `dict`
+            A dictionary of dictionaries mapping node->hash, variable_name to value.
+            This data structure is modified in place to represent the current state.
         given_args : `dict`, optional
             A dictionary representing the given arguments for this sample run.
             This can be used as the JAX PyTree for differentiation.
@@ -795,9 +795,9 @@ class FunctionNode(ParameterizedNode):
         ----------
         results : iterable
             The function's results.
-        graph_state : `GraphState`
-            An object mapping graph parameters to their values. This object is modified
-            in place as it is sampled.
+        graph_state : `dict`
+            A dictionary of dictionaries mapping node->hash, variable_name to value.
+            This data structure is modified in place to represent the current state.
         """
         if len(self.outputs) == 1:
             graph_state[self.node_hash][self.outputs[0]] = results

--- a/src/tdastro/sources/physical_model.py
+++ b/src/tdastro/sources/physical_model.py
@@ -4,6 +4,7 @@ import numpy as np
 
 from tdastro.astro_utils.cosmology import RedshiftDistFunc
 from tdastro.base_models import ParameterizedNode
+from tdastro.util_nodes.np_random import build_rngs_from_hashes
 
 
 class PhysicalModel(ParameterizedNode):
@@ -263,3 +264,25 @@ class PhysicalModel(ParameterizedNode):
         for effect in self.effects:
             result.extend(effect.get_all_node_info(field, seen_nodes))
         return result
+
+    def build_np_rngs(self, base_seed=None):
+        """Construct a dictionary of random generators for this model.
+
+        Parameters
+        ----------
+        base_seed : `int`
+            The key on which to base the keys for the individual nodes.
+
+        Returns
+        -------
+        np_rngs : `dict`
+            A dictionary mapping each node's hash value to a numpy random number generator.
+        """
+        # If the graph has not been sampled ever, update the node positions for
+        # every node (model, background, effects).
+        if self.node_pos is None:
+            self.set_graph_positions()
+
+        node_hashes = self.get_all_node_info("node_hash")
+        np_rngs = build_rngs_from_hashes(node_hashes, base_seed)
+        return np_rngs

--- a/src/tdastro/util_nodes/jax_random.py
+++ b/src/tdastro/util_nodes/jax_random.py
@@ -124,20 +124,10 @@ class JaxRandomFunc(FunctionNode):
         next_key, current_key = jax.random.split(rng_info[self.node_hash])
         rng_info[self.node_hash] = next_key
 
-        # Build a dictionary of arguments for the function.
-        args = {}
-        for key in self.arg_names:
-            # Override with the given arg or kwarg in that order.
-            if given_args is not None and self.setters[key].full_name in given_args:
-                args[key] = given_args[self.setters[key].full_name]
-            elif key in kwargs:
-                args[key] = kwargs[key]
-            else:
-                args[key] = graph_state[self.node_hash][key]
-
         # Generate the results.
+        args = self._build_inputs(graph_state, given_args, **kwargs)
         results = float(self.func(current_key, **args))
-        graph_state[self.node_hash][self.outputs[0]] = results
+        self._save_results(results, graph_state)
         return results
 
     def generate(self, given_args=None, rng_info=None, **kwargs):

--- a/src/tdastro/util_nodes/np_random.py
+++ b/src/tdastro/util_nodes/np_random.py
@@ -156,15 +156,16 @@ class NumpyRandomFunc(FunctionNode):
         ------
         ``ValueError`` is ``func`` attribute is ``None``.
         """
+        args = self._build_inputs(graph_state, given_args, **kwargs)
+
         # If we are given a numpy random number generator, use that for this sample.
         if rng_info is not None and self.node_hash in rng_info:
-            old_func = self.func
-            self.func = getattr(rng_info[self.node_hash], self.func_name)
-            result = super().compute(graph_state, given_args, rng_info, **kwargs)
-            self.func = old_func
+            func = getattr(rng_info[self.node_hash], self.func_name)
+            results = func(**args)
         else:
-            result = super().compute(graph_state, given_args, rng_info, **kwargs)
-        return result
+            results = self.func(**args)
+        self._save_results(results, graph_state)
+        return results
 
     def generate(self, given_args=None, rng_info=None, **kwargs):
         """A helper function for testing that regenerates the output.

--- a/tests/tdastro/sources/test_physical_models.py
+++ b/tests/tdastro/sources/test_physical_models.py
@@ -59,3 +59,19 @@ def test_physical_model_get_all_node_info():
     assert "bg" in node_labels
     assert "source" in node_labels
     assert "noise" in node_labels
+
+
+def test_physical_model_build_np_rngs():
+    """Test that we can build a dictionary of random number generators from a PhysicalModel."""
+    bg_model = PhysicalModel(ra=1.0, dec=2.0, distance=3.0, redshift=0.0, node_label="bg")
+    source_model = PhysicalModel(
+        ra=1.0,
+        dec=2.0,
+        distance=3.0,
+        redshift=0.0,
+        background=bg_model,
+        node_label="source",
+    )
+    source_model.add_effect(WhiteNoise(10.0, node_label="noise"))
+    np_rngs = source_model.build_np_rngs(base_seed=10)
+    assert len(np_rngs) == 3


### PR DESCRIPTION
Refactor some of `FunctionNode.compute()` by adding two helper functions to prepare the arguments and save the data.  Use those helpers to cleanup some of the logic in the numpy and JAX random generators.

Also adds a helper function for setting random seeds for a `PhysicalModel`.