### PR TITLE
Add a helper functions for GraphState

### DIFF
--- a/src/tdastro/graph_state.py
+++ b/src/tdastro/graph_state.py
@@ -121,6 +121,31 @@ class GraphState:
             # If the GraphState holds N samples and we got a single value, make an array of it.
             self.states[node_name][var_name] = np.full((self.num_samples), value)
 
+    def update(self, inputs, force_copy=False):
+        """Set multiple parameters' value in the GraphState from a GraphState or a
+        dictionary of the same form.
+
+        Parameters
+        ----------
+        inputs : `GraphState` or `dict`
+            Values to copy.
+        force_copy : `bool`
+            Make a copy of data in an array. If set to ``False`` this will link
+            to the array, saving memory and computation time.
+            Default: ``False``
+        """
+        if isinstance(inputs, GraphState):
+            if self.num_samples != inputs.num_samples:
+                raise ValueError("GraphSates must have the same number of samples.")
+            new_states = inputs.states
+        else:
+            new_states = inputs
+
+        # Set the values one by one.
+        for node_name, node_vars in new_states.items():
+            for var_name, value in node_vars.items():
+                self.set(node_name, var_name, value, force_copy=force_copy)
+
     def extract_single_sample(self, sample_num):
         """Create a new GraphState with a single sample state.
 

--- a/src/tdastro/graph_state.py
+++ b/src/tdastro/graph_state.py
@@ -125,6 +125,11 @@ class GraphState:
         """Set multiple parameters' value in the GraphState from a GraphState or a
         dictionary of the same form.
 
+        Note
+        ----
+        The number of samples in input must either match the number of samples in the
+        current object or be 1.
+
         Parameters
         ----------
         inputs : `GraphState` or `dict`
@@ -133,15 +138,21 @@ class GraphState:
             Make a copy of data in an array. If set to ``False`` this will link
             to the array, saving memory and computation time.
             Default: ``False``
+
+        Raises
+        ------
+        ValueError if the input an invalid number of samples.
         """
         if isinstance(inputs, GraphState):
-            if self.num_samples != inputs.num_samples:
+            if self.num_samples != inputs.num_samples and inputs.num_samples != 1:
                 raise ValueError("GraphSates must have the same number of samples.")
             new_states = inputs.states
         else:
             new_states = inputs
 
-        # Set the values one by one.
+        # Set the values one by one. The set function takes care of expanding
+        # any values that are constants (e.g. float or int) to match the correct
+        # number of samples.
         for node_name, node_vars in new_states.items():
             for var_name, value in node_vars.items():
                 self.set(node_name, var_name, value, force_copy=force_copy)

--- a/tests/tdastro/test_graph_state.py
+++ b/tests/tdastro/test_graph_state.py
@@ -165,6 +165,45 @@ def test_graph_state_update():
         state.update(state4)
 
 
+def test_graph_state_update_multi():
+    """Test that we can update a single sample GraphState."""
+    state = GraphState(num_samples=3)
+    state.set("a", "v1", [1.0, 2.0, 3.0])
+    state.set("a", "v2", [3.0, 4.0, 5.0])
+    state.set("b", "v1", [6.0, 7.0, 8.0])
+
+    state2 = GraphState(num_samples=3)
+    state2.set("a", "v1", [9.0, 10.0, 11.0])
+    state2.set("c", "v1", [12.0, 13.0, 14.0])
+
+    assert len(state) == 3
+    assert len(state2) == 2
+
+    # We set one new parameter and overwrite one.
+    state.update(state2)
+    assert len(state) == 4
+    assert np.allclose(state["a"]["v1"], [9.0, 10.0, 11.0])
+    assert np.allclose(state["a"]["v2"], [3.0, 4.0, 5.0])
+    assert np.allclose(state["b"]["v1"], [6.0, 7.0, 8.0])
+    assert np.allclose(state["c"]["v1"], [12.0, 13.0, 14.0])
+
+    # If we add a parameter with sample_size = 1, we correctly expand it out.
+    state3 = {"a": {"v2": 15.0}, "d": {"v1": 16.0}}
+    state.update(state3)
+    assert len(state) == 5
+    assert np.allclose(state["a"]["v1"], [9.0, 10.0, 11.0])
+    assert np.allclose(state["a"]["v2"], [15.0, 15.0, 15.0])
+    assert np.allclose(state["b"]["v1"], [6.0, 7.0, 8.0])
+    assert np.allclose(state["c"]["v1"], [12.0, 13.0, 14.0])
+    assert np.allclose(state["d"]["v1"], [16.0, 16.0, 16.0])
+
+    # Test we cannot update with mismatched number of samples.
+    state4 = GraphState(num_samples=2)
+    state4.set("e", "v1", 1.0)
+    with pytest.raises(ValueError):
+        state.update(state4)
+
+
 def test_transpose_dict_of_list():
     """Test the transpose_dict_of_list helper function"""
     input_dict = {

--- a/tests/tdastro/test_graph_state.py
+++ b/tests/tdastro/test_graph_state.py
@@ -119,6 +119,27 @@ def test_create_multi_sample_graph_state_reference():
     assert np.allclose(state2["b"]["v1"], [2.0, 2.5, 3.0, 3.5, 4.0])
 
 
+def test_graph_state_fixed():
+    """Test that we respected the 'fixed' flag for GraphState."""
+    state = GraphState()
+    assert len(state) == 0
+    state.set("a", "v1", 1.0)
+    state.set("a", "v2", 2.0)
+    state.set("b", "v1", 3.0, fixed=True)
+    assert len(state) == 3
+    assert state["a"]["v1"] == 1.0
+    assert state["a"]["v2"] == 2.0
+    assert state["b"]["v1"] == 3.0
+
+    # Try changing each of the states. Only two should actually change.
+    state.set("a", "v1", 4.0)
+    state.set("a", "v2", 5.0)
+    state.set("b", "v1", 6.0)
+    assert state["a"]["v1"] == 4.0
+    assert state["a"]["v2"] == 5.0
+    assert state["b"]["v1"] == 3.0
+
+
 def test_graph_state_update():
     """Test that we can update a single sample GraphState."""
     state = GraphState()

--- a/tests/tdastro/test_graph_state.py
+++ b/tests/tdastro/test_graph_state.py
@@ -117,3 +117,49 @@ def test_create_multi_sample_graph_state_reference():
     state2["a"]["v2"][2] = 5.0
     assert np.allclose(state2["a"]["v2"], [2.0, 2.5, 5.0, 3.5, 4.0])
     assert np.allclose(state2["b"]["v1"], [2.0, 2.5, 3.0, 3.5, 4.0])
+
+
+def test_graph_state_update():
+    """Test that we can update a single sample GraphState."""
+    state = GraphState()
+    state.set("a", "v1", 1.0)
+    state.set("a", "v2", 2.0)
+    state.set("b", "v1", 3.0)
+
+    state2 = GraphState()
+    state2.set("a", "v1", 4.0)
+    state2.set("a", "v3", 5.0)
+    state2.set("c", "v1", 6.0)
+    state2.set("c", "v2", 7.0)
+
+    assert len(state) == 3
+    assert len(state2) == 4
+
+    # We set 3 new parameters and overwrite one.
+    state.update(state2)
+    assert len(state) == 6
+    assert state["a"]["v1"] == 4.0
+    assert state["a"]["v2"] == 2.0
+    assert state["a"]["v3"] == 5.0
+    assert state["b"]["v1"] == 3.0
+    assert state["c"]["v1"] == 6.0
+    assert state["c"]["v2"] == 7.0
+
+    # We set 3 new parameters and overwrite one.
+    state3 = {"a": {"v2": 8.0, "v4": 9.0}, "d": {"v1": 10.0}}
+    state.update(state3)
+    assert len(state) == 8
+    assert state["a"]["v1"] == 4.0
+    assert state["a"]["v2"] == 8.0
+    assert state["a"]["v3"] == 5.0
+    assert state["a"]["v4"] == 9.0
+    assert state["b"]["v1"] == 3.0
+    assert state["c"]["v1"] == 6.0
+    assert state["c"]["v2"] == 7.0
+    assert state["d"]["v1"] == 10.0
+
+    # Test we cannot update with mismatched number of samples.
+    state4 = GraphState(num_samples=2)
+    state4.set("e", "v1", 1.0)
+    with pytest.raises(ValueError):
+        state.update(state4)


### PR DESCRIPTION
This PR adds some helper functions that will be used in future functionality:
1) Set values in a `GraphState` from a dictionary or another `GraphState`
2) Allow the `GraphState` to fix some values (needed for JAX gradients).