### PR TITLE
Fixes for various issues trying to set up first time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -148,3 +148,6 @@ _html/
 
 # Project initialization script
 .initialize_new_project.sh
+
+# Default cached location for passband tables
+src/tdastro/astro_utils/passbands/*

--- a/docs/notebooks/test_snia.ipynb
+++ b/docs/notebooks/test_snia.ipynb
@@ -19,8 +19,12 @@
    "outputs": [],
    "source": [
     "import sys\n",
+    "from pathlib import Path\n",
+    "import tdastro\n",
     "\n",
-    "sys.path.append(\"/Users/mi/Work/tdastro/tdastro/tests/tdastro/sources/\")"
+    "sys.path.append(\n",
+    "    str((Path(tdastro.__file__).parent / \"..\" / \"..\" / \"tests\" / \"tdastro\" / \"sources\").resolve())\n",
+    ")"
    ]
   },
   {
@@ -254,9 +258,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:tdastro]",
+   "display_name": "tdastro",
    "language": "python",
-   "name": "conda-env-tdastro-py"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -268,7 +272,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.9"
+   "version": "3.10.14"
   }
  },
  "nbformat": 4,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dev = [
     "pytest",
     "pytest-cov", # Used to report total code coverage
     "ruff", # Used for static linting of files
+    "matplotlib", # Used in example notebooks
 ]
 
 [build-system]

--- a/src/tdastro/astro_utils/passbands.py
+++ b/src/tdastro/astro_utils/passbands.py
@@ -1,7 +1,10 @@
 import logging
 import os
 import socket
+import urllib.parse
 import urllib.request
+from pathlib import Path
+from typing import Literal, Optional
 from urllib.error import HTTPError, URLError
 
 import numpy as np
@@ -115,14 +118,42 @@ class Passband:
         A 2D array of wavelengths and normalized transmissions.
     """
 
-    def __init__(self, survey, label, table_path=None, table_url=None):
+    def __init__(
+        self,
+        survey: str,
+        label: str,
+        table_path: Optional[str] = None,
+        table_url: Optional[str] = None,
+        units: Optional[Literal["nm", "A"]] = "A",
+    ):
+        """Construct a Passband object
+
+        Parameters
+        ----------
+        survey : str
+            Which survey does this passband correspond to. Often "LSST"
+        label : str
+            Which label does this passband correspond to, Sometimes a filter name like "g"
+        table_path : Optional[str], optional
+            Path to the table defining the passband on the filesystem. Will take precedence over table_url
+        table_url : Optional[str], optional
+            URL to download the table from.
+        units : Optional[Literal[&#39;nm&#39;,&#39;A&#39;]], optional
+            Denotes whether the wavelength units of the table are nanometers ('nm') or Angstroms ('A').
+            By default 'A'. Does not affect the output units of the class, only the interpretation of the
+            provided passband table.
+        """
         self.label = label
         self.survey = survey
         self.full_name = f"{survey}_{label}"
-        self.transmission_table = self._load_transmission_table(table_path=table_path, table_url=table_url)
+        self.transmission_table = self._load_transmission_table(
+            table_path=table_path, table_url=table_url, units=units
+        )
         self.normalized_transmission_table = self._normalize_transmission_table()
 
-    def _load_transmission_table(self, table_path=None, table_url=None) -> np.ndarray:
+    def _load_transmission_table(
+        self, table_path=None, table_url=None, units: Optional[Literal["nm", "A"]] = "A"
+    ) -> np.ndarray:
         """Load a transmission table from a file or URL.
 
         Parameters
@@ -131,7 +162,13 @@ class Passband:
             The path to the transmission table file. If None, a passbands directory will be created in the
             current directory.
         table_url : str, optional
-            The URL to download the transmission table file, if it does not exist locally.
+            The URL to download the transmission table file, if it does not exist locally. If None, the URL
+            will be constructed based on the survey and label. This is only available for the LSST survey at
+            the moment.
+        units : Optional[Literal[&#39;nm&#39;,&#39;A&#39;]], optional
+            Denotes whether the wavelength units of the table are nanometers ('nm') or Angstroms ('A').
+            By default 'A'. Does not affect the output units of the class, only the interpretation of the
+            provided passband table.
 
         Returns
         -------
@@ -140,43 +177,57 @@ class Passband:
             values.
         """
         if table_path is None:
-            table_path = os.path.join(os.path.dirname(__file__), f"passbands/{self.survey}/{self.label}.dat")
-            os.makedirs(os.path.dirname(table_path), exist_ok=True)
-        if not os.path.exists(table_path):
-            self._download_transmission_table(table_path, table_url)
-        return np.loadtxt(table_path)
+            if table_url is None:
+                if self.survey == "LSST":
+                    # TODO: This area will be changed with incoming Pooch data manager PR :)
+                    # Consider: https://raw.githubusercontent.com/lsst/throughputs/e70d1daf069e606caa3feb43eccc62ec21e0baf5/baseline/total_g.dat
+                    table_url = (
+                        f"http://svo2.cab.inta-csic.es/svo/theory/fps3/getdata.php"
+                        f"?format=ascii&id=LSST/LSST.{self.label}"
+                    )
+                else:
+                    raise NotImplementedError(
+                        f"Transmission table download is not yet implemented for survey: {self.survey}."
+                        "Please provide a table URL."
+                    )
 
-    def _download_transmission_table(self, table_path, table_url=None) -> bool:
+            table_cache_dir = Path(__file__).parent / "passbands" / self.survey
+            table_cache_dir.mkdir(exist_ok=True, parents=True)
+
+            # Cache using the URL provided so when the URL changes we re-download
+            # Primarily useful for local development
+            table_cache_filename = f"{urllib.parse.quote_plus(table_url)}_{self.label}.dat"
+            table_path = table_cache_dir / table_cache_filename
+
+        if not table_path.exists():
+            self._download_transmission_table(table_path, table_url)
+
+        np_table = np.loadtxt(table_path)
+        if units == "nm":
+            np_table[:, 0] *= 10.0  # Multiply the first column (wavelength) by 10.0 to convert to Angstroms
+
+        # Ensure the table is sorted by wavelength, which is the first column. Most data files do this
+        # anyway, but we depend on a descending order in fluxes_to_bandpass()
+        return np_table[np_table[:, 0].argsort()]
+
+    def _download_transmission_table(self, table_path: Path, table_url: str) -> bool:
         """Download a transmission table from a URL.
 
         Parameters
         ----------
         table_path : str
             The path to save the downloaded transmission table.
-        table_url : str, optional
-            The URL to download the transmission table file. If None, the URL will be constructed based on
-            the survey and label. This is only available for the LSST survey at the moment.
+        table_url : str
+            The URL to download the transmission table file.
 
         Returns
         -------
         bool
             True if the download was successful, False otherwise.
         """
-        if table_url is None:
-            if self.survey == "LSST":
-                # TODO: This area will be changed with incoming Pooch data manager PR :)
-                # Consider: https://github.com/lsst/throughputs/blob/main/baseline/total_g.dat
-                table_url = (
-                    f"http://svo2.cab.inta-csic.es/svo/theory/fps3/getdata.php"
-                    f"?format=ascii&id=LSST/LSST.{self.label}"
-                )
-            else:
-                raise NotImplementedError(
-                    f"Transmission table download is not yet implemented for survey: {self.survey}."
-                    "Please provide a table URL."
-                )
         try:
             socket.setdefaulttimeout(10)
+            print(f"Retrieving {table_url}", flush=True)
             urllib.request.urlretrieve(table_url, table_path)
             if os.path.getsize(table_path) == 0:
                 logging.error(f"Transmission table downloaded for {self.full_name} is empty.")
@@ -244,8 +295,8 @@ class Passband:
         # For now, min exterpolation check: the bounds of the flux density grid are within the transmission
         # table bounds
         if (
-            wavelengths_angstrom[-1] < self.normalized_transmission_table[-1, 0]
-            or wavelengths_angstrom[0] > self.normalized_transmission_table[0, 0]
+            wavelengths_angstrom[-1] > self.normalized_transmission_table[-1, 0]
+            or wavelengths_angstrom[0] < self.normalized_transmission_table[0, 0]
         ):
             raise ValueError(
                 f"Extrapolation needed: flux density interval [{wavelengths_angstrom[0]}, "
@@ -256,7 +307,20 @@ class Passband:
         # Get only the flux densities that are within the passband's wavelength range
         passband_wavelengths = self.normalized_transmission_table[:, 0]
         passband_wavelengths_indices = np.searchsorted(wavelengths_angstrom, passband_wavelengths)
-        passband_flux_density_matrix = flux_density_matrix[:, passband_wavelengths_indices]
+
+        # Since the passband wavelength table should (for the moment) always cover a wider range than the
+        # wavelengths we are sampling, we will always find some passband wavelengths that index past the
+        # end of of the wavelengths array. We truncate these past-the-end indiies and then pad the resulting
+        # flux array out to the size of our passband table
+        trunc_condition = passband_wavelengths_indices < len(wavelengths_angstrom)
+        passband_wavelengths_indices_trunc = np.extract(trunc_condition, passband_wavelengths_indices)
+        values_truncated = len(passband_wavelengths_indices) - len(passband_wavelengths_indices_trunc)
+
+        # Create and pad flux density array
+        passband_flux_density_matrix = flux_density_matrix[:, passband_wavelengths_indices_trunc]
+        passband_flux_density_matrix = np.pad(
+            passband_flux_density_matrix, [(0, 0), (0, values_truncated)], "constant", constant_values=0.0
+        )
 
         # Calculate the bandflux as ∫ f(λ)φ_b(λ) dλ,
         # where f(λ) is the in-band flux density and φ_b(λ) is the normalized system response

--- a/src/tdastro/astro_utils/passbands.py
+++ b/src/tdastro/astro_utils/passbands.py
@@ -134,11 +134,11 @@ class Passband:
             Which survey does this passband correspond to. Often "LSST"
         label : str
             Which label does this passband correspond to, Sometimes a filter name like "g"
-        table_path : Optional[str], optional
+        table_path : str, optional
             Path to the table defining the passband on the filesystem. Will take precedence over table_url
-        table_url : Optional[str], optional
+        table_url : str, optional
             URL to download the table from.
-        units : Optional[Literal[&#39;nm&#39;,&#39;A&#39;]], optional
+        units : Literal['nm','A'], optional
             Denotes whether the wavelength units of the table are nanometers ('nm') or Angstroms ('A').
             By default 'A'. Does not affect the output units of the class, only the interpretation of the
             provided passband table.
@@ -165,7 +165,7 @@ class Passband:
             The URL to download the transmission table file, if it does not exist locally. If None, the URL
             will be constructed based on the survey and label. This is only available for the LSST survey at
             the moment.
-        units : Optional[Literal[&#39;nm&#39;,&#39;A&#39;]], optional
+        units : Literal['nm','A'], optional
             Denotes whether the wavelength units of the table are nanometers ('nm') or Angstroms ('A').
             By default 'A'. Does not affect the output units of the class, only the interpretation of the
             provided passband table.
@@ -207,7 +207,7 @@ class Passband:
             np_table[:, 0] *= 10.0  # Multiply the first column (wavelength) by 10.0 to convert to Angstroms
 
         # Ensure the table is sorted by wavelength, which is the first column. Most data files do this
-        # anyway, but we depend on a descending order in fluxes_to_bandpass()
+        # anyway, but we depend on an ascending order in fluxes_to_bandpass()
         return np_table[np_table[:, 0].argsort()]
 
     def _download_transmission_table(self, table_path: Path, table_url: str) -> bool:
@@ -227,7 +227,7 @@ class Passband:
         """
         try:
             socket.setdefaulttimeout(10)
-            print(f"Retrieving {table_url}", flush=True)
+            logging.info(f"Retrieving {table_url}", flush=True)
             urllib.request.urlretrieve(table_url, table_path)
             if os.path.getsize(table_path) == 0:
                 logging.error(f"Transmission table downloaded for {self.full_name} is empty.")
@@ -310,7 +310,7 @@ class Passband:
 
         # Since the passband wavelength table should (for the moment) always cover a wider range than the
         # wavelengths we are sampling, we will always find some passband wavelengths that index past the
-        # end of of the wavelengths array. We truncate these past-the-end indiies and then pad the resulting
+        # end of of the wavelengths array. We truncate these past-the-end indices and then pad the resulting
         # flux array out to the size of our passband table
         trunc_condition = passband_wavelengths_indices < len(wavelengths_angstrom)
         passband_wavelengths_indices_trunc = np.extract(trunc_condition, passband_wavelengths_indices)

--- a/tests/tdastro/sources/test_snia.py
+++ b/tests/tdastro/sources/test_snia.py
@@ -127,14 +127,11 @@ def test_snia_end2end(
 
     source.add_effect(Redshift(redshift=source.redshift, t0=source.t0))
 
+    url_base = "https://raw.githubusercontent.com/lsst/throughputs/e70d1daf069e606caa3feb43eccc62ec21e0baf5/"
     passbands = PassbandGroup(
         passbands=[
-            Passband(
-                "LSST", "g", table_url="https://github.com/lsst/throughputs/blob/main/baseline/total_g.dat"
-            ),
-            Passband(
-                "LSST", "r", table_url="https://github.com/lsst/throughputs/blob/main/baseline/total_r.dat"
-            ),
+            Passband("LSST", "g", table_url=f"{url_base}baseline/total_g.dat", units="nm"),
+            Passband("LSST", "r", table_url=f"{url_base}baseline/total_r.dat", units="nm"),
         ]
     )
 


### PR DESCRIPTION
- Fixed passband caching system to use URL in filename, to avoid unwittingly using wrong locally cached files.
- Added passband file cache to .gitignore so `git status` doesn't report untracked files.
- Changed path in example ipynb to be relative to tdastro module path rather than hardcoded
- Fixed passbands.py to accept the LSST files from LSST github,
   - passbands.py now accepts a unit parameter for angstrom vs nm so LSST github files can be configured to work, as well as legacy files from svo2.cab.inta-csic.es
   - Fixed wavelength overlap condition and fluxes_to_bandflux() calculation so that longer passband tables from github work.


