### PR TITLE
Increate the flexibility of the OpSim Table.

### DIFF
--- a/src/tdastro/astro_utils/opsim.py
+++ b/src/tdastro/astro_utils/opsim.py
@@ -357,3 +357,23 @@ class OpSim:  # noqa: D101
             readout_noise=self.read_noise,
             dark_current=self.dark_current,
         )
+
+
+def opsim_add_random_data(opsim_data, colname, min_val=0.0, max_val=1.0):
+    """Add a column composed of random uniform data. Used for testing.
+
+    Parameters
+    ----------
+    opsim_data : OpSim
+        The OpSim data structure to modify.
+    colname : `str`
+        The name of the new column to add.
+    min_val : `float`
+        The minimum value of the uniform range.
+        Default: 0.0
+    max_val : `float`
+        The maximum value of the uniform range.
+        Default: 1.0
+    """
+    values = np.random.uniform(low=min_val, high=max_val, size=len(opsim_data))
+    opsim_data.add_column(colname, values)

--- a/src/tdastro/astro_utils/opsim.py
+++ b/src/tdastro/astro_utils/opsim.py
@@ -1,5 +1,6 @@
 from __future__ import annotations  # "type1 | type2" syntax in Python <3.10
 
+import logging
 import sqlite3
 from pathlib import Path
 
@@ -17,11 +18,13 @@ from tdastro.astro_utils.zeropoint import (
 from tdastro.consts import GAUSS_EFF_AREA2FWHM_SQ
 
 _rubin_opsim_colnames = {
-    "time": "observationStartMJD",
-    "ra": "fieldRA",
+    "airmass": "airmass",
     "dec": "fieldDec",
-    "zp": "zp_nJy",  # We add this column to the table
+    "exptime": "visitExposureTime",
     "filter": "filter",
+    "ra": "fieldRA",
+    "time": "observationStartMJD",
+    "zp": "zp_nJy",  # We add this column to the table
 }
 """Default mapping of short column names to Rubin OpSim column names."""
 
@@ -128,8 +131,16 @@ class OpSim:  # noqa: D101
         self._kd_tree = None
         self._build_kd_tree()
 
-        if self.colmap["zp"] not in self.table.columns:
-            self._assign_zero_points(col_name=self.colmap["zp"], ext_coeff=ext_coeff, zp_per_sec=zp_per_sec)
+        # If we are not given zero point data, try to derive it from the other columns.
+        if not self.has_columns("zp"):
+            if self.has_columns(["filter", "airmass", "exptime"]):
+                self.add_zero_points(ext_coeff=ext_coeff, zp_per_sec=zp_per_sec)
+            else:
+                logging.getLogger(__name__).warning(
+                    "Missing both zero point data and columns needed to compute it. "
+                    "Setting a default of 1.0."
+                )
+                self.add_column(self.colmap["zp"], 1.0)
 
     def __len__(self):
         return len(self.table)
@@ -142,6 +153,25 @@ class OpSim:  # noqa: D101
     def columns(self):
         """Get the column names."""
         return self.table.columns
+
+    def has_columns(self, columns):
+        """Checks whether OpSim has a column or columns while accounting
+        for the colmap.
+
+        Parameters
+        ----------
+        columns : `str` or iterable
+            The column name or column names to check.
+
+        Returns
+        -------
+        `bool`
+            True if and only if all the columns are contained in the table.
+        """
+        if isinstance(columns, str):
+            return self.colmap.get(columns, columns) in self.table.columns
+
+        return all(self.colmap.get(col, col) in self.table.columns for col in columns)
 
     def _build_kd_tree(self):
         """Construct the KD-tree from the opsim table."""
@@ -156,17 +186,36 @@ class OpSim:  # noqa: D101
         # Construct the kd-tree.
         self._kd_tree = KDTree(cart_coords)
 
-    def _assign_zero_points(
-        self, col_name: str, *, ext_coeff: dict[str, float] | None, zp_per_sec: dict[str, float] | None
-    ):
-        """Assign instrumental zero points in nJy to the OpSim tables"""
-        self.table[col_name] = flux_electron_zeropoint(
+    def add_zero_points(self, *, ext_coeff: dict[str, float] | None, zp_per_sec: dict[str, float] | None):
+        """Assign instrumental zero points in nJy to the OpSim tables.
+
+        Parameters
+        ----------
+        ext_coeff : dict[str, float], optional
+            Atmospheric extinction coefficient for each bandpass.
+            Keys are the bandpass names, values are the coefficients.
+            If None, the LSST coefficients are used.
+        zp_per_sec : dict[str, float], optional
+             The instrumental zeropoint for each bandpass in AB magnitudes,
+             i.e. the magnitude that produces 1 electron in a 1-second exposure.
+             Keys are the bandpass names, values are the zeropoints.
+             If None, the LSST zeropoints are used.
+        """
+        req_cols = ["filter", "airmass", "exptime"]
+        if not self.has_columns(req_cols):
+            raise ValueError(
+                "Missing columns needed to compute zero point. "
+                f"OpSim must contain the following columns: {req_cols}"
+            )
+
+        zp_values = flux_electron_zeropoint(
             ext_coeff=ext_coeff,
             instr_zp_mag=zp_per_sec,
             band=self.table[self.colmap.get("filter", "filter")],
             airmass=self.table[self.colmap.get("airmass", "airmass")],
             exptime=self.table[self.colmap.get("exptime", "visitExposureTime")],
         )
+        self.add_column(self.colmap.get("zp", "zp"), zp_values, overwrite=True)
 
     @classmethod
     def from_db(cls, filename, sql_query="SELECT * FROM observations", colmap=_rubin_opsim_colnames):
@@ -221,6 +270,7 @@ class OpSim:  # noqa: D101
             Overwrite the column is it already exists.
             Default: False
         """
+        colname = self.colmap.get(colname, colname)
         if colname in self.table.columns and not overwrite:
             raise KeyError(f"Column {colname} already exists.")
 

--- a/src/tdastro/astro_utils/opsim.py
+++ b/src/tdastro/astro_utils/opsim.py
@@ -21,6 +21,7 @@ _rubin_opsim_colnames = {
     "ra": "fieldRA",
     "dec": "fieldDec",
     "zp": "zp_nJy",  # We add this column to the table
+    "filter": "filter",
 }
 """Default mapping of short column names to Rubin OpSim column names."""
 
@@ -77,7 +78,7 @@ class OpSim:  # noqa: D101
 
     Attributes
     ----------
-    table : `dict` or `pandas.core.frame.DataFrame`
+    table : `pandas.core.frame.DataFrame`
         The table with all the OpSim information.
     colmap : `dict`
         A mapping of short column names to their names in the underlying table.
@@ -136,6 +137,11 @@ class OpSim:  # noqa: D101
     def __getitem__(self, key):
         """Access the underlying opsim table."""
         return self.table[key]
+
+    @property
+    def columns(self):
+        """Get the column names."""
+        return self.table.columns
 
     def _build_kd_tree(self):
         """Construct the KD-tree from the opsim table."""
@@ -201,6 +207,27 @@ class OpSim:  # noqa: D101
         con.close()
 
         return OpSim(opsim, colmap=colmap)
+
+    def add_column(self, colname, values, overwrite=False):
+        """Add a column to the current opsim table.
+
+        Parameters
+        ----------
+        colname : `str`
+            The name of the new column.
+        values : `int`, `float`, `str`, `list`, or `numpy.ndarray`
+            The value(s) to add.
+        overwrite : `bool`
+            Overwrite the column is it already exists.
+            Default: False
+        """
+        if colname in self.table.columns and not overwrite:
+            raise KeyError(f"Column {colname} already exists.")
+
+        # If the input is a scalar, turn it into an array of the correct length
+        if np.isscalar(values):
+            values = np.full((len(self.table)), values)
+        self.table[colname] = values
 
     def write_opsim_table(self, filename, tablename="observations", overwrite=False):
         """Write out an opsim database to a given SQL table.

--- a/tests/tdastro/astro_utils/test_opsim.py
+++ b/tests/tdastro/astro_utils/test_opsim.py
@@ -1,4 +1,3 @@
-import logging
 import os
 import tempfile
 from pathlib import Path
@@ -239,37 +238,6 @@ def test_read_opsim_shorten(opsim_shorten):
     """Read in a shorten OpSim file from the testing data directory."""
     ops_data = OpSim.from_db(opsim_shorten)
     assert len(ops_data) == 100
-
-
-def test_add_zero_points():
-    """Test that we can compute and add the zero points."""
-
-    # Create a fake opsim data frame with just time, RA, and dec.
-    values = {
-        "observationStartMJD": np.array([0.0, 1.0, 2.0]),
-        "fieldRA": np.array([15.0, 15.01, 15.0]),
-        "fieldDec": np.array([-10.0, 10.0, 0.0]),
-    }
-
-    # Turn off the warning that happens when we create an OpSim with no zero points.
-    org_level = logging.getLogger().getEffectiveLevel()
-    logging.disable(logging.CRITICAL)
-    ops_data = OpSim(values)
-    logging.disable(org_level)
-
-    # The default zp (if nothing is provided is all 1.0)
-    assert ops_data.has_columns("zp_nJy")
-    assert np.allclose(ops_data["zp_nJy"], [1.0, 1.0, 1.0])
-
-    # Add the columns we need and compute the zero points.
-    ops_data.add_column("filter", "r")
-    ops_data.add_column("airmass", 1.379607)
-    ops_data.add_column("exptime", 29.2)
-    ops_data.add_zero_points(ext_coeff=None, zp_per_sec=None)
-
-    # TODO: Add a test that actually checks the accuracy of the computed zero points.
-    assert ops_data.has_columns("zp_nJy")
-    assert np.all(ops_data["zp_nJy"] < 1.0)
 
 
 def test_opsim_flux_err_point_source(opsim_shorten):


### PR DESCRIPTION
Make `OpSim` easier to use for testing:

- Provide a more meaningful error if zero points are not provided.
- Add the helper method `has_columns()` that wraps the column name map.
- Add a function to add columns with column name map support.
- Add the function `opsim_add_random_data()` to create a new column filled with random data (for testing).