### PR TITLE
Provide ability to set whether we compute gradients at parameters

### DIFF
--- a/src/tdastro/astro_utils/passbands.py
+++ b/src/tdastro/astro_utils/passbands.py
@@ -279,9 +279,9 @@ class Passband:
 
         # Correct for units
         if self.units == "nm":
-            loaded_table[
-                :, 0
-            ] *= 10.0  # Multiply the first column (wavelength) by 10.0 to convert to Angstroms
+            loaded_table[:, 0] *= (
+                10.0  # Multiply the first column (wavelength) by 10.0 to convert to Angstroms
+            )
 
         self._loaded_table = loaded_table
 

--- a/src/tdastro/astro_utils/passbands.py
+++ b/src/tdastro/astro_utils/passbands.py
@@ -279,9 +279,8 @@ class Passband:
 
         # Correct for units
         if self.units == "nm":
-            loaded_table[:, 0] *= (
-                10.0  # Multiply the first column (wavelength) by 10.0 to convert to Angstroms
-            )
+            # Multiply the first column (wavelength) by 10.0 to convert to Angstroms
+            loaded_table[:, 0] *= 10.0
 
         self._loaded_table = loaded_table
 

--- a/src/tdastro/base_models.py
+++ b/src/tdastro/base_models.py
@@ -73,11 +73,8 @@ class ParameterSource:
         or the attribute name of a dependency node.
     dependency : `ParameterizedNode` or None
         The node on which this parameter is dependent
-    fixed : `bool`
-        The attribute cannot be changed during resampling.
-        Default = ``False``
-    required : `bool`
-        The attribute must exist and be non-None.
+    allow_gradient : `bool`
+        Allow gradients to be computed at this variable.
         Default = ``False``
     """
 
@@ -88,27 +85,30 @@ class ParameterSource:
     FUNCTION_NODE = 3
     COMPUTE_OUTPUT = 4
 
-    def __init__(self, parameter_name, source_type=0, fixed=False, required=False, node_name=""):
+    def __init__(self, parameter_name, source_type=0, node_name=""):
         self.parameter_name = parameter_name
         self.node_name = node_name
         self.source_type = source_type
-        self.fixed = fixed
-        self.required = required
+        self.allow_gradient = False
         self.value = None
         self.dependency = None
 
-    def set_as_constant(self, value):
+    def set_as_constant(self, value, allow_gradient=True):
         """Set the parameter as a constant value.
 
         Parameters
         ----------
         value : any
             The constant value to use.
+        allow_gradient : bool
+            Allow a gradient to be computed at this variable.
+            Default = ``True``
         """
         if callable(value):
             raise ValueError(f"Using set_as_constant on callable {value}")
 
         self.source_type = ParameterSource.CONSTANT
+        self.allow_gradient = allow_gradient
         self.dependency = None
         self.value = value
 
@@ -123,6 +123,7 @@ class ParameterSource:
             The name of the parameter to access.
         """
         self.source_type = ParameterSource.MODEL_PARAMETER
+        self.allow_gradient = False
         self.dependency = dependency
         self.value = param_name
 
@@ -137,6 +138,7 @@ class ParameterSource:
             The name of where the result is stored in the FunctionNode.
         """
         self.source_type = ParameterSource.FUNCTION_NODE
+        self.allow_gradient = False
         self.dependency = dependency
         self.value = param_name
 
@@ -151,6 +153,7 @@ class ParameterSource:
             The name of where the result is stored in the FunctionNode.
         """
         self.source_type = ParameterSource.COMPUTE_OUTPUT
+        self.allow_gradient = False
         self.value = param_name
 
 
@@ -325,7 +328,6 @@ class ParameterizedNode:
         Raise a ``KeyError`` if there is a parameter collision or the parameter
         cannot be found.
         Raise a ``ValueError`` if the setter type is not supported.
-        Raise a ``ValueError`` if the parameter is required, but set to None.
         """
         # Set the node's position in the graph to None to indicate that the
         # structure might have changed. It needs to be updated with set_graph_positions().
@@ -371,8 +373,6 @@ class ParameterizedNode:
         else:
             # Case 4: The value is constant (including None).
             self.setters[name].set_as_constant(value)
-            if self.setters[name].required and value is None:
-                raise ValueError(f"Missing required parameter {name}")
 
         # Update the dependencies to account for any new nodes in the graph.
         self.direct_dependencies = {}
@@ -380,7 +380,19 @@ class ParameterizedNode:
             if setter_info.dependency is not None and setter_info.dependency is not self:
                 self.direct_dependencies[setter_info.dependency] = True
 
-    def add_parameter(self, name, value=None, required=False, fixed=False, **kwargs):
+    def set_allow_gradient(self, name, allow_gradient):
+        """Turn on or off the ability to compute a gradient for this variable.
+
+        Parameters
+        ----------
+        name : `str`
+            The parameter name to modify.
+        allow_gradient : `bool`
+            The new setting for allow_gradient.
+        """
+        self.setters[name].allow_gradient = allow_gradient
+
+    def add_parameter(self, name, value=None, allow_gradient=None, **kwargs):
         """Add a single *new* parameter to the ParameterizedNode.
 
         Notes
@@ -398,12 +410,10 @@ class ParameterizedNode:
         value : any, optional
             The information to use to set the parameter. Can be a constant,
             function, ParameterizedNode, or self.
-        required : `bool`
-            Fail if the parameter is set to ``None``.
-            Default = ``False``
-        fixed : `bool`
-            The attribute cannot be changed during resampling.
-            Default = ``False``
+        allow_gradient : `bool` or None
+            Allow gradients to be computed for this variable. If set to None uses the default
+            for the setter type (True for constant and False for everything else).
+            Default = None
         **kwargs : `dict`, optional
            All other keyword arguments, possibly including the parameter setters.
 
@@ -411,7 +421,6 @@ class ParameterizedNode:
         ------
         Raise a ``KeyError`` if there is a parameter collision or the parameter
         cannot be found.
-        Raise a ``ValueError`` if the parameter is required, but set to None.
         """
         # Check for parameter collision and add a place holder value.
         if hasattr(self, name) and name not in self.setters:
@@ -425,15 +434,13 @@ class ParameterizedNode:
         self.setters[name] = ParameterSource(
             parameter_name=name,
             source_type=ParameterSource.UNDEFINED,
-            fixed=fixed,
-            required=required,
             node_name=str(self),
         )
         self.set_parameter(name, value, **kwargs)
 
-        # Only constant sources can be fixed.
-        if fixed and self.setters[name].source_type != ParameterSource.CONSTANT:
-            raise ValueError(f"Tried to make {name} fixed but source_type={self.setters[name].source_type}.")
+        # Check if we should override allow_gradient.
+        if allow_gradient is not None:
+            self.setters[name].allow_gradient = allow_gradient
 
         # Create a callable getter function using. We override the __self__ and __name__
         # attributes so it looks like method of this object.
@@ -637,11 +644,12 @@ class ParameterizedNode:
         # Add new values to the pytree, recursively exploring dependencies.
         partial[self.node_string] = {}
         for name, setter_info in self.setters.items():
-            if setter_info.dependency is not None:
-                partial = setter_info.dependency.build_pytree(graph_state, partial)
-            elif setter_info.source_type == ParameterSource.CONSTANT and not setter_info.fixed:
-                # Only the non-fixed, constants go into the PyTree.
+            if setter_info.allow_gradient:
+                # Anything wth allow_gradient == True goes in the PyTree.
                 partial[self.node_string][name] = graph_state[self.node_string][name]
+            elif setter_info.dependency is not None:
+                # We only recursively check parameters above non-gradient nodes.
+                partial = setter_info.dependency.build_pytree(graph_state, partial)
         return partial
 
 
@@ -664,7 +672,7 @@ class SingleVariableNode(ParameterizedNode):
 
     def __init__(self, name, value, **kwargs):
         super().__init__(**kwargs)
-        self.add_parameter(name, value, required=True, **kwargs)
+        self.add_parameter(name, value, **kwargs)
 
 
 class FunctionNode(ParameterizedNode):

--- a/src/tdastro/effects/redshift.py
+++ b/src/tdastro/effects/redshift.py
@@ -30,8 +30,8 @@ class Redshift(EffectModel):
            Any additional keyword arguments.
         """
         super().__init__(**kwargs)
-        self.add_parameter("redshift", redshift, required=True, **kwargs)
-        self.add_parameter("t0", t0, required=True, **kwargs)
+        self.add_parameter("redshift", redshift, **kwargs)
+        self.add_parameter("t0", t0, **kwargs)
 
     def pre_effect(self, observer_frame_times, observer_frame_wavelengths, graph_state, **kwargs):
         """Calculate the rest-frame times and wavelengths needed to give us the observer-frame times

--- a/src/tdastro/effects/white_noise.py
+++ b/src/tdastro/effects/white_noise.py
@@ -20,7 +20,7 @@ class WhiteNoise(EffectModel):
     def __init__(self, scale, **kwargs):
         self._rng = np.random.default_rng()
         super().__init__(**kwargs)
-        self.add_parameter("scale", scale, required=True, **kwargs)
+        self.add_parameter("scale", scale, **kwargs)
 
     def _update_object_seed(self):
         """Update the object seed to the new value."""

--- a/src/tdastro/sources/galaxy_models.py
+++ b/src/tdastro/sources/galaxy_models.py
@@ -20,8 +20,8 @@ class GaussianGalaxy(PhysicalModel):
 
     def __init__(self, brightness, radius, **kwargs):
         super().__init__(**kwargs)
-        self.add_parameter("galaxy_radius_std", radius, required=True, **kwargs)
-        self.add_parameter("brightness", brightness, required=True, **kwargs)
+        self.add_parameter("galaxy_radius_std", radius, **kwargs)
+        self.add_parameter("brightness", brightness, **kwargs)
 
     def _evaluate(self, times, wavelengths, graph_state, ra=None, dec=None, **kwargs):
         """Draw effect-free observations for this object.

--- a/src/tdastro/sources/periodic_source.py
+++ b/src/tdastro/sources/periodic_source.py
@@ -19,8 +19,8 @@ class PeriodicSource(PhysicalModel, ABC):
 
     def __init__(self, period, t0, **kwargs):
         super().__init__(**kwargs)
-        self.add_parameter("period", period, required=True, **kwargs)
-        self.add_parameter("t0", t0, required=True, **kwargs)
+        self.add_parameter("period", period, **kwargs)
+        self.add_parameter("t0", t0, **kwargs)
 
     @abstractmethod
     def _evaluate_phases(self, phases, wavelengths, graph_state, **kwargs):

--- a/src/tdastro/sources/periodic_variable_star.py
+++ b/src/tdastro/sources/periodic_variable_star.py
@@ -105,12 +105,12 @@ class EclipsingBinaryStar(PeriodicVariableStar):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self.add_parameter("major_semiaxis", required=True, **kwargs)
-        self.add_parameter("inclination", required=True, **kwargs)
-        self.add_parameter("primary_radius", required=True, **kwargs)
-        self.add_parameter("secondary_radius", required=True, **kwargs)
-        self.add_parameter("primary_temperature", required=True, **kwargs)
-        self.add_parameter("secondary_temperature", required=True, **kwargs)
+        self.add_parameter("major_semiaxis", **kwargs)
+        self.add_parameter("inclination", **kwargs)
+        self.add_parameter("primary_radius", **kwargs)
+        self.add_parameter("secondary_radius", **kwargs)
+        self.add_parameter("primary_temperature", **kwargs)
+        self.add_parameter("secondary_temperature", **kwargs)
 
     def _dl_dnu_domega_phases(self, phases, wavelengths, graph_state, **kwargs):
         """Draw effect-free luminosity density for this object, as a function of phase.

--- a/src/tdastro/sources/physical_model.py
+++ b/src/tdastro/sources/physical_model.py
@@ -49,19 +49,19 @@ class PhysicalModel(ParameterizedNode):
         self.effects = []
 
         # Set RA, dec, and redshift from the parameters.
-        self.add_parameter("ra", ra)
-        self.add_parameter("dec", dec)
-        self.add_parameter("redshift", redshift)
+        self.add_parameter("ra", ra, allow_gradient=False)
+        self.add_parameter("dec", dec, allow_gradient=False)
+        self.add_parameter("redshift", redshift, allow_gradient=False)
 
         # If the luminosity distance is provided, use that. Otherwise try the
         # redshift value using the cosmology (if given). Finally, default to None.
         if distance is not None:
-            self.add_parameter("distance", distance)
+            self.add_parameter("distance", distance, allow_gradient=False)
         elif redshift is not None and kwargs.get("cosmology", None) is not None:
             self._redshift_func = RedshiftDistFunc(redshift=self.redshift, **kwargs)
-            self.add_parameter("distance", self._redshift_func)
+            self.add_parameter("distance", self._redshift_func, allow_gradient=False)
         else:
-            self.add_parameter("distance", None)
+            self.add_parameter("distance", None, allow_gradient=False)
 
         # Background is an object not a sampled parameter
         self.background = background

--- a/src/tdastro/sources/snia_host.py
+++ b/src/tdastro/sources/snia_host.py
@@ -8,4 +8,4 @@ class SNIaHost(PhysicalModel):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self.add_parameter("hostmass", required=True, **kwargs)
+        self.add_parameter("hostmass", **kwargs)

--- a/src/tdastro/sources/static_source.py
+++ b/src/tdastro/sources/static_source.py
@@ -16,7 +16,7 @@ class StaticSource(PhysicalModel):
 
     def __init__(self, brightness, **kwargs):
         super().__init__(**kwargs)
-        self.add_parameter("brightness", brightness, required=True, **kwargs)
+        self.add_parameter("brightness", brightness, **kwargs)
 
     def _evaluate(self, times, wavelengths, graph_state, **kwargs):
         """Draw effect-free observations for this object.

--- a/src/tdastro/sources/step_source.py
+++ b/src/tdastro/sources/step_source.py
@@ -20,8 +20,8 @@ class StepSource(StaticSource):
 
     def __init__(self, brightness, t0, t1, **kwargs):
         super().__init__(brightness, **kwargs)
-        self.add_parameter("t0", t0, required=True, **kwargs)
-        self.add_parameter("t1", t1, required=True, **kwargs)
+        self.add_parameter("t0", t0, **kwargs)
+        self.add_parameter("t1", t1, **kwargs)
 
     def _evaluate(self, times, wavelengths, graph_state, **kwargs):
         """Draw effect-free observations for this object.

--- a/tests/tdastro/sources/test_physical_models.py
+++ b/tests/tdastro/sources/test_physical_models.py
@@ -14,6 +14,10 @@ def test_physical_model():
     assert model1.get_param(state, "distance") == 3.0
     assert model1.get_param(state, "redshift") == 0.0
 
+    # None of the parameters are in the PyTree.
+    pytree = model1.build_pytree(state)
+    assert len(pytree["0:PhysicalModel"]) == 0
+
     # Derive the distance from the redshift.
     model2 = PhysicalModel(ra=1.0, dec=2.0, redshift=1100.0, cosmology=Planck18)
     state = model2.sample_parameters()

--- a/tests/tdastro/sources/test_static_source.py
+++ b/tests/tdastro/sources/test_static_source.py
@@ -41,6 +41,17 @@ def test_static_source() -> None:
     assert np.all(values == 5.0)
 
 
+def test_test_physical_model_pytree():
+    """Test tthat the PyTree only contains brightness."""
+    model = StaticSource(brightness=10.0, node_label="my_static_source")
+    state = model.sample_parameters()
+
+    pytree = model.build_pytree(state)
+    assert pytree["0:my_static_source"]["brightness"] == 10.0
+    assert len(pytree["0:my_static_source"]) == 1
+    assert len(pytree) == 1
+
+
 def test_static_source_host() -> None:
     """Test that we can sample and create a StaticSource object with properties
     derived from the host object."""


### PR DESCRIPTION
Allow us to set whether we compute a gradient for a given parameter in the PyTree. The default is `True` for all constant and `False` for everything else. But we can now do overrides.

Also removes the `required` and `fixed` fields from the setter info as these are not needed. The `fixed` setting has been replaced by `allow_gradient`. The `required` field is not needed because the program will still fail during sampling when required data is missing. Before it was only doing a check during graph construction on some of the input paths. This will make the behavior consistent across different paths.