### PR TITLE
Passband optimization: store wave indices in each Passband

### DIFF
--- a/src/tdastro/astro_utils/passbands.py
+++ b/src/tdastro/astro_utils/passbands.py
@@ -108,9 +108,11 @@ class PassbandGroup:
             self.waves = np.unique(np.concatenate([passband.waves for passband in self.passbands.values()]))
 
     def _calculate_in_band_wave_indices(self) -> None:
-        """Calculate the indices of the groupd's wave grid that are in the passband's wave grid.
+        """Calculate the indices of the group's wave grid that are in the passband's wave grid.
+        
+        Eg, if a group's waves are [11, 12, 13, 14, 15] and a single band's are [13, 14], we get [2, 3].
 
-        The indices are stored in the passband's in_band_wave_indices attribute as either a tuple of two ints
+        The indices are stored in the passband's _in_band_wave_indices attribute as either a tuple of two ints
         (lower, upper) or a 1D np.ndarray of ints.
         """
         for passband in self.passbands.values():
@@ -121,7 +123,7 @@ class PassbandGroup:
 
             # Check that this is the right grid after all (check will fail if passbands overlap and passbands
             # do not happen to be on the same phase of the grid; eg, even if the step is 10, if the first
-            # passband starts at 100 and the second at 105, the second passband will share the same grid)
+            # passband starts at 100 and the second at 105, the passbands won't share the same grid)
             if np.array_equal(self.waves[lower_index : upper_index + 1], passband.waves):
                 indices = (lower_index, upper_index + 1)
             else:
@@ -175,7 +177,7 @@ class PassbandGroup:
 
             if indices is None:
                 raise ValueError(
-                    f"Passband {full_name} does not have in_band_wave_indices set. "
+                    f"Passband {full_name} does not have _in_band_wave_indices set. "
                     "This should have been calculated in PassbandGroup._calculate_in_band_wave_indices."
                 )
 

--- a/src/tdastro/astro_utils/passbands.py
+++ b/src/tdastro/astro_utils/passbands.py
@@ -109,7 +109,7 @@ class PassbandGroup:
 
     def _calculate_in_band_wave_indices(self) -> None:
         """Calculate the indices of the group's wave grid that are in the passband's wave grid.
-        
+
         Eg, if a group's waves are [11, 12, 13, 14, 15] and a single band's are [13, 14], we get [2, 3].
 
         The indices are stored in the passband's _in_band_wave_indices attribute as either a tuple of two ints
@@ -127,7 +127,7 @@ class PassbandGroup:
             if np.array_equal(self.waves[lower_index : upper_index + 1], passband.waves):
                 indices = (lower_index, upper_index + 1)
             else:
-                indices = np.unique(np.searchsorted(self.waves, passband.waves))
+                indices = np.searchsorted(self.waves, passband.waves)
             passband._in_band_wave_indices = indices
 
     def process_transmission_tables(

--- a/src/tdastro/astro_utils/passbands.py
+++ b/src/tdastro/astro_utils/passbands.py
@@ -69,6 +69,7 @@ class PassbandGroup:
                 self.passbands[passband.full_name] = passband
 
         self._update_waves()
+        self._calculate_in_band_wave_indices()
 
     def __str__(self) -> str:
         """Return a string representation of the PassbandGroup."""
@@ -106,6 +107,27 @@ class PassbandGroup:
         else:
             self.waves = np.unique(np.concatenate([passband.waves for passband in self.passbands.values()]))
 
+    def _calculate_in_band_wave_indices(self) -> None:
+        """Calculate the indices of the groupd's wave grid that are in the passband's wave grid.
+
+        The indices are stored in the passband's in_band_wave_indices attribute as either a tuple of two ints
+        (lower, upper) or a 1D np.ndarray of ints.
+        """
+        for passband in self.passbands.values():
+            # We only want the fluxes that are in the passband's wavelength range
+            # So, find the indices in the group's wave grid that are in the passband's wave grid
+            lower, upper = passband.waves[0], passband.waves[-1]
+            lower_index, upper_index = np.searchsorted(self.waves, [lower, upper])
+
+            # Check that this is the right grid after all (check will fail if passbands overlap and passbands
+            # do not happen to be on the same phase of the grid; eg, even if the step is 10, if the first
+            # passband starts at 100 and the second at 105, the second passband will share the same grid)
+            if np.array_equal(self.waves[lower_index : upper_index + 1], passband.waves):
+                indices = (lower_index, upper_index + 1)
+            else:
+                indices = np.unique(np.searchsorted(self.waves, passband.waves))
+            passband._in_band_wave_indices = indices
+
     def process_transmission_tables(
         self, delta_wave: Optional[float] = 5.0, trim_quantile: Optional[float] = 1e-3
     ):
@@ -123,6 +145,7 @@ class PassbandGroup:
             passband.process_transmission_table(delta_wave, trim_quantile)
 
         self._update_waves()
+        self._calculate_in_band_wave_indices()
 
     def fluxes_to_bandfluxes(self, flux_density_matrix: np.ndarray) -> np.ndarray:
         """Calculate bandfluxes for all passbands in the group.
@@ -148,18 +171,17 @@ class PassbandGroup:
 
         bandfluxes = {}
         for full_name, passband in self.passbands.items():
-            # We only want the fluxes that are in the passband's wavelength range
-            # So, find the indices in the group's wave grid that are in the passband's wave grid
-            lower, upper = passband.waves[0], passband.waves[-1]
-            lower_index, upper_index = np.searchsorted(self.waves, [lower, upper])
-            # Check that this is the right grid after all (check will fail if the grid is not regular, or
-            # passbands are overlapping)
-            if np.array_equal(self.waves[lower_index : upper_index + 1], passband.waves):
-                in_band_fluxes = flux_density_matrix[:, lower_index : upper_index + 1]
+            indices = passband._in_band_wave_indices
+
+            if indices is None:
+                raise ValueError(
+                    f"Passband {full_name} does not have in_band_wave_indices set. "
+                    "This should have been calculated in PassbandGroup._calculate_in_band_wave_indices."
+                )
+
+            if isinstance(passband._in_band_wave_indices, tuple):
+                in_band_fluxes = flux_density_matrix[:, indices[0] : indices[1]]
             else:
-                indices = np.unique(np.searchsorted(passband.waves, self.waves))
-                if indices[-1] == len(passband.waves):
-                    indices = indices[:-1]
                 in_band_fluxes = flux_density_matrix[:, indices]
 
             bandfluxes[full_name] = passband.fluxes_to_bandflux(in_band_fluxes)
@@ -190,6 +212,9 @@ class Passband:
     processed_transmission_table : np.ndarray
         A 2D array where the first col is wavelengths (Angstrom) and the second col is transmission values.
         This table is both interpolated to the _wave_grid and normalized to calculate phi_b(λ).
+    _in_band_wave_indices : np.ndarray, optional
+        The indices of the full wave grid used in PassbandGroup that correspond to this Passband's wave grid.
+        This is only set when the Passband is part of a PassbandGroup.
     """
 
     def __init__(
@@ -240,6 +265,7 @@ class Passband:
         self.table_path = table_path
         self.table_url = table_url
         self.units = units
+        self._in_band_wave_indices = None
 
         self._load_transmission_table(force_download=force_download)
         self.process_transmission_table(delta_wave, trim_quantile)

--- a/tests/tdastro/astro_utils/test_passband_groups.py
+++ b/tests/tdastro/astro_utils/test_passband_groups.py
@@ -100,6 +100,30 @@ def test_passband_group_str(tmp_path):
     assert str(test_passband_group) == "PassbandGroup containing 3 passbands: TEST_a, TEST_b, TEST_c"
 
 
+def test_passband_group_calculate_in_band_wave_indices(tmp_path):
+    """Test the calculate_in_band_wave_indices method of the PassbandGroup class."""
+    # Test with simple passband group
+    test_passband_group = create_passband_group(tmp_path, delta_wave=20, trim_quantile=None)
+
+    passband_A = test_passband_group.passbands["TEST_a"]
+    passband_B = test_passband_group.passbands["TEST_b"]
+    passband_C = test_passband_group.passbands["TEST_c"]
+
+    # Note that passband_A and passband_B have overlapping wavelength ranges
+    # Where passband_A covers 100-300 and passband_B covers 250-350 (and passband_C covers 400-600)
+    assert np.allclose(passband_A._in_band_wave_indices, np.array([0, 1, 2, 3, 4, 5, 6, 7, 9, 11, 13]))
+    assert np.allclose(passband_A.waves, test_passband_group.waves[passband_A._in_band_wave_indices])
+
+    assert np.allclose(passband_B._in_band_wave_indices, np.array([8, 10, 12, 14, 15, 16]))
+    assert np.allclose(passband_B.waves, test_passband_group.waves[passband_B._in_band_wave_indices])
+
+    assert passband_C._in_band_wave_indices == (17, 28)
+    assert np.allclose(
+        passband_C.waves,
+        test_passband_group.waves[passband_C._in_band_wave_indices[0] : passband_C._in_band_wave_indices[1]],
+    )
+
+
 def test_passband_group_fluxes_to_bandfluxes(tmp_path):
     """Test the fluxes_to_bandfluxes method of the PassbandGroup class."""
     # Test with simple passband group


### PR DESCRIPTION
Described in and closes #112:

> When calling `fluxes_to_bandfluxes`, we recalculate the portion of `PassbandGroup.waves` that overlaps with each individual `Passband`'s `waves`. This could be done ahead of time and stored to make `fluxes_to_bandfluxes` faster (and recalculated each time the transmission table is re-gridded).