### PR TITLE
Add get_band_fluxes to source models

### DIFF
--- a/src/tdastro/sources/physical_model.py
+++ b/src/tdastro/sources/physical_model.py
@@ -299,7 +299,7 @@ class PhysicalModel(ParameterizedNode):
         Parameters
         ----------
         passband_or_group : `Passband` or `PassbandGroup`
-            The passband to use.
+            The passband (or passband group) to use.
         times : `numpy.ndarray`
             A length T array of observer frame timestamps.
         state : `GraphState`

--- a/src/tdastro/sources/physical_model.py
+++ b/src/tdastro/sources/physical_model.py
@@ -3,6 +3,7 @@
 import numpy as np
 
 from tdastro.astro_utils.cosmology import RedshiftDistFunc
+from tdastro.astro_utils.passbands import Passband, PassbandGroup
 from tdastro.base_models import ParameterizedNode
 from tdastro.graph_state import GraphState
 from tdastro.util_nodes.np_random import build_rngs_from_hashes
@@ -289,3 +290,29 @@ class PhysicalModel(ParameterizedNode):
         node_hashes = self.get_all_node_info("node_hash")
         np_rngs = build_rngs_from_hashes(node_hashes, base_seed)
         return np_rngs
+
+    def get_band_fluxes(self, passband_or_group, times, state) -> np.ndarray | dict:
+        """Get the band fluxes for a given Passband or PassbandGroup.
+
+        Parameters
+        ----------
+        passband_or_group : `Passband` or `PassbandGroup`
+            The passband to use.
+        times : `numpy.ndarray`
+            A length T array of observer frame timestamps.
+        state : `GraphState`
+            An object mapping graph parameters to their values.
+
+        Returns
+        -------
+        band_fluxes : `numpy.ndarray` or `dict
+            A length T array of band fluxes, or a dictionary of band names mapped to fluxes (if a passband
+            group is used).
+        """
+        spectral_fluxes = self._evaluate(times, passband_or_group.waves, state)
+        if isinstance(passband_or_group, Passband):
+            return passband_or_group.fluxes_to_bandflux(spectral_fluxes)
+        elif isinstance(passband_or_group, PassbandGroup):
+            return passband_or_group.fluxes_to_bandfluxes(spectral_fluxes)
+        else:
+            raise ValueError(f"Unknown passband type: {type(passband_or_group)}")

--- a/src/tdastro/sources/physical_model.py
+++ b/src/tdastro/sources/physical_model.py
@@ -1,5 +1,7 @@
 """The base PhysicalModel used for all sources."""
 
+from typing import Union
+
 import numpy as np
 
 from tdastro.astro_utils.cosmology import RedshiftDistFunc
@@ -291,7 +293,7 @@ class PhysicalModel(ParameterizedNode):
         np_rngs = build_rngs_from_hashes(node_hashes, base_seed)
         return np_rngs
 
-    def get_band_fluxes(self, passband_or_group, times, state) -> np.ndarray | dict:
+    def get_band_fluxes(self, passband_or_group, times, state) -> Union[np.ndarray, dict]:
         """Get the band fluxes for a given Passband or PassbandGroup.
 
         Parameters

--- a/tests/tdastro/astro_utils/test_passband_groups.py
+++ b/tests/tdastro/astro_utils/test_passband_groups.py
@@ -119,7 +119,7 @@ def test_passband_group_fluxes_to_bandfluxes(tmp_path):
 
 
 def test_passband_group_wrapped_from_physical_source(tmp_path):
-    """Test the wrapped_from_physical_source method of the Passband class."""
+    """Test get_band_fluxes, PhysicalModel's wrapped version of PassbandGroup's fluxes_to_bandfluxes."""
     times = np.array([1.0, 2.0, 3.0])
     wavelengths = np.array([10.0, 20.0, 30.0])
     fluxes = np.array([[1.0, 5.0, 1.0], [5.0, 10.0, 5.0], [1.0, 5.0, 3.0]])

--- a/tests/tdastro/astro_utils/test_passbands.py
+++ b/tests/tdastro/astro_utils/test_passbands.py
@@ -305,7 +305,7 @@ def test_passband_fluxes_to_bandflux(tmp_path):
 
 
 def test_passband_wrapped_from_physical_source(tmp_path):
-    """Test the wrapped_from_physical_source method of the Passband class."""
+    """Test get_band_fluxes, PhysicalModel's wrapped version of Passband's fluxes_to_bandflux.."""
     times = np.array([1.0, 2.0, 3.0])
     wavelengths = np.array([10.0, 20.0, 30.0])
     fluxes = np.array([[1.0, 5.0, 1.0], [5.0, 10.0, 5.0], [1.0, 5.0, 3.0]])

--- a/tests/tdastro/astro_utils/test_passbands.py
+++ b/tests/tdastro/astro_utils/test_passbands.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 import numpy as np
 import pytest
 from tdastro.astro_utils.passbands import Passband
+from tdastro.sources.spline_model import SplineModel
 
 
 def test_passband_init():
@@ -301,3 +302,24 @@ def test_passband_fluxes_to_bandflux(tmp_path):
     # Test we raise an error if the fluxes are empty
     with pytest.raises(ValueError):
         a_band.fluxes_to_bandflux(np.array([]))
+
+
+def test_passband_wrapped_from_physical_source(tmp_path):
+    """Test the wrapped_from_physical_source method of the Passband class."""
+    times = np.array([1.0, 2.0, 3.0])
+    wavelengths = np.array([10.0, 20.0, 30.0])
+    fluxes = np.array([[1.0, 5.0, 1.0], [5.0, 10.0, 5.0], [1.0, 5.0, 3.0]])
+    model = SplineModel(times, wavelengths, fluxes, time_degree=1, wave_degree=1)
+    state = model.sample_parameters()
+
+    test_times = np.array([1.0, 1.5, 2.0, 2.5, 3.0, 3.5])
+
+    # Try with a single passband (see PassbandGroup tests for group tests)
+    transmission_table = "100 0.5\n200 0.75\n300 0.25\n"
+    a_band = create_test_passband(tmp_path, transmission_table, delta_wave=100, trim_quantile=None)
+    result_from_source_model = model.get_band_fluxes(a_band, test_times, state)
+
+    evaluated_fluxes = model.evaluate(test_times, a_band.waves, state)
+    result_from_passband = a_band.fluxes_to_bandflux(evaluated_fluxes)
+
+    np.testing.assert_allclose(result_from_source_model, result_from_passband)


### PR DESCRIPTION
Described in and closes #115:

> We should add a method in source models that:
> - takes in a Passband or PassbandGroup (and time t)
> - evaluates the model based on the Passband/PassbandGroup's `waves` array to get spectral fluxes
> - call the Passband/PassbandGroup's `flux_to_bandflux/fluxes_to_bandfluxes` on these spectral fluxes
> - returns the band fluxes 