### PR TITLE
Move redshift from effect to physical model

### DIFF
--- a/src/tdastro/sources/physical_model.py
+++ b/src/tdastro/sources/physical_model.py
@@ -116,6 +116,49 @@ class PhysicalModel(ParameterizedNode):
         for effect in self.effects:
             effect.set_graph_positions(seen_nodes=seen_nodes)
 
+    def _redshift_pre_effect(self, observer_frame_times, observer_frame_wavelengths, params):
+        """Calculate the rest-frame times and wavelengths needed to give us the observer-frame times
+        and wavelengths (given the redshift).
+
+        Parameters
+        ----------
+        observer_frame_times : numpy.ndarray
+            The times at which the observation is made.
+        observer_frame_wavelengths : numpy.ndarray
+            The wavelengths at which the observation is made (in angstroms).
+        params : `dict`
+            A dictionary of the model's parameters.
+
+        Returns
+        -------
+        tuple of (numpy.ndarray, numpy.ndarray)
+            The rest-frame times and wavelengths needed to generate the rest-frame flux densities,
+            which will later be redshifted  back to observer-frame flux densities at the observer-frame
+            times and wavelengths.
+        """
+        observed_times_rel_to_t0 = observer_frame_times - params["t0"]
+        rest_frame_times_rel_to_t0 = observed_times_rel_to_t0 / (1 + params["redshift"])
+        rest_frame_times = rest_frame_times_rel_to_t0 + params["t0"]
+        rest_frame_wavelengths = observer_frame_wavelengths / (1 + params["redshift"])
+        return (rest_frame_times, rest_frame_wavelengths)
+
+    def _redshift_post_effect(self, flux_density, params):
+        """Apply the redshift effect to observations (rest-frame flux_density values).
+
+        Parameters
+        ----------
+        flux_density : `numpy.ndarray`
+            A length T X N matrix of flux density values (in nJy).
+        params : `dict`
+            A dictionary of the model's parameters.
+
+        Returns
+        -------
+        flux_density : `numpy.ndarray`
+            The redshifted results (in nJy).
+        """
+        return flux_density / (1 + params["redshift"])
+
     def _evaluate(self, times, wavelengths, graph_state):
         """Draw effect-free observations for this object.
 
@@ -172,9 +215,8 @@ class PhysicalModel(ParameterizedNode):
         params = self.get_local_params(graph_state)
 
         # Pre-effects are adjustments done to times and/or wavelengths, before flux density computation.
-        for effect in self.effects:
-            if hasattr(effect, "pre_effect"):
-                times, wavelengths = effect.pre_effect(times, wavelengths, graph_state, **kwargs)
+        if self.redshift is not None and self.redshift != 0.0:
+            times, wavelengths = self._redshift_pre_effect(times, wavelengths, params)
 
         # Compute the flux density for both the current object and add in anything
         # behind it, such as a host galaxy.
@@ -191,6 +233,11 @@ class PhysicalModel(ParameterizedNode):
 
         for effect in self.effects:
             flux_density = effect.apply(flux_density, wavelengths, graph_state, **kwargs)
+
+        # Post-effects are adjustments done to the flux density after computation.
+        if self.redshift is not None and self.redshift != 0.0:
+            flux_density = self._redshift_post_effect(flux_density, params)
+
         return flux_density
 
     def sample_parameters(self, given_args=None, num_samples=1, rng_info=None, **kwargs):

--- a/tests/tdastro/sources/test_redshift.py
+++ b/tests/tdastro/sources/test_redshift.py
@@ -1,0 +1,21 @@
+import numpy as np
+from tdastro.sources.step_source import StepSource
+
+
+def test_redshift_values() -> None:
+    """Test that we correctly calculate redshifted values."""
+    times = np.linspace(0, 100, 1000)
+    wavelengths = np.array([100.0, 200.0, 300.0])
+    t0 = 10.0
+    t1 = 30.0
+    brightness = 50.0
+
+    for redshift in [0.0, 0.5, 2.0, 3.0, 30.0]:
+        model_redshift = StepSource(brightness=brightness, t0=t0, t1=t1, redshift=redshift)
+        values_redshift = model_redshift.evaluate(times, wavelengths)
+
+        for i, time in enumerate(times):
+            if t0 <= time and time <= (t1 - t0) * (1 + redshift) + t0:
+                assert np.all(values_redshift[i] == brightness / (1 + redshift))
+            else:
+                assert np.all(values_redshift[i] == 0.0)


### PR DESCRIPTION
Described in and closes #76 (pardon the mismatch in the branch name):

> Instead of applying redshift as an effect, I think we should make it part of PhysicalModel. If redshift != 0, PhysicalModel.evaluate always calls the pre-effect function to transform the frame and then always calls the post effect afterward. This way the user does not need to manually add redshift effects.