### PR TITLE
Fix the HostmassX1Func return type

### DIFF
--- a/src/tdastro/astro_utils/snia_utils.py
+++ b/src/tdastro/astro_utils/snia_utils.py
@@ -251,7 +251,9 @@ class HostmassX1Func(NumericalInversePolynomialFunc):
         hostmass = self.get_param(graph_state, "hostmass")
 
         if graph_state.num_samples == 1:
-            results = self._inv_poly_ge_10.rvs(1, rng) if hostmass >= 10 else self._inv_poly_lt_10.rvs(1, rng)
+            results = (
+                self._inv_poly_ge_10.rvs(1, rng)[0] if hostmass >= 10 else self._inv_poly_lt_10.rvs(1, rng)[0]
+            )
         else:
             results = np.zeros(graph_state.num_samples)
 

--- a/tests/tdastro/astro_utils/test_snia_utils.py
+++ b/tests/tdastro/astro_utils/test_snia_utils.py
@@ -63,6 +63,11 @@ def test_sample_hostmass_x1c():
     assert len(values1) == num_samples
     assert len(np.unique(values1)) == num_samples
 
+    # If we are only querying a single sample, we get a float.
+    states_single = hm_node1.sample_parameters(num_samples=1)
+    values_single = hm_node1.get_param(states_single, "function_node_result")
+    assert isinstance(values_single, float)
+
     # If we create a new node with the same hostmas and the same seeds, we get the
     # same results and the same hostmasses.
     hm_node2 = HostmassX1Func(


### PR DESCRIPTION
Closes #134 

`HostmassX1Func` should return a float (instead of a numpy array with one element) when `num_samples` is 1.