### PR TITLE
Rename _evaluate to compute_flux()

### DIFF
--- a/src/tdastro/sources/galaxy_models.py
+++ b/src/tdastro/sources/galaxy_models.py
@@ -23,7 +23,7 @@ class GaussianGalaxy(PhysicalModel):
         self.add_parameter("galaxy_radius_std", radius, **kwargs)
         self.add_parameter("brightness", brightness, **kwargs)
 
-    def _evaluate(self, times, wavelengths, graph_state, ra=None, dec=None, **kwargs):
+    def compute_flux(self, times, wavelengths, graph_state, ra=None, dec=None, **kwargs):
         """Draw effect-free observations for this object.
 
         Parameters

--- a/src/tdastro/sources/periodic_source.py
+++ b/src/tdastro/sources/periodic_source.py
@@ -44,7 +44,7 @@ class PeriodicSource(PhysicalModel, ABC):
         """
         raise NotImplementedError()
 
-    def _evaluate(self, times, wavelengths, graph_state, **kwargs):
+    def compute_flux(self, times, wavelengths, graph_state, **kwargs):
         """Draw effect-free observations for this object.
 
         Parameters

--- a/src/tdastro/sources/physical_model.py
+++ b/src/tdastro/sources/physical_model.py
@@ -99,7 +99,7 @@ class PhysicalModel(ParameterizedNode):
         """
         self.apply_redshift = apply_redshift
 
-    def _evaluate(self, times, wavelengths, graph_state):
+    def compute_flux(self, times, wavelengths, graph_state):
         """Draw effect-free rest frame flux densities.
         The rest-frame flux is defined as F_nu = L_nu / 4*pi*D_L**2,
         where D_L is the luminosity distance.
@@ -167,9 +167,9 @@ class PhysicalModel(ParameterizedNode):
 
         # Compute the flux density for both the current object and add in anything
         # behind it, such as a host galaxy.
-        flux_density = self._evaluate(times, wavelengths, graph_state, **kwargs)
+        flux_density = self.compute_flux(times, wavelengths, graph_state, **kwargs)
         if self.background is not None:
-            flux_density += self.background._evaluate(
+            flux_density += self.background.compute_flux(
                 times,
                 wavelengths,
                 graph_state,

--- a/src/tdastro/sources/physical_model.py
+++ b/src/tdastro/sources/physical_model.py
@@ -1,6 +1,5 @@
 """The base PhysicalModel used for all sources."""
 
-
 import numpy as np
 
 from tdastro.astro_utils.passbands import Passband

--- a/src/tdastro/sources/sncomso_models.py
+++ b/src/tdastro/sources/sncomso_models.py
@@ -128,7 +128,7 @@ class SncosmoWrapperModel(PhysicalModel):
         super()._sample_helper(graph_state, seen_nodes, rng_info)
         self._update_sncosmo_model_parameters(graph_state)
 
-    def _evaluate(self, times, wavelengths, graph_state=None, **kwargs):
+    def compute_flux(self, times, wavelengths, graph_state=None, **kwargs):
         """Draw effect-free observations for this object.
 
         Parameters

--- a/src/tdastro/sources/spline_model.py
+++ b/src/tdastro/sources/spline_model.py
@@ -71,7 +71,7 @@ class SplineModel(PhysicalModel):
         self._wavelengths = wavelengths
         self._spline = RectBivariateSpline(times, wavelengths, flux, kx=time_degree, ky=wave_degree)
 
-    def _evaluate(self, times, wavelengths, graph_state, **kwargs):
+    def compute_flux(self, times, wavelengths, graph_state, **kwargs):
         """Draw effect-free observations for this object.
 
         Parameters

--- a/src/tdastro/sources/static_source.py
+++ b/src/tdastro/sources/static_source.py
@@ -18,7 +18,7 @@ class StaticSource(PhysicalModel):
         super().__init__(**kwargs)
         self.add_parameter("brightness", brightness, **kwargs)
 
-    def _evaluate(self, times, wavelengths, graph_state, **kwargs):
+    def compute_flux(self, times, wavelengths, graph_state, **kwargs):
         """Draw effect-free observations for this object.
 
         Parameters

--- a/src/tdastro/sources/step_source.py
+++ b/src/tdastro/sources/step_source.py
@@ -23,7 +23,7 @@ class StepSource(StaticSource):
         self.add_parameter("t0", t0, **kwargs)
         self.add_parameter("t1", t1, **kwargs)
 
-    def _evaluate(self, times, wavelengths, graph_state, **kwargs):
+    def compute_flux(self, times, wavelengths, graph_state, **kwargs):
         """Draw effect-free observations for this object.
 
         Parameters


### PR DESCRIPTION
Rename `_evaluate()` to make it distinct from `evaluate()`.