### PR TITLE
Basic IO Functions for GraphState

### DIFF
--- a/src/tdastro/sources/physical_model.py
+++ b/src/tdastro/sources/physical_model.py
@@ -1,6 +1,5 @@
 """The base PhysicalModel used for all sources."""
 
-
 import numpy as np
 
 from tdastro.astro_utils.passbands import Passband


### PR DESCRIPTION
Add some IO and helper functions for `GraphState`:
- Transform a `GraphState` to/from an AstroPy Table.
- Save/Read a `GraphState` to a ecsv file.
- Compare two `GraphState`s for equality.
These will be used in the future to save program state and output the lightcurves.