### PR TITLE
Add a helper function for looking at variables

### DIFF
--- a/src/tdastro/graph_state.py
+++ b/src/tdastro/graph_state.py
@@ -226,13 +226,15 @@ class GraphState:
 
         Parameters
         ----------
-        param_names : list-like
-            The names of the parameters to extract.
+        param_names : str or list-like
+            The name of s single parameter (str) or a list of names of the parameters
+            to extract.
 
         Returns
         -------
-        results : dict
-            A dictionary mapping all the given names to their values.
+        results
+            If extracting a single parameter, returns its values. Otherwise returns a
+            dictionary mapping the given names to their values.
 
         Raises
         ------
@@ -240,7 +242,10 @@ class GraphState:
         different values for those nodes.
         """
         # Store the param_names in a set so we can do fast look ups.
-        match_set = set([item for item in param_names])
+        if isinstance(param_names, str):
+            match_set = set([param_names])
+        elif not isinstance(param_names, set):
+            match_set = set([item for item in param_names])
 
         results = {}
         for node_params in self.states.values():
@@ -255,6 +260,15 @@ class GraphState:
                             )
                     else:
                         results[var_name] = value
+
+        # Check that we found everything.
+        for val in match_set:
+            if val not in results:
+                raise KeyError(f"Parameter {val} not found in the GraphState.")
+
+        # Check if we should be returning a dictionary or just the values.
+        if len(match_set) == 1:
+            results = list(results.values())[0]
         return results
 
 

--- a/tests/tdastro/sources/test_snia.py
+++ b/tests/tdastro/sources/test_snia.py
@@ -27,8 +27,10 @@ def draw_single_random_sn(
 
     res = {"wavelengths_rest": wavelengths_rest}
 
-    t0 = source.get_param(state, "t0")
+    t0 = state.extract_params("t0")
 
+    # We cannot use extract_params on RA and dec since the host and source have
+    # different values.
     ra = source.get_param(state, "ra")
     dec = source.get_param(state, "dec")
     obs_index = np.array(opsim.range_search(ra, dec, radius=1.75))
@@ -167,15 +169,12 @@ def run_snia_end2end(oversampled_observations, passbands_dir, nsample=1):
             continue
         any_valid_results = True
 
+        # Extract important parameters that we want to use. The pair ra and dec must be extracted
+        # from a specific node because the host and source have different values.
         state = res["state"]
-
-        p = {}
-        for parname in ["t0", "x0", "x1", "c", "redshift", "ra", "dec"]:
+        p = state.extract_params(["t0", "x0", "x1", "c", "redshift", "hostmass", "distmod"])
+        for parname in ["ra", "dec"]:
             p[parname] = float(source.get_param(state, parname))
-        for parname in ["hostmass"]:
-            p[parname] = host.get_param(state, parname)
-        for parname in ["distmod"]:
-            p[parname] = x0_func.get_param(state, parname)
         res["parameter_values"] = p
 
         saltpars = {"x0": p["x0"], "x1": p["x1"], "c": p["c"], "z": p["redshift"], "t0": p["t0"]}

--- a/tests/tdastro/test_graph_state.py
+++ b/tests/tdastro/test_graph_state.py
@@ -210,6 +210,10 @@ def test_graph_state_extract_params():
     assert results["v3"] == 3.0
     assert results["v4"] == 6.0
 
+    # We can extract a single value at a time.
+    assert state.extract_params("v2") == 2.0
+    assert state.extract_params("v5") == 7.0
+
     # We fail if we find different values for the same parameter name. This could
     # happen with something like 'loc' in nodes generating Guassian distributions.
     with pytest.raises(ValueError):

--- a/tests/tdastro/test_graph_state.py
+++ b/tests/tdastro/test_graph_state.py
@@ -190,6 +190,32 @@ def test_graph_state_update():
         state.update(state4)
 
 
+def test_graph_state_extract_params():
+    """Test that we can extract named parameters from a GraphState."""
+    state = GraphState()
+    state.set("a", "v1", 1.0)
+    state.set("a", "v2", 2.0)
+    state.set("a", "v3", 3.0)
+    state.set("b", "v1", 4.0)
+    state.set("c", "v3", 3.0)
+    state.set("d", "v4", 6.0)
+    state.set("e", "v3", 3.0)
+    state.set("e", "v5", 7.0)
+
+    # We succeed for parameters with a single value. Although v3 appears in three
+    # nodes, it has one value (3.0).
+    results = state.extract_params(["v2", "v3", "v4"])
+    assert len(results) == 3
+    assert results["v2"] == 2.0
+    assert results["v3"] == 3.0
+    assert results["v4"] == 6.0
+
+    # We fail if we find different values for the same parameter name. This could
+    # happen with something like 'loc' in nodes generating Guassian distributions.
+    with pytest.raises(ValueError):
+        _ = state.extract_params(["v1"])
+
+
 def test_graph_state_update_multi():
     """Test that we can update a single sample GraphState."""
     state = GraphState(num_samples=3)


### PR DESCRIPTION
For common parameters, we might want to extract them from the `GraphState` without going through the node. This is useful in both logging and debugging. This PR adds a helper function that can extract (uniquely named) parameters from arbitrary nodes in the graph.