### PR TITLE
Add the ability to capture debugging information

### DIFF
--- a/src/tdastro/graph_state.py
+++ b/src/tdastro/graph_state.py
@@ -24,6 +24,8 @@ We could have one mean for an object's brightness and another for it's positiona
 of a host galaxy.
 """
 
+import copy
+
 import numpy as np
 from astropy.io import ascii
 from astropy.table import Table
@@ -156,6 +158,10 @@ class GraphState:
         """
         data_table = ascii.read(filename, format="ecsv")
         return GraphState.from_table(data_table)
+
+    def copy(self):
+        """Create and return a copy of the GraphState."""
+        return copy.deepcopy(self)
 
     def get_node_state(self, node_name, sample_num=0):
         """Get a dictionary of all parameters local to the given node

--- a/tests/tdastro/sources/test_step_source.py
+++ b/tests/tdastro/sources/test_step_source.py
@@ -55,6 +55,35 @@ def test_step_source() -> None:
     assert np.array_equal(values, expected)
 
 
+def test_step_source_debug() -> None:
+    """Test that we can produce debugging data during an evaluate call."""
+    model = StepSource(brightness=10.0, t0=1.0, t1=2.0, ra=0.0, dec=0.0, redshift=0.1)
+    state = model.sample_parameters()
+
+    times = np.array([0.0, 1.0, 2.0, 3.0])
+    wavelengths = np.array([100.0, 200.0])
+    debug_data = {}
+    flux_density_obs = model.evaluate(times, wavelengths, state, debug_data=debug_data)
+
+    assert "times_obs" in debug_data
+    assert np.array_equal(debug_data["times_obs"], times)
+
+    assert "wavelengths_obs" in debug_data
+    assert np.array_equal(debug_data["wavelengths_obs"], wavelengths)
+
+    assert "times_rest" in debug_data
+    assert not np.array_equal(debug_data["times_rest"], times)
+
+    assert "wavelengths_rest" in debug_data
+    assert not np.array_equal(debug_data["wavelengths_rest"], wavelengths)
+
+    assert "flux_density_rest" in debug_data
+    assert debug_data["flux_density_rest"].shape == (4, 2)
+    assert not np.array_equal(flux_density_obs, debug_data["flux_density_rest"])
+
+    assert "state" in debug_data
+
+
 def test_step_source_resample() -> None:
     """Check that we can call resample on the model parameters."""
     random.seed(1111)

--- a/tests/tdastro/test_graph_state.py
+++ b/tests/tdastro/test_graph_state.py
@@ -248,6 +248,38 @@ def test_graph_state_update():
         state.update(state4)
 
 
+def test_graph_state_copy():
+    """Test that we can copy a GraphState."""
+    state = GraphState()
+    state.set("a", "v1", 1.0)
+    state.set("a", "v2", 2.0)
+    state.set("b", "v1", 3.0)
+    state.set("c", "v1", 4.0, fixed=True)
+
+    copy_state = state.copy()
+    assert copy_state.num_samples == 1
+    assert copy_state.num_parameters == 4
+    assert copy_state["a"]["v1"] == 1.0
+    assert copy_state["a"]["v2"] == 2.0
+    assert copy_state["b"]["v1"] == 3.0
+    assert copy_state["c"]["v1"] == 4.0
+    assert "v1" in copy_state.fixed_vars["c"]
+
+    # We can change values in the original state without modifying the copied state.
+    state.set("a", "v2", 3.0)
+    state.set("d", "v1", 3.0)
+    state.set("d", "v2", 3.0)
+    assert state.num_parameters == 6
+    assert state["a"]["v2"] == 3.0
+
+    assert copy_state.num_samples == 1
+    assert copy_state.num_parameters == 4
+    assert copy_state["a"]["v1"] == 1.0
+    assert copy_state["a"]["v2"] == 2.0
+    assert copy_state["b"]["v1"] == 3.0
+    assert copy_state["c"]["v1"] == 4.0
+
+
 def test_graph_state_from_table():
     """Test that we can create a GraphState from an AstroPy Table."""
     input = Table(


### PR DESCRIPTION
Add the ability to snapshot intermediate data products during the `evaluate()`, but have this functionality off by default so it does not add overhead.