### PR TITLE
Add a helper function for looking at variables

### DIFF
--- a/src/tdastro/graph_state.py
+++ b/src/tdastro/graph_state.py
@@ -340,7 +340,7 @@ class GraphState:
         if isinstance(params, str):
             params = [params]
 
-        # Go through all the parameters. If a parameters fill name is provided,
+        # Go through all the parameters. If a parameters full name is provided,
         # look it up now and save the result. Otherwise put it into a list to check
         # for in each node.
         single_params = set()
@@ -350,6 +350,8 @@ class GraphState:
                 node_name, param_name = current.split(".")
                 if node_name in self.states and param_name in self.states[node_name]:
                     results[current] = self.states[node_name][param_name]
+                else:
+                    raise KeyError(f"Parameter {current} not found in GraphState.")
             else:
                 single_params.add(current)
 
@@ -357,7 +359,7 @@ class GraphState:
             # Nothing else to do.
             return results
 
-        # Traverse the trnested dictionaries looking for cases where the parameter names match.
+        # Traverse the nested dictionaries looking for cases where the parameter names match.
         first_seen_node = {}
         for node_name, node_params in self.states.items():
             for param_name, param_value in node_params.items():
@@ -380,6 +382,11 @@ class GraphState:
                         # just the parameter name. Also save the node where we saw it.
                         results[param_name] = param_value
                         first_seen_node[param_name] = node_name
+
+        # Check that we found a match for all the short parameter names.
+        for param_name in single_params:
+            if param_name not in first_seen_node:
+                raise KeyError(f"Parameter {param_name} not found in GraphState.")
 
         return results
 

--- a/tests/tdastro/test_graph_state.py
+++ b/tests/tdastro/test_graph_state.py
@@ -433,12 +433,24 @@ def test_graph_state_extract_parameters():
     assert results["e.v3"] == 3.0
     assert results["d.v4"] == 6.0
 
+    # We can also provide a single parameter name.
+    results = state.extract_parameters("v2")
+    assert len(results) == 2
+    assert results["a.v2"] == 2.0
+    assert results["c.v2"] == 5.0
+
     # We can extract from only certain nodes.
     results = state.extract_parameters(nodes=["a", "c"])
     assert len(results) == 5
     assert results["a.v1"] == 1.0
     assert results["a.v2"] == 2.0
     assert results["a.v3"] == 3.0
+    assert results["c.v2"] == 5.0
+    assert results["c.v3"] == 3.0
+
+    # We can also provide a single node name.
+    results = state.extract_parameters(nodes="c")
+    assert len(results) == 2
     assert results["c.v2"] == 5.0
     assert results["c.v3"] == 3.0
 

--- a/tests/tdastro/test_graph_state.py
+++ b/tests/tdastro/test_graph_state.py
@@ -405,61 +405,53 @@ def test_graph_to_from_file():
 def test_graph_state_extract_parameters():
     """Test that we can extract named parameters from a GraphState."""
     state = GraphState()
+    state.set("a", "v0", 0.0)
     state.set("a", "v1", 1.0)
     state.set("a", "v2", 2.0)
     state.set("a", "v3", 3.0)
     state.set("b", "v1", 4.0)
     state.set("c", "v2", 5.0)
-    state.set("c", "v3", 3.0)
-    state.set("d", "v4", 6.0)
-    state.set("e", "v3", 3.0)
-    state.set("e", "v5", 7.0)
+    state.set("c", "v3", 6.0)
+    state.set("d", "v4", 7.0)
+    state.set("e", "v3", 8.0)
+    state.set("e", "v5", 9.0)
+    state.set("e", "v6", 10.0)
+    state.set("f", "v6", 11.0)
 
-    # We can always access a parameter by its full name.
-    assert state["a.v1"] == 1.0
-    assert state["a.v2"] == 2.0
+    # We can extract a mixture of unique parameters based on full and short names.
+    results = state.extract_parameters(["a.v1", "c.v2", "v5"])
+    assert len(results) == 3
+    assert results["a.v1"] == 1.0
+    assert results["c.v2"] == 5.0
+    assert results["v5"] == 9.0
 
-    # With no filtering, we extract all the parameters.
-    results = state.extract_parameters()
-    assert len(results) == 9
-
-    # We can extract only certain parameters.
+    # If we extract a parameter that appears in multiple nodes with its short
+    # name, we expand the name for each instance.
     results = state.extract_parameters(["v2", "v3", "v4"])
     assert len(results) == 6
     assert results["a.v2"] == 2.0
     assert results["a.v3"] == 3.0
     assert results["c.v2"] == 5.0
-    assert results["c.v3"] == 3.0
-    assert results["e.v3"] == 3.0
-    assert results["d.v4"] == 6.0
+    assert results["c.v3"] == 6.0
+    assert results["e.v3"] == 8.0
+    assert results["v4"] == 7.0  # We do not expand the name.
 
-    # We can also provide a single parameter name.
+    # We can also provide a single parameter name as a string.
     results = state.extract_parameters("v2")
     assert len(results) == 2
     assert results["a.v2"] == 2.0
     assert results["c.v2"] == 5.0
 
-    # We can extract from only certain nodes.
-    results = state.extract_parameters(nodes=["a", "c"])
-    assert len(results) == 5
-    assert results["a.v1"] == 1.0
-    assert results["a.v2"] == 2.0
+    # Test a complicated list.
+    results = state.extract_parameters(["v0", "c.v2", "e.v3", "v5", "v6", "a.v3"])
+    assert len(results) == 7
+    assert results["v0"] == 0.0
+    assert results["c.v2"] == 5.0
+    assert results["e.v3"] == 8.0
+    assert results["v5"] == 9.0
+    assert results["e.v6"] == 10.0
+    assert results["f.v6"] == 11.0
     assert results["a.v3"] == 3.0
-    assert results["c.v2"] == 5.0
-    assert results["c.v3"] == 3.0
-
-    # We can also provide a single node name.
-    results = state.extract_parameters(nodes="c")
-    assert len(results) == 2
-    assert results["c.v2"] == 5.0
-    assert results["c.v3"] == 3.0
-
-    # We can extract a set of parameters from a set of nodes.
-    results = state.extract_parameters(nodes=["a", "c", "e"], params=["v1", "v2"])
-    assert len(results) == 3
-    assert results["a.v1"] == 1.0
-    assert results["a.v2"] == 2.0
-    assert results["c.v2"] == 5.0
 
 
 def test_transpose_dict_of_list():

--- a/tests/tdastro/test_graph_state.py
+++ b/tests/tdastro/test_graph_state.py
@@ -453,6 +453,13 @@ def test_graph_state_extract_parameters():
     assert results["f.v6"] == 11.0
     assert results["a.v3"] == 3.0
 
+    # We raise a KeyError if we try to lookup a parameter that is not in the GraphState.
+    with pytest.raises(KeyError):
+        _ = state.extract_parameters(["v2", "v3", "c.v4"])
+
+    with pytest.raises(KeyError):
+        _ = state.extract_parameters(["v2", "v100"])
+
 
 def test_transpose_dict_of_list():
     """Test the transpose_dict_of_list helper function"""

--- a/tests/tdastro/test_graph_state.py
+++ b/tests/tdastro/test_graph_state.py
@@ -402,47 +402,48 @@ def test_graph_to_from_file():
         state.save_to_file(file_path, overwrite=True)
 
 
-def test_graph_state_extract_params():
+def test_graph_state_to_dict_extract_params():
     """Test that we can extract named parameters from a GraphState."""
     state = GraphState()
     state.set("a", "v1", 1.0)
     state.set("a", "v2", 2.0)
     state.set("a", "v3", 3.0)
     state.set("b", "v1", 4.0)
+    state.set("c", "v2", 5.0)
     state.set("c", "v3", 3.0)
     state.set("d", "v4", 6.0)
     state.set("e", "v3", 3.0)
     state.set("e", "v5", 7.0)
 
-    # We can extract and collapse parameters with a single value.
-    # Although v3 appears in three nodes, it has one value (3.0).
-    results = state.extract_params(["v2", "v3", "v4"])
-    assert len(results) == 3
-    assert results["v2"] == 2.0
-    assert results["v3"] == 3.0
-    assert results["v4"] == 6.0
+    # With no filtering, we extract all the parameters.
+    results = state.to_dict()
+    assert len(results) == 9
 
-    # We can extract a single value at a time.
-    results = state.extract_params("v5")
-    assert len(results) == 1
-    assert results["v5"] == 7.0
-
-    # If we set collapse to False then we see the duplicates.
-    results = state.extract_params(["v2", "v3", "v4"], collapse=False)
-    assert len(results) == 5
+    # We can extract only certain parameters.
+    results = state.to_dict(params=["v2", "v3", "v4"])
+    assert len(results) == 6
     assert results["a.v2"] == 2.0
     assert results["a.v3"] == 3.0
+    assert results["c.v2"] == 5.0
     assert results["c.v3"] == 3.0
     assert results["e.v3"] == 3.0
     assert results["d.v4"] == 6.0
 
-    # We can collapse consistent parameters while keeping insconsistent ones expanded.
-    results = state.extract_params(["v1", "v2", "v3"])
-    assert len(results) == 4
+    # We can extract from only certain nodes.
+    results = state.to_dict(nodes=["a", "c"])
+    assert len(results) == 5
     assert results["a.v1"] == 1.0
-    assert results["b.v1"] == 4.0
-    assert results["v2"] == 2.0
-    assert results["v3"] == 3.0
+    assert results["a.v2"] == 2.0
+    assert results["a.v3"] == 3.0
+    assert results["c.v2"] == 5.0
+    assert results["c.v3"] == 3.0
+
+    # We can extract a set of parameters from a set of nodes.
+    results = state.to_dict(nodes=["a", "c", "e"], params=["v1", "v2"])
+    assert len(results) == 3
+    assert results["a.v1"] == 1.0
+    assert results["a.v2"] == 2.0
+    assert results["c.v2"] == 5.0
 
 
 def test_transpose_dict_of_list():

--- a/tests/tdastro/test_graph_state.py
+++ b/tests/tdastro/test_graph_state.py
@@ -28,11 +28,11 @@ def test_create_single_sample_graph_state():
         _ = state["c"]["v1"]
 
     # We can access the entries using the extended key name.
-    assert state[f"a{state._NAME_SEPARATOR}v1"] == 1.0
-    assert state[f"a{state._NAME_SEPARATOR}v2"] == 2.0
-    assert state[f"b{state._NAME_SEPARATOR}v1"] == 3.0
+    assert state["a.v1"] == 1.0
+    assert state["a.v2"] == 2.0
+    assert state["b.v1"] == 3.0
     with pytest.raises(KeyError):
-        _ = state[f"c{state._NAME_SEPARATOR}v1"]
+        _ = state["c.v1"]
 
     # We can create a human readable string representation of the GraphState.
     debug_str = str(state)
@@ -70,9 +70,9 @@ def test_create_single_sample_graph_state():
 
     # Test we cannot use a name containing the separator as a substring.
     with pytest.raises(ValueError):
-        state.set(f"a{state._NAME_SEPARATOR}b", "v1", 10.0)
+        state.set("a.b", "v1", 10.0)
     with pytest.raises(ValueError):
-        state.set("b", f"v1{state._NAME_SEPARATOR}v3", 10.0)
+        state.set("b", "v1.v3", 10.0)
 
 
 def test_graph_state_contains():
@@ -86,14 +86,14 @@ def test_graph_state_contains():
     assert "b" in state
     assert "c" not in state
 
-    assert f"a{state._NAME_SEPARATOR}v1" in state
-    assert f"a{state._NAME_SEPARATOR}v2" in state
-    assert f"a{state._NAME_SEPARATOR}v3" not in state
-    assert f"b{state._NAME_SEPARATOR}v1" in state
-    assert f"c{state._NAME_SEPARATOR}v1" not in state
+    assert "a.v1" in state
+    assert "a.v2" in state
+    assert "a.v3" not in state
+    assert "b.v1" in state
+    assert "c.v1" not in state
 
     with pytest.raises(KeyError):
-        assert f"b{state._NAME_SEPARATOR}v1{state._NAME_SEPARATOR}v2" not in state
+        assert "b.v1.v2" not in state
 
 
 def test_create_multi_sample_graph_state():
@@ -402,7 +402,7 @@ def test_graph_to_from_file():
         state.save_to_file(file_path, overwrite=True)
 
 
-def test_graph_state_to_dict_extract_params():
+def test_graph_state_extract_parameters():
     """Test that we can extract named parameters from a GraphState."""
     state = GraphState()
     state.set("a", "v1", 1.0)
@@ -415,12 +415,16 @@ def test_graph_state_to_dict_extract_params():
     state.set("e", "v3", 3.0)
     state.set("e", "v5", 7.0)
 
+    # We can always access a parameter by its full name.
+    assert state["a.v1"] == 1.0
+    assert state["a.v2"] == 2.0
+
     # With no filtering, we extract all the parameters.
-    results = state.to_dict()
+    results = state.extract_parameters()
     assert len(results) == 9
 
     # We can extract only certain parameters.
-    results = state.to_dict(params=["v2", "v3", "v4"])
+    results = state.extract_parameters(["v2", "v3", "v4"])
     assert len(results) == 6
     assert results["a.v2"] == 2.0
     assert results["a.v3"] == 3.0
@@ -430,7 +434,7 @@ def test_graph_state_to_dict_extract_params():
     assert results["d.v4"] == 6.0
 
     # We can extract from only certain nodes.
-    results = state.to_dict(nodes=["a", "c"])
+    results = state.extract_parameters(nodes=["a", "c"])
     assert len(results) == 5
     assert results["a.v1"] == 1.0
     assert results["a.v2"] == 2.0
@@ -439,7 +443,7 @@ def test_graph_state_to_dict_extract_params():
     assert results["c.v3"] == 3.0
 
     # We can extract a set of parameters from a set of nodes.
-    results = state.to_dict(nodes=["a", "c", "e"], params=["v1", "v2"])
+    results = state.extract_parameters(nodes=["a", "c", "e"], params=["v1", "v2"])
     assert len(results) == 3
     assert results["a.v1"] == 1.0
     assert results["a.v2"] == 2.0


### PR DESCRIPTION
For common parameters, we might want to extract them from the GraphState without going through the node. This is useful in both logging and debugging. This PR adds a helper function that can extract (uniquely named) parameters from arbitrary nodes in the graph.