### PR TITLE
A few small clean ups to node naming and data storage

### DIFF
--- a/src/tdastro/base_models.py
+++ b/src/tdastro/base_models.py
@@ -203,7 +203,7 @@ class ParameterizedNode:
         else:
             # Otherwise use a combination of the node's class and position.
             pos_string = f"{self.node_pos}:" if self.node_pos is not None else ""
-            self.node_string = f"{pos_string}{self.__class__.__qualname__}"
+            self.node_string = f"{pos_string}{self.__class__.__name__}"
 
         # Allow for the appending of an extra tag.
         if extra_tag is not None:

--- a/tests/tdastro/sources/test_physical_models.py
+++ b/tests/tdastro/sources/test_physical_models.py
@@ -19,7 +19,7 @@ def test_physical_model():
 
     # None of the parameters are in the PyTree.
     pytree = model1.build_pytree(state)
-    assert len(pytree["0:PhysicalModel"]) == 0
+    assert len(pytree["PhysicalModel_0"]) == 0
 
     # We can turn off the redshift computation.
     model1.set_apply_redshift(False)

--- a/tests/tdastro/sources/test_sncosmo_models.py
+++ b/tests/tdastro/sources/test_sncosmo_models.py
@@ -11,7 +11,7 @@ def test_sncomso_models_hsiao() -> None:
     state = model.sample_parameters()
     assert model.get_param(state, "amplitude") == 2.0e10
     assert model.get_param(state, "t0") == 0.0
-    assert str(model) == "0:SncosmoWrapperModel"
+    assert str(model) == "SncosmoWrapperModel_0"
 
     assert np.array_equal(model.param_names, ["amplitude"])
     assert np.array_equal(model.parameter_values, [2.0e10])

--- a/tests/tdastro/sources/test_static_source.py
+++ b/tests/tdastro/sources/test_static_source.py
@@ -63,10 +63,10 @@ def test_static_source_host() -> None:
     assert model.get_param(state, "ra") == 1.0
     assert model.get_param(state, "dec") == 2.0
     assert model.get_param(state, "distance") == 3.0
-    assert str(model) == "0:StaticSource"
+    assert str(model) == "StaticSource_0"
 
     # Test that we have given a different name to the host.
-    assert str(host) == "1:StaticSource"
+    assert str(host) == "StaticSource_1"
 
 
 def test_static_source_resample() -> None:

--- a/tests/tdastro/test_base_models.py
+++ b/tests/tdastro/test_base_models.py
@@ -109,7 +109,7 @@ def test_parameterized_node():
     # If we set a position (and there is no node_label), the position shows up in the name.
     model1.node_pos = 100
     model1._update_node_string()
-    assert str(model1) == "100:PairModel"
+    assert str(model1) == "PairModel_100"
 
     # Use value1=model.value and value2=1.0
     model2 = PairModel(value1=model1.value1, value2=1.0, node_label="test")
@@ -218,7 +218,7 @@ def test_function_node_basic():
     assert my_func.compute(state, value2=3.0) == 4.0
     assert my_func.compute(state, value2=3.0, unused_param=5.0) == 4.0
     assert my_func.compute(state, value2=3.0, value1=1.0) == 4.0
-    assert str(my_func) == "0:FunctionNode:_test_func"
+    assert str(my_func) == "FunctionNode:_test_func_0"
 
 
 def test_function_node_chain():
@@ -312,11 +312,9 @@ def test_function_node_jax():
     graph_state = sum_node.sample_parameters()
 
     pytree = sum_node.build_pytree(graph_state)
-    print(pytree)
     gr_func = jax.value_and_grad(sum_node.resample_and_compute)
     values, gradients = gr_func(pytree)
-    print(gradients)
     assert values == 9.0
-    assert gradients["sum:_test_func"]["value1"] == 1.0
-    assert gradients["div:_test_func2"]["value1"] == 2.0
-    assert gradients["div:_test_func2"]["value2"] == -16.0
+    assert gradients["sum"]["value1"] == 1.0
+    assert gradients["div"]["value1"] == 2.0
+    assert gradients["div"]["value2"] == -16.0

--- a/tests/tdastro/test_base_models.py
+++ b/tests/tdastro/test_base_models.py
@@ -152,21 +152,6 @@ def test_parameterized_node():
     assert model4.get_param(state, "value_sum") != model4.get_param(new_state, "value_sum")
 
 
-def test_parameterized_node_get_dependencies():
-    """Test that we can extract the parameters of a graph of ParameterizedNode."""
-    model1 = PairModel(value1=0.5, value2=1.5, node_label="1")
-    assert len(model1.direct_dependencies) == 1
-
-    model2 = PairModel(value1=model1.value1, value2=3.0, node_label="2")
-    assert len(model2.direct_dependencies) == 2
-    assert model1 in model2.direct_dependencies
-
-    model3 = PairModel(value1=model1.value1, value2=model2.value_sum, node_label="3")
-    assert len(model3.direct_dependencies) == 3
-    assert model1 in model3.direct_dependencies
-    assert model2 in model3.direct_dependencies
-
-
 def test_parameterized_node_modify():
     """Test that we can modify the parameters in a node."""
     model = PairModel(value1=0.5, value2=0.5)


### PR DESCRIPTION
Simplify some of the aspects of the `ParameterizedNode`:
1) Don't precompute and store `direct_dependencies` as it is only used in a single place.
2) Change default node string from "pos:class_name" to "class_name_pos"
3) Simplify `extra_tag` logic that `FunctionNode` was using to include the function name. Instead `FunctionNode` just generates the new name and passes that along.