### PR TITLE
Improve error checking for node labels

### DIFF
--- a/src/tdastro/base_models.py
+++ b/src/tdastro/base_models.py
@@ -472,7 +472,7 @@ class ParameterizedNode:
             An object mapping graph parameters to their values. This object is modified
             in place as it is sampled.
         seen_nodes : `dict`
-            A dictionary mapping nodes seen during this sampling run to their ID.
+            A dictionary mapping nodes strings seen during this sampling run to their object.
             Used to avoid sampling nodes multiple times and to validity check the graph.
         rng_info : numpy.random._generator.Generator, optional
             A given numpy random number generator to use for this computation. If not
@@ -482,9 +482,12 @@ class ParameterizedNode:
         ------
         Raise a ``KeyError`` if the sampling encounters an error with the order of dependencies.
         """
-        if self in seen_nodes:
+        node_str = str(self)
+        if node_str in seen_nodes:
+            if seen_nodes[node_str] != self:
+                raise ValueError(f"Duplicate node label {node_str}.")
             return  # Nothing to do
-        seen_nodes[self] = self.node_pos
+        seen_nodes[node_str] = self
 
         # Run through each parameter and sample it based on the given recipe.
         # As of Python 3.7 dictionaries are guaranteed to preserve insertion ordering,

--- a/src/tdastro/sources/physical_model.py
+++ b/src/tdastro/sources/physical_model.py
@@ -144,8 +144,8 @@ class PhysicalModel(ParameterizedNode):
             A length T x N matrix of SED values (in nJy).
         """
         # Make sure times and wavelengths are numpy arrays.
-        times = np.array(times)
-        wavelengths = np.array(wavelengths)
+        times = np.asarray(times)
+        wavelengths = np.asarray(wavelengths)
 
         # Check if we need to sample the graph.
         if graph_state is None:

--- a/src/tdastro/sources/sncomso_models.py
+++ b/src/tdastro/sources/sncomso_models.py
@@ -36,6 +36,9 @@ class SncosmoWrapperModel(PhysicalModel):
         Any additional keyword arguments.
     """
 
+    # A class variable for the units so we are not computing them each time.
+    _FLAM_UNIT = u.erg / u.second / u.cm**2 / u.AA
+
     def __init__(self, source_name, t0=0.0, node_label=None, **kwargs):
         super().__init__(node_label=node_label, **kwargs)
         self.source_name = source_name
@@ -160,7 +163,7 @@ class SncosmoWrapperModel(PhysicalModel):
             flux_flam,
             wavelengths,
             wave_unit=u.AA,
-            flam_unit=u.erg / u.second / u.cm**2 / u.AA,
+            flam_unit=self._FLAM_UNIT,
             fnu_unit=u.nJy,
         )
 


### PR DESCRIPTION
The node strings must be unique in order to store the data internally in a `GraphState`. This PR changes the logic to check that each node seen during sampling has a unique string.

Also adds a few very small performance optimizations (e.g. `np.array` -> `np.asarray`).