### PR TITLE
Add some basic logging for errors in math node

### DIFF
--- a/src/tdastro/math_nodes/basic_math_node.py
+++ b/src/tdastro/math_nodes/basic_math_node.py
@@ -133,11 +133,8 @@ class BasicMathNode(FunctionNode):
             except Exception as problem:
                 # Provide more detailed logging, including the expression and parameters
                 # used, when we encounter a math error like divide by zero.
-                logger.error(
-                    f"{type(problem)} encountered during operation: {self.expression}\n"
-                    f"with arguments={kwargs}"
-                )
-                raise problem
+                new_message = f"Error during math operation '{self.expression}' with args={kwargs}"
+                raise type(problem)(new_message) from problem
 
         super().__init__(eval_func, node_label=node_label, **kwargs)
 

--- a/src/tdastro/math_nodes/basic_math_node.py
+++ b/src/tdastro/math_nodes/basic_math_node.py
@@ -5,7 +5,6 @@ small FunctionNodes to perform basic math.
 """
 
 import ast
-import logging
 
 # Disable unused import because we need all of these imported
 # so they can be used during evaluation of the node.
@@ -15,8 +14,6 @@ import jax.numpy as jnp  # noqa: F401
 import numpy as np  # noqa: F401
 
 from tdastro.base_models import FunctionNode
-
-logger = logging.getLogger(__name__)
 
 
 class BasicMathNode(FunctionNode):

--- a/src/tdastro/math_nodes/basic_math_node.py
+++ b/src/tdastro/math_nodes/basic_math_node.py
@@ -5,6 +5,7 @@ small FunctionNodes to perform basic math.
 """
 
 import ast
+import logging
 
 # Disable unused import because we need all of these imported
 # so they can be used during evaluation of the node.
@@ -14,6 +15,8 @@ import jax.numpy as jnp  # noqa: F401
 import numpy as np  # noqa: F401
 
 from tdastro.base_models import FunctionNode
+
+logger = logging.getLogger(__name__)
 
 
 class BasicMathNode(FunctionNode):
@@ -125,7 +128,16 @@ class BasicMathNode(FunctionNode):
         # Create a function from the expression. Note the expression has
         # already been sanitized and validated via _prepare().
         def eval_func(**kwargs):
-            return eval(self.expression, globals(), kwargs)
+            try:
+                return eval(self.expression, globals(), kwargs)
+            except Exception as problem:
+                # Provide more detailed logging, including the expression and parameters
+                # used, when we encounter a math error like divide by zero.
+                logger.error(
+                    f"{type(problem)} encountered during operation: {self.expression}\n"
+                    f"with arguments={kwargs}"
+                )
+                raise problem
 
         super().__init__(eval_func, node_label=node_label, **kwargs)
 

--- a/tests/tdastro/math_nodes/test_basic_math_node.py
+++ b/tests/tdastro/math_nodes/test_basic_math_node.py
@@ -63,6 +63,22 @@ def test_basic_math_node_fail():
         _ = BasicMathNode("x + y", x=1.0)
 
 
+@pytest.mark.filterwarnings("ignore::RuntimeWarning")
+def test_basic_math_node_error():
+    """Test that we augment the error with information about the expression and parameters."""
+    node = BasicMathNode("y / x", x=0.0, y=1.0)
+    try:
+        node.sample_parameters()
+    except ZeroDivisionError as err:
+        assert str(err) == "Error during math operation 'y / x' with args={'x': 0.0, 'y': 1.0}"
+
+    node = BasicMathNode("sqrt(x)", x=-10.0)
+    try:
+        node.sample_parameters()
+    except ValueError as err:
+        assert str(err) == "Error during math operation 'np.sqrt(x)' with args={'x': -10.0}"
+
+
 def test_basic_math_node_numpy():
     """Test that we can perform computations via a BasicMathNode."""
     node_a = SingleVariableNode("a", 10.0)


### PR DESCRIPTION
closes #188 

Add logging to record the expression being evaluated and the parameters used when an exception is encountered in a `BasicMathNode`.