### PR TITLE
Fix the units for the JAX SALT2 model

### DIFF
--- a/src/tdastro/sources/salt2_jax.py
+++ b/src/tdastro/sources/salt2_jax.py
@@ -96,7 +96,7 @@ class SALT2JaxModel(PhysicalModel):
         # Use the default color correction values.
         self._colorlaw = SALT2ColorLaw.from_file(model_path / cl_filename)
 
-    def compute_flux(self, phase, wavelengths, graph_state, use_flam=False, **kwargs):
+    def compute_flux(self, phase, wavelengths, graph_state, **kwargs):
         """Draw effect-free observations for this object.
 
         Parameters
@@ -107,9 +107,6 @@ class SALT2JaxModel(PhysicalModel):
             A length N array of wavelengths (in angstroms).
         graph_state : `GraphState`
             An object mapping graph parameters to their values.
-        use_flam : bool
-            Output the results in f_lambda units as opposed to f_nu units.
-            This should only be set to True for specific testing scenarios.
 
         **kwargs : `dict`, optional
            Any additional keyword arguments.
@@ -117,7 +114,7 @@ class SALT2JaxModel(PhysicalModel):
         Returns
         -------
         flux_density : `numpy.ndarray`
-            A length T x N matrix of SED values (in nJy by default).
+            A length T x N matrix of SED values (in nJy).
         """
         m0_vals = self._m0_model(phase, wavelengths)
         m1_vals = self._m1_model(phase, wavelengths)
@@ -129,14 +126,12 @@ class SALT2JaxModel(PhysicalModel):
             * 10.0 ** (-0.4 * self._colorlaw.apply(wavelengths) * params["c"])
         )
 
-        # Convert to f_nu. Doing this conversion should be the desired behavior
-        # almost all of the time.
-        if not use_flam:
-            flux_density = flam_to_fnu(
-                flux_density,
-                wavelengths,
-                wave_unit=u.AA,
-                flam_unit=self._FLAM_UNIT,
-                fnu_unit=u.nJy,
-            )
+        # Convert to the correct units.
+        flux_density = flam_to_fnu(
+            flux_density,
+            wavelengths,
+            wave_unit=u.AA,
+            flam_unit=self._FLAM_UNIT,
+            fnu_unit=u.nJy,
+        )
         return flux_density

--- a/tests/tdastro/sources/test_salt2.py
+++ b/tests/tdastro/sources/test_salt2.py
@@ -5,58 +5,7 @@ from tdastro.sources.salt2_jax import SALT2JaxModel
 from tdastro.sources.sncomso_models import SncosmoWrapperModel
 
 
-def test_salt2_model(test_data_dir):
-    """Test loading a SALT2 object from a file and querying it."""
-    dir_name = test_data_dir / "truncated-salt2-h17"
-    model = SALT2JaxModel(x0=0.5, x1=0.2, c=1.0, model_dir=dir_name)
-
-    assert model._colorlaw is not None
-    assert model._m0_model is not None
-    assert model._m1_model is not None
-
-    # Test compared to values computed via sncosmo's implementation that
-    # fall within the range of the truncated grid. We multiple by 1e12
-    # for comparison precision purposes.
-    times = np.array([1.0, 2.1, 3.9, 4.0])
-    waves = np.array([4000.0, 4102.0, 4200.0])
-    expected_times_1e12 = np.array(
-        [
-            [0.12842110, 0.17791164, 0.17462753],
-            [0.12287933, 0.17060205, 0.17152248],
-            [0.11121435, 0.15392100, 0.16234423],
-            [0.11051545, 0.15288580, 0.16170497],
-        ]
-    )
-
-    # Keep the TDAstro results in f_lambda units to compare with sncosmo.
-    state = model.sample_parameters()
-    flux = model.compute_flux(times, waves, state, use_flam=True)
-    assert np.allclose(flux * 1e12, expected_times_1e12)
-
-
 def test_salt2_model_parity(test_data_dir):
-    """Test loading a SALT2 object from a file and test we get the same
-    results as the sncosmo version.
-    """
-    dir_name = test_data_dir / "truncated-salt2-h17"
-    td_model = SALT2JaxModel(x0=0.4, x1=0.3, c=1.1, model_dir=dir_name)
-    sn_model = SALT2Source(modeldir=dir_name)
-    sn_model.set(x0=0.4, x1=0.3, c=1.1)
-
-    # Test compared to values computed via sncosmo's implementation that
-    # fall within the range of the truncated grid. We multiple by 1e12
-    # for comparison precision purposes.
-    times = np.arange(-1.0, 15.0, 0.01)
-    waves = np.arange(3800.0, 4200.0, 0.5)
-
-    # Keep the TDAstro results in f_lambda units to compare with sncosmo.
-    state = td_model.sample_parameters()
-    flux_td = td_model.compute_flux(times, waves, state, use_flam=True)
-    flux_sn = sn_model._flux(times, waves)
-    assert np.allclose(flux_td * 1e12, flux_sn * 1e12)
-
-
-def test_salt2_model_parity_fnu(test_data_dir):
     """Test loading a SALT2 object from a file and test we get the same
     results as the sncosmo version.
     """
@@ -77,7 +26,7 @@ def test_salt2_model_parity_fnu(test_data_dir):
     # Allow TDAstro to return both sets of results in f_nu.
     flux_td = td_model.evaluate(times, waves)
     flux_sn = sn_model.evaluate(times, waves)
-    assert np.allclose(flux_td * 1e12, flux_sn * 1e12)
+    assert np.allclose(flux_td, flux_sn)
 
 
 def test_salt2_no_model(test_data_dir):


### PR DESCRIPTION
Change the default units for the JAX Salt2 model to nJy. Updates the unit test to compare against the wrapped sncosmo SALT2 instead of the raw sncosmo code.