### PR TITLE
Small restructuring of passbands

### DIFF
--- a/tests/tdastro/astro_utils/test_passband_groups.py
+++ b/tests/tdastro/astro_utils/test_passband_groups.py
@@ -289,16 +289,14 @@ def test_passband_group_calculate_in_band_wave_indices(passbands_dir, tmp_path):
 
     # Note that passband_A and passband_B have overlapping wavelength ranges
     # Where passband_A covers 100-300 and passband_B covers 250-350 (and passband_C covers 400-600)
-    np.testing.assert_allclose(
-        passband_A._in_band_wave_indices, np.array([0, 1, 2, 3, 4, 5, 6, 7, 9, 11, 13])
-    )
-    np.testing.assert_allclose(passband_A.waves, toy_passband_group.waves[passband_A._in_band_wave_indices])
+    toy_a_inds = toy_passband_group._in_band_wave_indices["TOY_a"]
+    np.testing.assert_allclose(toy_a_inds, np.array([0, 1, 2, 3, 4, 5, 6, 7, 9, 11, 13]))
+    np.testing.assert_allclose(passband_A.waves, toy_passband_group.waves[toy_a_inds])
 
-    np.testing.assert_allclose(passband_B._in_band_wave_indices, np.array([8, 10, 12, 14, 15, 16]))
-    np.testing.assert_allclose(passband_B.waves, toy_passband_group.waves[passband_B._in_band_wave_indices])
+    toy_b_inds = toy_passband_group._in_band_wave_indices["TOY_b"]
+    np.testing.assert_allclose(toy_b_inds, np.array([8, 10, 12, 14, 15, 16]))
+    np.testing.assert_allclose(passband_B.waves, toy_passband_group.waves[toy_b_inds])
 
-    assert passband_C._in_band_wave_indices == slice(17, 28)
-    np.testing.assert_allclose(
-        passband_C.waves,
-        toy_passband_group.waves[passband_C._in_band_wave_indices],
-    )
+    toy_c_inds = toy_passband_group._in_band_wave_indices["TOY_c"]
+    assert toy_c_inds == slice(17, 28)
+    np.testing.assert_allclose(passband_C.waves, toy_passband_group.waves[toy_c_inds])


### PR DESCRIPTION
Two small changes to the passbands code:
1) Move the `_in_band_wave_indices` from the passbands to the passband group for better encapsulation. The passbands do not need to know anything about the large group they are in.
2) Combine two preprocessing functions that should always be called together.