### PR TITLE
Create batch versions of multiple evaluation functions

### DIFF
--- a/src/tdastro/astro_utils/passbands.py
+++ b/src/tdastro/astro_utils/passbands.py
@@ -591,16 +591,31 @@ class Passband:
         Parameters
         ----------
         flux_density_matrix : np.ndarray
-            A 2D array of flux densities where rows are times and columns are wavelengths.
+            A 2D or 3D array of flux densities. If the array is 2D is contains a single sample where
+            the rows are the T times and columns are M wavelengths. If the array is 3D it contains S
+            samples and the values are indexed as (sample_num, time, wavelength).
 
         Returns
         -------
-        np.ndarray
-            An array of bandfluxes with length flux_density_matrix, where each element is the bandflux
-            at the corresponding time.
+        bandfluxes : np.ndarray
+            A 1D or 2D array. If the flux_density_matrix contains a single sample (2D input) then
+            the function returns a 1D length T array where each element is the bandflux
+            at the corresponding time. Otherwise the function returns a size S x T array where
+            each entry corresponds to the value for a given sample at a given time.
         """
-        if flux_density_matrix.size == 0 or len(self.waves) != len(flux_density_matrix[0]):
-            flux_density_matrix_num_cols = 0 if flux_density_matrix.size == 0 else len(flux_density_matrix[0])
+        if flux_density_matrix.size == 0:
+            raise ValueError("Empty flux density matrix used.")
+        if len(flux_density_matrix.shape) == 2:
+            w_axis = 1
+            flux_density_matrix_num_cols = flux_density_matrix.shape[1]
+        elif len(flux_density_matrix.shape) == 3:
+            w_axis = 2
+            flux_density_matrix_num_cols = flux_density_matrix.shape[2]
+        else:
+            raise ValueError("Invalid flux density matrix. Must be 2 or 3-dimensional.")
+
+        # Check the number of wavelengths match.
+        if len(self.waves) != flux_density_matrix_num_cols:
             raise ValueError(
                 f"Passband mismatched grids: Flux density matrix has {flux_density_matrix_num_cols} "
                 f"columns, which does not match the {len(self.waves)} rows in band {self.full_name}'s "
@@ -612,6 +627,5 @@ class Passband:
         # Calculate the bandflux as ∫ f(λ)φ_b(λ) dλ,
         # where f(λ) is the flux density and φ_b(λ) is the normalized system response
         integrand = flux_density_matrix * self.processed_transmission_table[:, 1]
-        bandfluxes = scipy.integrate.trapezoid(integrand, x=self.waves)
-
+        bandfluxes = scipy.integrate.trapezoid(integrand, x=self.waves, axis=w_axis)
         return bandfluxes

--- a/src/tdastro/astro_utils/passbands.py
+++ b/src/tdastro/astro_utils/passbands.py
@@ -591,7 +591,7 @@ class Passband:
         Parameters
         ----------
         flux_density_matrix : np.ndarray
-            A 2D or 3D array of flux densities. If the array is 2D is contains a single sample where
+            A 2D or 3D array of flux densities. If the array is 2D it contains a single sample where
             the rows are the T times and columns are M wavelengths. If the array is 3D it contains S
             samples and the values are indexed as (sample_num, time, wavelength).
 

--- a/src/tdastro/sources/physical_model.py
+++ b/src/tdastro/sources/physical_model.py
@@ -141,7 +141,8 @@ class PhysicalModel(ParameterizedNode):
         Returns
         -------
         flux_density : `numpy.ndarray`
-            A length S x T x N matrix of SED values (in nJy). Where S is the number of samples.
+            A length S x T x N matrix of SED values (in nJy), where S is the number of samples, 
+            T is the number of time steps, and N is the number of wavelengths.
             If S=1 then the function returns a T x N matrix.
         """
         # Make sure times and wavelengths are numpy arrays.

--- a/src/tdastro/sources/physical_model.py
+++ b/src/tdastro/sources/physical_model.py
@@ -141,7 +141,7 @@ class PhysicalModel(ParameterizedNode):
         Returns
         -------
         flux_density : `numpy.ndarray`
-            A length S x T x N matrix of SED values (in nJy), where S is the number of samples, 
+            A length S x T x N matrix of SED values (in nJy), where S is the number of samples,
             T is the number of time steps, and N is the number of wavelengths.
             If S=1 then the function returns a T x N matrix.
         """

--- a/tests/tdastro/astro_utils/test_passbands.py
+++ b/tests/tdastro/astro_utils/test_passbands.py
@@ -395,6 +395,36 @@ def test_passband_fluxes_to_bandflux(passbands_dir, tmp_path):
     assert len(in_band_flux) == 5
 
 
+def test_passband_fluxes_to_bandflux_mult_samples(passbands_dir, tmp_path):
+    """Test the fluxes_to_bandflux method of the Passband class with multiple samples."""
+    transmission_table = "100 0.5\n200 0.75\n300 0.25\n"
+    a_band = create_toy_passband(tmp_path, transmission_table, delta_wave=100, trim_quantile=None)
+
+    # Define some mock flux values and calculate our expected bandflux
+    flux = np.array(
+        [
+            [
+                [1.0, 1.0, 1.0],
+                [2.0, 1.0, 1.0],
+                [3.0, 1.0, 1.0],
+                [2.0, 1.0, 1.0],
+                [1.0, 1.0, 1.0],
+            ],
+            [
+                [2.0, 2.0, 2.0],
+                [4.0, 2.0, 2.0],
+                [6.0, 2.0, 2.0],
+                [4.0, 2.0, 2.0],
+                [2.0, 2.0, 2.0],
+            ],
+        ]
+    )
+    expected = np.array([[1.0, 1.375, 1.75, 1.375, 1.0], [2.0, 2.75, 3.5, 2.75, 2.0]])
+
+    result = a_band.fluxes_to_bandflux(flux)
+    np.testing.assert_allclose(result, expected)
+
+
 def test_passband_wrapped_from_physical_source(passbands_dir, tmp_path):
     """Test get_band_fluxes, PhysicalModel's wrapped version of Passband's fluxes_to_bandflux.."""
     # Set up physical model


### PR DESCRIPTION
Closes #192 

Allow a GraphState with multiple samples to be passed to `PhysicalModel.evaluate()` and `PhysicalModel.get_band_fluxes()`. In the process update `Passband.fluxes_to_bandflux()` so that it can also process a batch of samples at once.