### PR TITLE
update PhysicalModel.get_band_fluxes() in physical_model.py

### DIFF
--- a/src/tdastro/sources/physical_model.py
+++ b/src/tdastro/sources/physical_model.py
@@ -274,10 +274,14 @@ class PhysicalModel(ParameterizedNode):
 
         band_fluxes = np.empty((state.num_samples, len(times)))
         for filter_name in np.unique(filters):
-            passband = passband_or_group.passbands[filter_name]
-            filter_mask = filters == filter_name
-            spectral_fluxes = self.evaluate(times[filter_mask], passband.waves, state)
-            band_fluxes[:, filter_mask] = passband.fluxes_to_bandflux(spectral_fluxes)
+            if filter_name in passband_or_group.passbands:
+                passband = passband_or_group.passbands[filter_name]
+                filter_mask = filters == filter_name
+                spectral_fluxes = self.evaluate(times[filter_mask], passband.waves, state)
+                band_fluxes[:, filter_mask] = passband.fluxes_to_bandflux(spectral_fluxes)
+            else:
+                filter_mask = filters == filter_name
+                band_fluxes[:, filter_mask] = np.nan
 
         if state.num_samples == 1:
             return band_fluxes[0, :]


### PR DESCRIPTION
An error occured when `filter_name` in opsim was not included in PassbandGroup when calculating the fluxes using PhysicalModel.get_band_fluxes(). I added a check.