### PR TITLE
Expand documentation of the inherited parameterized values

### DIFF
--- a/src/tdastro/base_models.py
+++ b/src/tdastro/base_models.py
@@ -243,6 +243,39 @@ class ParameterizedNode:
             if setter_info.dependency is not None and setter_info.dependency is not self:
                 setter_info.dependency.set_graph_positions(seen_nodes)
 
+    def list_params(self):
+        """Return a list of this node's parameterized values.
+
+        Returns
+        -------
+        names : list[str]
+            The name of all of the parameterized values for this node.
+        """
+        return list(self.setters.keys())
+
+    def has_valid_param(self, name):
+        """Check whether the node has a given parameterized value and that it is not
+        always set to None.
+
+        Parameters
+        ----------
+        name : str
+            The name of the parameter.
+
+        Returns
+        -------
+        contains : bool
+            Whether the node contains a given parameter and it is not always None.
+        """
+        if name not in self.setters:
+            return False
+
+        setter = self.setters[name]
+        if setter.source_type == ParameterSource.CONSTANT and setter.value is None:
+            return False
+
+        return True
+
     def get_param(self, graph_state, name, default=None):
         """Get the value of a parameter stored in this node or a default value.
 

--- a/src/tdastro/sources/galaxy_models.py
+++ b/src/tdastro/sources/galaxy_models.py
@@ -5,15 +5,24 @@ from tdastro.sources.physical_model import PhysicalModel
 
 
 class GaussianGalaxy(PhysicalModel):
-    """A static source.
+    """A galaxy with constant brightness that falls of as a Guassian
+    as the distance from the center increases.
+
+    Parameterized values include:
+      * brightness - The inherent brightness at the center of the galaxy.
+      * dec - The object's declination in degrees. [from PhysicalModel]
+      * distance - The object's luminosity distance in pc. [from PhysicalModel]
+      * galaxy_radius_std - The standard deviation of the brightness in degrees.
+      * ra - The object's right ascension in degrees. [from PhysicalModel]
+      * redshift - The object's redshift. [from PhysicalModel]
 
     Parameters
     ----------
-    radius_std : `float`
-        The standard deviation of the brightness as we move away
-        from the galaxy's center (in degrees).
     brightness : `float`
         The inherent brightness at the center of the galaxy.
+    radius : `float`
+        The standard deviation of the brightness as we move away
+        from the galaxy's center (in degrees).
     **kwargs : `dict`, optional
         Any additional keyword arguments.
     """

--- a/src/tdastro/sources/periodic_source.py
+++ b/src/tdastro/sources/periodic_source.py
@@ -6,6 +6,14 @@ from tdastro.sources.physical_model import PhysicalModel
 class PeriodicSource(PhysicalModel, ABC):
     """A periodic source.
 
+    Parameterized values include:
+      * dec - The object's declination in degrees. [from PhysicalModel]
+      * distance - The object's luminosity distance in pc. [from PhysicalModel]
+      * period - The period of the source, in days.
+      * ra - The object's right ascension in degrees. [from PhysicalModel]
+      * redshift - The object's redshift. [from PhysicalModel]
+      * t0 - The t0 of the zero phase, date.
+
     Parameters
     ----------
     period : `float`

--- a/src/tdastro/sources/periodic_variable_star.py
+++ b/src/tdastro/sources/periodic_variable_star.py
@@ -10,6 +10,14 @@ from tdastro.sources.periodic_source import PeriodicSource
 class PeriodicVariableStar(PeriodicSource, ABC):
     """A model for a periodic variable star.
 
+    Parameterized values include:
+      * dec - The object's declination in degrees. [from PhysicalModel]
+      * distance - The object's luminosity distance in pc. [from PhysicalModel]
+      * period - The period of the source, in days. [from PeriodicSource]
+      * ra - The object's right ascension in degrees. [from PhysicalModel]
+      * redshift - The object's redshift. [from PhysicalModel]
+      * t0 - The t0 of the zero phase, date. [from PeriodicSource]
+
     Attributes
     ----------
     period : `float`
@@ -23,7 +31,7 @@ class PeriodicVariableStar(PeriodicSource, ABC):
 
     def __init__(self, period, t0, **kwargs):
         super().__init__(period, t0, **kwargs)
-        if "distance" not in self.setters:
+        if not self.has_valid_param("distance"):
             raise ValueError("Distance parameter is required for PeriodicVariableStar")
 
     def _evaluate_phases(self, phases, wavelengths, graph_state, **kwargs):
@@ -87,6 +95,20 @@ class EclipsingBinaryStar(PeriodicVariableStar):
     It is assumed that the stars are spherical, SED is black-body,
     and the orbits are circular. t0 is the epoch of the primary minimum.
     No limb darkening, reflection, or other effects are included.
+
+    Parameterized values include:
+      * dec - The object's declination in degrees. [from PhysicalModel]
+      * distance - The object's luminosity distance in pc. [from PhysicalModel]
+      * inclination - The inclination of the orbit, in degrees.
+      * major_semiaxis - The major semiaxis of the orbit, in AU.
+      * period - The period of the source, in days. [from PeriodicSource]
+      * primary_radius - The radius of the primary star, in solar radii.
+      * primary_temperature - The effective temperature of the primary star, in kelvins.
+      * ra - The object's right ascension in degrees. [from PhysicalModel]
+      * redshift - The object's redshift. [from PhysicalModel]
+      * secondary_radius - The radius of the secondary star, in solar radii.
+      * secondary_temperature - The effective temperature of the secondary star, in kelvins.
+      * t0 - The t0 of the zero phase, date. [from PeriodicSource]
 
     Attributes
     ----------

--- a/src/tdastro/sources/physical_model.py
+++ b/src/tdastro/sources/physical_model.py
@@ -21,6 +21,12 @@ class PhysicalModel(ParameterizedNode):
 
     Physical models also support adding and applying a variety of effects, such as redshift.
 
+    Parameterized values include:
+      * dec - The object's declination in degrees.
+      * distance - The object's luminosity distance in pc.
+      * ra - The object's right ascension in degrees.
+      * redshift - The object's redshift.
+
     Attributes
     ----------
     background : `PhysicalModel`

--- a/src/tdastro/sources/salt2_jax.py
+++ b/src/tdastro/sources/salt2_jax.py
@@ -28,6 +28,16 @@ class SALT2JaxModel(PhysicalModel):
     The wrapped sncosmo version in sncosmo_models.py is faster and should be used
     when auto-differentiation is not needed.
 
+    Parameterized values include:
+      * c - The SALT2 c parameter.
+      * dec - The object's declination in degrees. [from PhysicalModel]
+      * distance - The object's luminosity distance in pc. [from PhysicalModel]
+      * period - The period of the source, in days.
+      * ra - The object's right ascension in degrees. [from PhysicalModel]
+      * redshift - The object's redshift. [from PhysicalModel]
+      * x0 - The SALT2 x0 parameter.
+      * x1 - The SALT2 x0 parameter.
+
     Attributes
     ----------
     _m0_model : BicubicInterpolator

--- a/src/tdastro/sources/sncomso_models.py
+++ b/src/tdastro/sources/sncomso_models.py
@@ -14,6 +14,14 @@ from tdastro.sources.physical_model import PhysicalModel
 class SncosmoWrapperModel(PhysicalModel):
     """A wrapper for sncosmo models.
 
+    Parameterized values include:
+      * dec - The object's declination in degrees. [from PhysicalModel]
+      * distance - The object's luminosity distance in pc. [from PhysicalModel]
+      * ra - The object's right ascension in degrees. [from PhysicalModel]
+      * redshift - The object's redshift. [from PhysicalModel]
+      * t0 - The t0 of the zero phase, date.
+    Additional parameterized values are used for specific sncosmo models.
+
     Attributes
     ----------
     source : `sncosmo.Source`

--- a/src/tdastro/sources/snia_host.py
+++ b/src/tdastro/sources/snia_host.py
@@ -2,8 +2,14 @@ from tdastro.sources.physical_model import PhysicalModel
 
 
 class SNIaHost(PhysicalModel):
-    """
-    A SN Ia host galaxy model with a hostmass parameter, more to be added.
+    """A SN Ia host galaxy model with a hostmass parameter, more to be added.
+
+    Parameterized values include:
+      * dec - The object's declination in degrees. [from PhysicalModel]
+      * distance - The object's luminosity distance in pc. [from PhysicalModel]
+      * hostmass - The hostmass value.
+      * ra - The object's right ascension in degrees. [from PhysicalModel]
+      * redshift - The object's redshift. [from PhysicalModel]
     """
 
     def __init__(self, **kwargs):

--- a/src/tdastro/sources/spline_model.py
+++ b/src/tdastro/sources/spline_model.py
@@ -15,6 +15,13 @@ class SplineModel(PhysicalModel):
     points are fit by a spline. Based on sncosmo's TimeSeriesSource:
     https://github.com/sncosmo/sncosmo/blob/v2.10.1/sncosmo/models.py
 
+    Parameterized values include:
+      * amplitude - A unitless scaling parameter for the flux density values.
+      * dec - The object's declination in degrees. [from PhysicalModel]
+      * distance - The object's luminosity distance in pc. [from PhysicalModel]
+      * ra - The object's right ascension in degrees. [from PhysicalModel]
+      * redshift - The object's redshift. [from PhysicalModel]
+
     Attributes
     ----------
     _times : `numpy.ndarray`

--- a/src/tdastro/sources/static_source.py
+++ b/src/tdastro/sources/static_source.py
@@ -6,6 +6,13 @@ from tdastro.sources.physical_model import PhysicalModel
 class StaticSource(PhysicalModel):
     """A static source.
 
+    Parameterized values include:
+      * brightness - The inherent brightness
+      * dec - The object's declination in degrees. [from PhysicalModel]
+      * distance - The object's luminosity distance in pc. [from PhysicalModel]
+      * ra - The object's right ascension in degrees. [from PhysicalModel]
+      * redshift - The object's redshift. [from PhysicalModel]
+
     Parameters
     ----------
     brightness : `float`

--- a/src/tdastro/sources/step_source.py
+++ b/src/tdastro/sources/step_source.py
@@ -6,14 +6,23 @@ from tdastro.sources.static_source import StaticSource
 class StepSource(StaticSource):
     """A static source that is on for a fixed amount of time
 
+    Parameterized values include:
+      * brightness - The inherent brightness
+      * dec - The object's declination in degrees. [from PhysicalModel]
+      * distance - The object's luminosity distance in pc. [from PhysicalModel]
+      * ra - The object's right ascension in degrees. [from PhysicalModel]
+      * redshift - The object's redshift. [from PhysicalModel]
+      * t0 - The time the step function starts, in MJD.
+      * t1- The time the step function ends, in MJD.
+
     Parameters
     ----------
     brightness : `float`
         The inherent brightness
     t0 : `float`
-        The time the step function starts
+        The time the step function starts, in MJD.
     t1 : `float`
-        The time the step function ends
+        The time the step function ends, in MJD.
     **kwargs : `dict`, optional
         Any additional keyword arguments.
     """

--- a/tests/tdastro/math_nodes/test_single_value_node.py
+++ b/tests/tdastro/math_nodes/test_single_value_node.py
@@ -5,6 +5,17 @@ def test_single_variable_node():
     """Test that we can create and query a SingleVariableNode."""
     node = SingleVariableNode("A", 10.0)
     assert str(node) == "SingleVariableNode"
+    assert node.has_valid_param("A")
 
     state = node.sample_parameters()
     assert node.get_param(state, "A") == 10
+
+
+def test_single_variable_node_none():
+    """Test that we can create and query a SingleVariableNode with
+    a constant value of None."""
+    node = SingleVariableNode("A", None)
+    assert not node.has_valid_param("A")
+
+    state = node.sample_parameters()
+    assert node.get_param(state, "A") is None

--- a/tests/tdastro/sources/test_physical_models.py
+++ b/tests/tdastro/sources/test_physical_models.py
@@ -16,6 +16,8 @@ def test_physical_model():
     assert model1.get_param(state, "ra") == 1.0
     assert model1.get_param(state, "dec") == 2.0
     assert model1.get_param(state, "redshift") == 0.0
+    assert model1.get_param(state, "distance") is None
+    assert not model1.has_valid_param("distance")
     assert model1.apply_redshift
 
     # None of the parameters are in the PyTree.

--- a/tests/tdastro/test_base_models.py
+++ b/tests/tdastro/test_base_models.py
@@ -93,6 +93,12 @@ def test_parameterized_node():
     model1 = PairModel(value1=0.5, value2=0.5)
     assert str(model1) == "PairModel"
 
+    # Check that we can lookup parameters.
+    assert model1.has_valid_param("value1")
+    assert model1.has_valid_param("value2")
+    assert model1.has_valid_param("value_sum")
+    assert not model1.has_valid_param("value3")
+
     state = model1.sample_parameters()
     assert model1.get_param(state, "value1") == 0.5
     assert model1.get_param(state, "value2") == 0.5
@@ -106,6 +112,9 @@ def test_parameterized_node():
     # We use the default for un-assigned parameters.
     assert model1.get_param(state, "value3") is None
     assert model1.get_param(state, "value4", 1.0) == 1.0
+
+    # Check that we can list the parameters.
+    assert np.array_equal(model1.list_params(), ["value1", "value2", "value_sum"])
 
     # If we set a position (and there is no node_label), the position shows up in the name.
     model1.node_pos = 100


### PR DESCRIPTION
There is probably a better way to do this using meta-programming and inheriting part of the docstrings. But for now, we just list out the parameterized values that different `PhysicalModel` nodes have. This will help new users know what can be set.

Also add two helper functions:
- `list_params()` is for interactive development and debugging if a user wants to check what parameters are there (any node, not just a Physical Model).
- `has_valid_param()` performs a contains and a is not None check