### PR TITLE
Move t0 into PhysicalModel

### DIFF
--- a/src/tdastro/sources/galaxy_models.py
+++ b/src/tdastro/sources/galaxy_models.py
@@ -15,6 +15,7 @@ class GaussianGalaxy(PhysicalModel):
       * galaxy_radius_std - The standard deviation of the brightness in degrees.
       * ra - The object's right ascension in degrees. [from PhysicalModel]
       * redshift - The object's redshift. [from PhysicalModel]
+      * t0 - No effect for a GuassianGalaxy [from PhysicalModel]
 
     Parameters
     ----------

--- a/src/tdastro/sources/periodic_source.py
+++ b/src/tdastro/sources/periodic_source.py
@@ -17,10 +17,11 @@ class PeriodicSource(PhysicalModel, ABC):
         Any additional keyword arguments.
     """
 
-    def __init__(self, period, t0, **kwargs):
+    def __init__(self, period, **kwargs):
         super().__init__(**kwargs)
+
+        # t0 is added in the PhysicalModel constructor.
         self.add_parameter("period", period, **kwargs)
-        self.add_parameter("t0", t0, **kwargs)
 
     @abstractmethod
     def _evaluate_phases(self, phases, wavelengths, graph_state, **kwargs):

--- a/src/tdastro/sources/periodic_source.py
+++ b/src/tdastro/sources/periodic_source.py
@@ -12,15 +12,12 @@ class PeriodicSource(PhysicalModel, ABC):
       * period - The period of the source, in days.
       * ra - The object's right ascension in degrees. [from PhysicalModel]
       * redshift - The object's redshift. [from PhysicalModel]
-      * t0 - The t0 of the zero phase, date.
+      * t0 - The t0 of the zero phase, date. [from PhysicalModel]
 
     Parameters
     ----------
     period : `float`
         The period of the source, in days.
-    t0 : `float`
-        The t0 of the zero phase, date. Could be date of the minimum or maximum light
-        or any other reference time point.
     **kwargs : `dict`, optional
         Any additional keyword arguments.
     """

--- a/src/tdastro/sources/periodic_variable_star.py
+++ b/src/tdastro/sources/periodic_variable_star.py
@@ -31,7 +31,7 @@ class PeriodicVariableStar(PeriodicSource, ABC):
 
     def __init__(self, period, **kwargs):
         super().__init__(period, **kwargs)
-        if "distance" not in self.setters:
+        if not self.has_valid_param("distance"):
             raise ValueError("Distance parameter is required for PeriodicVariableStar")
 
     def _evaluate_phases(self, phases, wavelengths, graph_state, **kwargs):

--- a/src/tdastro/sources/periodic_variable_star.py
+++ b/src/tdastro/sources/periodic_variable_star.py
@@ -16,7 +16,7 @@ class PeriodicVariableStar(PeriodicSource, ABC):
       * period - The period of the source, in days. [from PeriodicSource]
       * ra - The object's right ascension in degrees. [from PhysicalModel]
       * redshift - The object's redshift. [from PhysicalModel]
-      * t0 - The t0 of the zero phase, date. [from PeriodicSource]
+      * t0 - The t0 of the zero phase, date. [from PhysicalModel]
 
     Attributes
     ----------

--- a/src/tdastro/sources/periodic_variable_star.py
+++ b/src/tdastro/sources/periodic_variable_star.py
@@ -21,8 +21,8 @@ class PeriodicVariableStar(PeriodicSource, ABC):
         The distance to the source, in pc.
     """
 
-    def __init__(self, period, t0, **kwargs):
-        super().__init__(period, t0, **kwargs)
+    def __init__(self, period, **kwargs):
+        super().__init__(period, **kwargs)
         if "distance" not in self.setters:
             raise ValueError("Distance parameter is required for PeriodicVariableStar")
 

--- a/src/tdastro/sources/physical_model.py
+++ b/src/tdastro/sources/physical_model.py
@@ -26,6 +26,7 @@ class PhysicalModel(ParameterizedNode):
       * distance - The object's luminosity distance in pc.
       * ra - The object's right ascension in degrees.
       * redshift - The object's redshift.
+      * t0 - The t0 of the zero phase, date.
 
     Attributes
     ----------

--- a/src/tdastro/sources/physical_model.py
+++ b/src/tdastro/sources/physical_model.py
@@ -36,6 +36,8 @@ class PhysicalModel(ParameterizedNode):
         The object's declination (in degrees)
     redshift : `float`
         The object's redshift.
+    t0 : `float`
+        The phase offset in MJD. Default: 0.0
     distance : `float`
         The object's luminosity distance (in pc). If no value is provided and
         a ``cosmology`` parameter is given, the model will try to derive from
@@ -46,13 +48,14 @@ class PhysicalModel(ParameterizedNode):
         Any additional keyword arguments.
     """
 
-    def __init__(self, ra=None, dec=None, redshift=None, distance=None, background=None, **kwargs):
+    def __init__(self, ra=None, dec=None, redshift=None, t0=0.0, distance=None, background=None, **kwargs):
         super().__init__(**kwargs)
 
         # Set RA, dec, and redshift from the parameters.
         self.add_parameter("ra", ra, allow_gradient=False)
         self.add_parameter("dec", dec, allow_gradient=False)
         self.add_parameter("redshift", redshift, allow_gradient=False)
+        self.add_parameter("t0", t0, allow_gradient=False)
 
         # If the luminosity distance is provided, use that. Otherwise try the
         # redshift value using the cosmology (if given). Finally, default to None.

--- a/src/tdastro/sources/physical_model.py
+++ b/src/tdastro/sources/physical_model.py
@@ -26,7 +26,7 @@ class PhysicalModel(ParameterizedNode):
       * distance - The object's luminosity distance in pc.
       * ra - The object's right ascension in degrees.
       * redshift - The object's redshift.
-      * t0 - The t0 of the zero phase, date.
+      * t0 - The t0 of the zero phase (if applicable), date.
 
     Attributes
     ----------
@@ -44,7 +44,8 @@ class PhysicalModel(ParameterizedNode):
     redshift : `float`
         The object's redshift.
     t0 : `float`
-        The phase offset in MJD. Default: 0.0
+        The phase offset in MJD. For non-time-varying phenomena, this has no effect.
+        Default: 0.0
     distance : `float`
         The object's luminosity distance (in pc). If no value is provided and
         a ``cosmology`` parameter is given, the model will try to derive from
@@ -62,7 +63,7 @@ class PhysicalModel(ParameterizedNode):
         self.add_parameter("ra", ra, allow_gradient=False)
         self.add_parameter("dec", dec, allow_gradient=False)
         self.add_parameter("redshift", redshift, allow_gradient=False)
-        self.add_parameter("t0", t0, allow_gradient=False)
+        self.add_parameter("t0", t0)
 
         # If the luminosity distance is provided, use that. Otherwise try the
         # redshift value using the cosmology (if given). Finally, default to None.

--- a/src/tdastro/sources/physical_model.py
+++ b/src/tdastro/sources/physical_model.py
@@ -45,7 +45,6 @@ class PhysicalModel(ParameterizedNode):
         The object's redshift.
     t0 : `float`
         The phase offset in MJD. For non-time-varying phenomena, this has no effect.
-        Default: 0.0
     distance : `float`
         The object's luminosity distance (in pc). If no value is provided and
         a ``cosmology`` parameter is given, the model will try to derive from
@@ -56,7 +55,7 @@ class PhysicalModel(ParameterizedNode):
         Any additional keyword arguments.
     """
 
-    def __init__(self, ra=None, dec=None, redshift=None, t0=0.0, distance=None, background=None, **kwargs):
+    def __init__(self, ra=None, dec=None, redshift=None, t0=None, distance=None, background=None, **kwargs):
         super().__init__(**kwargs)
 
         # Set RA, dec, and redshift from the parameters.

--- a/src/tdastro/sources/physical_model.py
+++ b/src/tdastro/sources/physical_model.py
@@ -97,6 +97,25 @@ class PhysicalModel(ParameterizedNode):
         """
         self.apply_redshift = apply_redshift
 
+    def mask_by_time(self, times, graph_state=None):
+        """Compute a mask for whether a given time is of interest for a given object.
+        For example, a user can use this function to generate a mask to include
+        only the observations of interest for a window around the supernova.
+
+        Parameters
+        ----------
+        times : numpy.ndarray
+            A length T array of observer frame timestamps in MJD.
+        graph_state : GraphState, optional
+            An object mapping graph parameters to their values.
+
+        Returns
+        -------
+        time_mask : numpy.ndarray
+            A length T array of Booleans indicating whether the time is of interest.
+        """
+        return np.full(len(times), True)
+
     def compute_flux(self, times, wavelengths, graph_state):
         """Draw effect-free rest frame flux densities.
         The rest-frame flux is defined as F_nu = L_nu / 4*pi*D_L**2,
@@ -105,7 +124,7 @@ class PhysicalModel(ParameterizedNode):
         Parameters
         ----------
         times : `numpy.ndarray`
-            A length T array of rest frame timestamps.
+            A length T array of rest frame timestamps in MJD.
         wavelengths : `numpy.ndarray`, optional
             A length N array of rest frame wavelengths (in angstroms).
         graph_state : `GraphState`
@@ -124,7 +143,7 @@ class PhysicalModel(ParameterizedNode):
         Parameters
         ----------
         times : `numpy.ndarray`
-            A length T array of observer frame timestamps.
+            A length T array of observer frame timestamps in MJD.
         wavelengths : `numpy.ndarray`, optional
             A length N array of wavelengths (in angstroms).
         graph_state : `GraphState`, optional
@@ -245,7 +264,7 @@ class PhysicalModel(ParameterizedNode):
         passband_or_group : `Passband` or `PassbandGroup`
             The passband (or passband group) to use.
         times : `numpy.ndarray`
-            A length T array of observer frame timestamps.
+            A length T array of observer frame timestamps in MJD.
         filters : `numpy.ndarray` or None
             A length T array of filter names. It may be None if
             passband_or_group is a Passband.

--- a/src/tdastro/sources/salt2_jax.py
+++ b/src/tdastro/sources/salt2_jax.py
@@ -45,9 +45,6 @@ class SALT2JaxModel(PhysicalModel):
         The SALT2 x1 parameter.
     c : parameter
         The SALT2 c parameter.
-    t0 : parameter
-        The start time of the supernova in MJD.
-        Default: 0.0
     model_dir : `str`
         The path for the model file directory.
         Default: ""
@@ -85,7 +82,6 @@ class SALT2JaxModel(PhysicalModel):
         self.add_parameter("x0", x0, **kwargs)
         self.add_parameter("x1", x1, **kwargs)
         self.add_parameter("c", c, **kwargs)
-        self.add_parameter("t0", t0, **kwargs)
 
         # Load the data files.
         model_path = Path(model_dir)
@@ -118,15 +114,15 @@ class SALT2JaxModel(PhysicalModel):
         time_mask : numpy.ndarray
             A length T array of Booleans indicating whether the time is of interest.
         """
-        if graph_state is not None:
-            # If we have the graph state, extract the sampled parameters from that.
-            z = self.get_param(graph_state, "redshift", 0.0)
-            z = z if z is not None else 0.0
+        if graph_state is None:
+            raise ValueError("graph_state needed to compute mask_by_time")
 
-            t0 = self.get_param(graph_state, "t0", 0.0)
-            t0 = t0 if t0 is not None else 0.0
-        else:
+        z = self.get_param(graph_state, "redshift", 0.0)
+        if z is None:
             z = 0.0
+
+        t0 = self.get_param(graph_state, "t0", 0.0)
+        if t0 is None:
             t0 = 0.0
 
         # Compute the mask.

--- a/src/tdastro/sources/salt2_jax.py
+++ b/src/tdastro/sources/salt2_jax.py
@@ -35,6 +35,7 @@ class SALT2JaxModel(PhysicalModel):
       * period - The period of the source, in days.
       * ra - The object's right ascension in degrees. [from PhysicalModel]
       * redshift - The object's redshift. [from PhysicalModel]
+      * t0 - The t0 of the zero phase, date. [from PhysicalModel]
       * x0 - The SALT2 x0 parameter.
       * x1 - The SALT2 x0 parameter.
 

--- a/src/tdastro/sources/sncomso_models.py
+++ b/src/tdastro/sources/sncomso_models.py
@@ -19,7 +19,7 @@ class SncosmoWrapperModel(PhysicalModel):
       * distance - The object's luminosity distance in pc. [from PhysicalModel]
       * ra - The object's right ascension in degrees. [from PhysicalModel]
       * redshift - The object's redshift. [from PhysicalModel]
-      * t0 - The t0 of the zero phase, date.
+      * t0 - The t0 of the zero phase, date. [from PhysicalModel]
     Additional parameterized values are used for specific sncosmo models.
 
     Attributes

--- a/src/tdastro/sources/snia_host.py
+++ b/src/tdastro/sources/snia_host.py
@@ -10,6 +10,7 @@ class SNIaHost(PhysicalModel):
       * hostmass - The hostmass value.
       * ra - The object's right ascension in degrees. [from PhysicalModel]
       * redshift - The object's redshift. [from PhysicalModel]
+      * t0 - The t0 of the zero phase, date. [from PhysicalModel]
     """
 
     def __init__(self, **kwargs):

--- a/src/tdastro/sources/spline_model.py
+++ b/src/tdastro/sources/spline_model.py
@@ -21,6 +21,7 @@ class SplineModel(PhysicalModel):
       * distance - The object's luminosity distance in pc. [from PhysicalModel]
       * ra - The object's right ascension in degrees. [from PhysicalModel]
       * redshift - The object's redshift. [from PhysicalModel]
+      * t0 - The t0 of the zero phase, date. [from PhysicalModel]
 
     Attributes
     ----------

--- a/src/tdastro/sources/static_source.py
+++ b/src/tdastro/sources/static_source.py
@@ -12,6 +12,7 @@ class StaticSource(PhysicalModel):
       * distance - The object's luminosity distance in pc. [from PhysicalModel]
       * ra - The object's right ascension in degrees. [from PhysicalModel]
       * redshift - The object's redshift. [from PhysicalModel]
+      * t0 - No effect for static model. [from PhysicalModel]
 
     Parameters
     ----------

--- a/src/tdastro/sources/step_source.py
+++ b/src/tdastro/sources/step_source.py
@@ -18,9 +18,8 @@ class StepSource(StaticSource):
         Any additional keyword arguments.
     """
 
-    def __init__(self, brightness, t0, t1, **kwargs):
+    def __init__(self, brightness, t1, **kwargs):
         super().__init__(brightness, **kwargs)
-        self.add_parameter("t0", t0, **kwargs)
         self.add_parameter("t1", t1, **kwargs)
 
     def compute_flux(self, times, wavelengths, graph_state, **kwargs):

--- a/src/tdastro/sources/step_source.py
+++ b/src/tdastro/sources/step_source.py
@@ -20,6 +20,8 @@ class StepSource(StaticSource):
 
     def __init__(self, brightness, t1, **kwargs):
         super().__init__(brightness, **kwargs)
+
+        # t0 is added in the PhysicalModel constructor.
         self.add_parameter("t1", t1, **kwargs)
 
     def compute_flux(self, times, wavelengths, graph_state, **kwargs):

--- a/tests/tdastro/sources/test_physical_models.py
+++ b/tests/tdastro/sources/test_physical_models.py
@@ -54,6 +54,15 @@ def test_physical_model():
     assert model4.get_param(state, "distance") is None
 
 
+def test_physical_model_mask_by_time():
+    """Test that we can use the default mask_by_time() function."""
+    model = PhysicalModel(ra=1.0, dec=2.0, redshift=0.0)
+    times = np.arange(-10.0, 10.0, 0.5)
+
+    # By default use all times.
+    assert np.all(model.mask_by_time(times))
+
+
 def test_physical_model_evaluate():
     """Test that we can evaluate a PhysicalModel."""
     times = np.array([0.0, 1.0, 2.0, 3.0, 4.0])

--- a/tests/tdastro/sources/test_physical_models.py
+++ b/tests/tdastro/sources/test_physical_models.py
@@ -21,9 +21,9 @@ def test_physical_model():
     assert not model1.has_valid_param("distance")
     assert model1.apply_redshift
 
-    # None of the parameters are in the PyTree.
+    # Only the t0 parameter is in the PyTree.
     pytree = model1.build_pytree(state)
-    assert len(pytree["PhysicalModel_0"]) == 0
+    assert len(pytree["PhysicalModel_0"]) == 1
 
     # We can turn off the redshift computation.
     model1.set_apply_redshift(False)

--- a/tests/tdastro/sources/test_physical_models.py
+++ b/tests/tdastro/sources/test_physical_models.py
@@ -36,7 +36,7 @@ def test_physical_model():
     assert model2.get_param(state, "dec") == 2.0
     assert model2.get_param(state, "redshift") == 1100.0
     assert 13.0 * 1e12 < model2.get_param(state, "distance") < 16.0 * 1e12
-    assert model2.get_param(state, "t0") == 0.0
+    assert model2.get_param(state, "t0") is None
 
     # Check that the RedshiftDistFunc node has the same computed value.
     # The syntax is a bit ugly because we are checking internal state.

--- a/tests/tdastro/sources/test_physical_models.py
+++ b/tests/tdastro/sources/test_physical_models.py
@@ -10,12 +10,13 @@ from tdastro.sources.static_source import StaticSource
 def test_physical_model():
     """Test that we can create a PhysicalModel."""
     # Everything is specified.
-    model1 = PhysicalModel(ra=1.0, dec=2.0, redshift=0.0)
+    model1 = PhysicalModel(ra=1.0, dec=2.0, redshift=0.0, t0=1.0)
     state = model1.sample_parameters()
 
     assert model1.get_param(state, "ra") == 1.0
     assert model1.get_param(state, "dec") == 2.0
     assert model1.get_param(state, "redshift") == 0.0
+    assert model1.get_param(state, "t0") == 1.0
     assert model1.apply_redshift
 
     # None of the parameters are in the PyTree.
@@ -26,13 +27,14 @@ def test_physical_model():
     model1.set_apply_redshift(False)
     assert not model1.apply_redshift
 
-    # Derive the distance from the redshift.
+    # Derive the distance from the redshift. t0 is not given.
     model2 = PhysicalModel(ra=1.0, dec=2.0, redshift=1100.0, cosmology=Planck18)
     state = model2.sample_parameters()
     assert model2.get_param(state, "ra") == 1.0
     assert model2.get_param(state, "dec") == 2.0
     assert model2.get_param(state, "redshift") == 1100.0
     assert 13.0 * 1e12 < model2.get_param(state, "distance") < 16.0 * 1e12
+    assert model2.get_param(state, "t0") == 0.0
 
     # Check that the RedshiftDistFunc node has the same computed value.
     # The syntax is a bit ugly because we are checking internal state.

--- a/tests/tdastro/sources/test_salt2.py
+++ b/tests/tdastro/sources/test_salt2.py
@@ -10,11 +10,11 @@ def test_salt2_model_parity(test_data_dir):
     results as the sncosmo version.
     """
     dir_name = test_data_dir / "truncated-salt2-h17"
-    td_model = SALT2JaxModel(x0=0.4, x1=0.3, c=1.1, model_dir=dir_name)
+    td_model = SALT2JaxModel(x0=0.4, x1=0.3, c=1.1, t0=0.0, model_dir=dir_name)
 
     # We need to overwrite the source parameter to correspond to
     # the truncated directory data.
-    sn_model = SncosmoWrapperModel("SALT2", x0=0.4, x1=0.3, c=1.1)
+    sn_model = SncosmoWrapperModel("SALT2", x0=0.4, x1=0.3, c=1.1, t0=0.0)
     sn_model.source = SALT2Source(modeldir=dir_name)
 
     # Test compared to values computed via sncosmo's implementation that
@@ -33,4 +33,4 @@ def test_salt2_no_model(test_data_dir):
     """Test that we fail if using the wrong model directory."""
     dir_name = test_data_dir / "no_such_salt2_model_dir"
     with pytest.raises(FileNotFoundError):
-        _ = SALT2JaxModel(x0=0.5, x1=0.2, c=1.0, model_dir=dir_name)
+        _ = SALT2JaxModel(x0=0.5, x1=0.2, c=1.0, t0=0.0, model_dir=dir_name)

--- a/tests/tdastro/sources/test_sncosmo_models.py
+++ b/tests/tdastro/sources/test_sncosmo_models.py
@@ -31,6 +31,13 @@ def test_sncomso_models_hsiao() -> None:
     )
     assert np.allclose(fluxes_flam, [133.98143039, 152.74613574, 134.40916824])
 
+    # Check that we can mask times.  The 'hsiao' model uses phases (-20.0, 85.0).
+    sample_times = np.arange(-50.0, 100.0, 1.0)
+    mask = model.mask_by_time(sample_times, graph_state=state)
+
+    expected_mask = (sample_times > -20.0) & (sample_times < 85.0)
+    assert np.array_equal(mask, expected_mask)
+
 
 def test_sncomso_models_hsiao_t0() -> None:
     """Test that we can create and evalue a 'hsiao' model with a t0."""
@@ -55,6 +62,14 @@ def test_sncomso_models_hsiao_t0() -> None:
         fnu_unit=u.nJy,
     )
     assert np.allclose(fluxes_flam, [67.83696271, 67.98471119, 47.20395186])
+
+    # Check that we can mask times.  The 'hsiao' model uses phases (-20.0, 85.0),
+    # which is offset by t0=55000.0.
+    sample_times = np.arange(-50.0, 100.0, 1.0) + 55000.0
+    mask = model.mask_by_time(sample_times, graph_state=state)
+
+    expected_mask = (sample_times > 54980.0) & (sample_times < 55085.0)
+    assert np.array_equal(mask, expected_mask)
 
 
 def test_sncomso_models_set() -> None:

--- a/tests/tdastro/sources/test_sncosmo_models.py
+++ b/tests/tdastro/sources/test_sncosmo_models.py
@@ -7,7 +7,7 @@ from tdastro.sources.sncomso_models import SncosmoWrapperModel
 
 def test_sncomso_models_hsiao() -> None:
     """Test that we can create and evalue a 'hsiao' model."""
-    model = SncosmoWrapperModel("hsiao", amplitude=2.0e10)
+    model = SncosmoWrapperModel("hsiao", t0=0.0, amplitude=2.0e10)
     state = model.sample_parameters()
     assert model.get_param(state, "amplitude") == 2.0e10
     assert model.get_param(state, "t0") == 0.0
@@ -74,7 +74,7 @@ def test_sncomso_models_hsiao_t0() -> None:
 
 def test_sncomso_models_set() -> None:
     """Test that we can create and evalue a 'hsiao' model and set parameter."""
-    model = SncosmoWrapperModel("hsiao", redshift=0.5)
+    model = SncosmoWrapperModel("hsiao", t0=0.0, redshift=0.5)
 
     # sncosmo parameters exist at default values.
     assert np.array_equal(model.param_names, ["amplitude"])

--- a/tests/tdastro/sources/test_static_source.py
+++ b/tests/tdastro/sources/test_static_source.py
@@ -41,14 +41,15 @@ def test_static_source() -> None:
     assert np.all(values == 5.0)
 
 
-def test_test_physical_model_pytree():
+def test_static_source_pytree():
     """Test tthat the PyTree only contains brightness."""
     model = StaticSource(brightness=10.0, node_label="my_static_source")
     state = model.sample_parameters()
 
     pytree = model.build_pytree(state)
     assert pytree["my_static_source"]["brightness"] == 10.0
-    assert len(pytree["my_static_source"]) == 1
+    assert pytree["my_static_source"]["t0"] == 0.0
+    assert len(pytree["my_static_source"]) == 2
     assert len(pytree) == 1
 
 

--- a/tests/tdastro/sources/test_static_source.py
+++ b/tests/tdastro/sources/test_static_source.py
@@ -48,7 +48,7 @@ def test_static_source_pytree():
 
     pytree = model.build_pytree(state)
     assert pytree["my_static_source"]["brightness"] == 10.0
-    assert pytree["my_static_source"]["t0"] == 0.0
+    assert pytree["my_static_source"]["t0"] is None
     assert len(pytree["my_static_source"]) == 2
     assert len(pytree) == 1
 


### PR DESCRIPTION
Originally we decided not to include a `t0` parameter in the `PhysicalModel` class, because it won't be used by all models. However we currently fail if we apply redshift without a valid `t0`. This PR includes `t0` in the base `PhysicalModel` and sets it to 0.0 (no effect) by default.

We also use the occurrence of `t0` to allow filtering by time to match the time pruning done in @mi-dai 's notebook in #205. By default the `PhysicalModel` uses all times. But subclasses, such as sncosmo models, can add their own restrictions.