### PR TITLE
Add helper functions for the passband

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -149,5 +149,6 @@ _html/
 # Project initialization script
 .initialize_new_project.sh
 
-# Default cached location for passband tables
+# Default cached location for all data
+data/*
 src/tdastro/astro_utils/passbands/*

--- a/docs/notebooks/opsim_notebook.ipynb
+++ b/docs/notebooks/opsim_notebook.ipynb
@@ -209,7 +209,7 @@
    "source": [
     "## Filtering\n",
     "\n",
-    "Depending on the analysis we run, we might want to need to use only a subset of the data.  The `OpSim` class provides a helper function `filter_rows()` that can be used to filter the data in an `OpSim` and thus speed up subsequent operations."
+    "Depending on the analysis we run, we might want to need to use only a subset of the data.  The `OpSim` class provides a helper function `filter_rows()` that can be used to filter the data in an `OpSim` and thus speed up subsequent operations. This function creates a new copy of the data set with a subset of the rows."
    ]
   },
   {

--- a/docs/notebooks/passband-demo.ipynb
+++ b/docs/notebooks/passband-demo.ipynb
@@ -86,6 +86,22 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Individual passbands can also be accessed by the filter name as long as it is unique."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "passband_group[\"g\"].plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Manually specified passbands\n",
     "\n",
     "For testing, we might want to manually specify the passband information. We can do this by creating a 2-dimensional n umpy array where the first column is wavelength and the second column is transmission values."
@@ -242,6 +258,26 @@
     "bands_to_keep = [\"LSST_g\", \"LSST_r\", \"LSST_i\", \"LSST_y\"]\n",
     "passband_group.subset(bands_to_keep)\n",
     "passband_group.plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As the inverse of this, we might wish to filter a large data set so it contains only the passbands of interest. For example if we are running a simulation of Rubin data in only the r-filter, we do not care about the pointings in an OpSim (or any other data set) for every other filter. We can remove those at the start by masking them out.\n",
+    "\n",
+    "For example we could have a list of observing filters as shown below, but only be interested in the ones corresponding to our current passband group."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "obs_filters = [\"r\", \"g\", \"p\", \"q\", \"r\", \"x\", \"w\", \"r\", \"something else\"]\n",
+    "filter_mask = passband_group.mask_by_filter(obs_filters)\n",
+    "print(filter_mask)"
    ]
   },
   {

--- a/docs/notebooks/passband-demo.ipynb
+++ b/docs/notebooks/passband-demo.ipynb
@@ -102,6 +102,26 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "If we only care about a subset of passbands, such as a few filters, we can load only those using the `filters_to_load` parameter. This is particularly helpful in reducing the computational cost of the simulation as TDAstro will evaluate the sources on the **union** of wavelengths in the `PassbandGroup`. By dropping individual passbands, we reduce the number of wavelengths at which we evaluate the object."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "passband_group_rg = PassbandGroup(preset=\"LSST\", filters_to_load=[\"r\", \"g\"])\n",
+    "print(passband_group_rg)\n",
+    "\n",
+    "min_wave, max_wave = passband_group_rg.wave_bounds()\n",
+    "print(f\"Wavelengths range [{min_wave}, {max_wave}]\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Manually specified passbands\n",
     "\n",
     "For testing, we might want to manually specify the passband information. We can do this by creating a 2-dimensional n umpy array where the first column is wavelength and the second column is transmission values."
@@ -238,35 +258,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Modifying Passbands and PassbandGroups\n",
+    "## Filtering on Passband\n",
     "\n",
-    "In some cases we might want to modify the passband information to fit our use case. In this section we show how to perform several different modifications, including: filtering the passbands used, updating the wave grid, and trimming the passbands.\n",
+    "We might wish to filter a large data set so it contains only the passbands of interest. For example if we are running a simulation of Rubin data in only the r-filter, we do not care about the pointings in an OpSim (or any other data set) for every other filter. We can remove those at the start by masking them out.\n",
     "\n",
-    "### Filtering Passbands\n",
-    "\n",
-    "If our analysis is not using all of the bands defined in a passband group, we can create a subset of the passbands using `PassbandGroup`'s subset functionality. This will prune unused passbands, removing unneeded overhead of future computations.\n",
-    "\n",
-    "For example we could drop the LSST_u and LSST_z filters."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "bands_to_keep = [\"LSST_g\", \"LSST_r\", \"LSST_i\", \"LSST_y\"]\n",
-    "passband_group.subset(bands_to_keep)\n",
-    "passband_group.plot()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "As the inverse of this, we might wish to filter a large data set so it contains only the passbands of interest. For example if we are running a simulation of Rubin data in only the r-filter, we do not care about the pointings in an OpSim (or any other data set) for every other filter. We can remove those at the start by masking them out.\n",
-    "\n",
-    "For example we could have a list of observing filters as shown below, but only be interested in the ones corresponding to our current passband group."
+    "For example we could have a list of observing filters as shown below, but only be interested in the ones corresponding to our current passband group. These can then be feed into `OpSim`'s `filter_rows()` function."
    ]
   },
   {
@@ -284,13 +280,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Update Wave Grid"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
+    "## Modifying Passbands and PassbandGroups\n",
+    "\n",
+    "In some cases we might want to modify the passband information to fit our use case. In this section we show how to perform several different modifications, including: filtering the passbands used, updating the wave grid, and trimming the passbands.\n",
+    "\n",
+    "### Update Wave Grid\n",
+    "\n",
     "By increasing our `delta_wave` parameter, we increase the grid step of our transmission table, and the fluxes caluculated from `passband_group.waves`."
    ]
   },

--- a/docs/notebooks/passband-demo.ipynb
+++ b/docs/notebooks/passband-demo.ipynb
@@ -19,7 +19,7 @@
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
     "\n",
-    "from tdastro.astro_utils.passbands import PassbandGroup\n",
+    "from tdastro.astro_utils.passbands import Passband, PassbandGroup\n",
     "from tdastro.utils.plotting import plot_flux_spectrogram, plot_lightcurves"
    ]
   },
@@ -27,9 +27,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Set Up PassbandGroup\n",
+    "## Set Up PassbandGroup\n",
     "\n",
     "Both the `Passband` and `PassbandGroup` classes provide multiple mechanisms for loading in the passband information. Users can manually specify the passband values, load from given files, or load from a preset (which will download the files if needed).\n",
+    "\n",
+    "### Loading present passbands\n",
     "\n",
     "We start this notebook by loading the default passbands for LSST and printing basic information. "
    ]
@@ -84,9 +86,47 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Set Up Spline Model\n",
+    "### Manually specified passbands\n",
     "\n",
-    "Create a simple model to compute flux densities using a predefined spline."
+    "For testing, we might want to manually specify the passband information. We can do this by creating a 2-dimensional n umpy array where the first column is wavelength and the second column is transmission values."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "values = np.array(\n",
+    "    [\n",
+    "        [1000, 0.5],\n",
+    "        [1005, 0.6],\n",
+    "        [1010, 0.7],\n",
+    "        [1015, 0.5],\n",
+    "        [1020, 0.7],\n",
+    "        [1025, 0.8],\n",
+    "        [1030, 0.2],\n",
+    "        [1035, 0.2],\n",
+    "    ]\n",
+    ")\n",
+    "\n",
+    "toy_passband = Passband(\n",
+    "    \"toy_survey\",  # Survey name.\n",
+    "    \"a\",  # Filter name\n",
+    "    table_values=values,  # The matrix of transmission data\n",
+    ")\n",
+    "toy_passband.plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Applying Passbands\n",
+    "\n",
+    "In order to apply passbands, we first need a 2-dimensional matrix flux densities for different times and wavelengths. We can manually specify these or generate them with one of the physical models. \n",
+    "\n",
+    "In this example, we use simple model to compute flux densities using a predefined spline."
    ]
   },
   {
@@ -110,16 +150,19 @@
     "        [0.0, 0.0, 0.0, 0.0, 0.0],\n",
     "    ]\n",
     ")\n",
-    "spline_model = SplineModel(input_times, input_wavelengths, input_fluxes, time_degree=3, wave_degree=3)"
+    "spline_model = SplineModel(input_times, input_wavelengths, input_fluxes, time_degree=3, wave_degree=3)\n",
+    "\n",
+    "# Query the model at different time steps and all the wavelengths covered\n",
+    "# by the current passband group.\n",
+    "times = np.linspace(1000.0, 1006.0, 40)\n",
+    "fluxes = spline_model.evaluate(times, wavelengths)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Query and plot the model\n",
-    "\n",
-    "Generate the flux densities at a few points and the passband group's wavelengths. Plot the flux spectrogram."
+    "To visualize the flux densities, we plot the flux spectrogram."
    ]
   },
   {
@@ -128,9 +171,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "times = np.linspace(1000.0, 1006.0, 40)\n",
-    "fluxes = spline_model.evaluate(times, wavelengths)\n",
-    "\n",
     "plot_flux_spectrogram(fluxes, times, wavelengths, title=\"Flux Spectrogram\")"
    ]
   },
@@ -182,6 +222,32 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Modifying Passbands and PassbandGroups\n",
+    "\n",
+    "In some cases we might want to modify the passband information to fit our use case. In this section we show how to perform several different modifications, including: filtering the passbands used, updating the wave grid, and trimming the passbands.\n",
+    "\n",
+    "### Filtering Passbands\n",
+    "\n",
+    "If our analysis is not using all of the bands defined in a passband group, we can create a subset of the passbands using `PassbandGroup`'s subset functionality. This will prune unused passbands, removing unneeded overhead of future computations.\n",
+    "\n",
+    "For example we could drop the LSST_u and LSST_z filters."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bands_to_keep = [\"LSST_g\", \"LSST_r\", \"LSST_i\", \"LSST_y\"]\n",
+    "passband_group.subset(bands_to_keep)\n",
+    "passband_group.plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Update Wave Grid"
    ]
   },
@@ -212,6 +278,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Setting Trim Quantile\n",
+    "\n",
     "By setting our `trim_quantile` parameter to None, we disable the automatic trimming performed on transmission table to remove the upper and lower tails."
    ]
   },

--- a/docs/notebooks/passband-demo.ipynb
+++ b/docs/notebooks/passband-demo.ipynb
@@ -4,7 +4,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Passband Demo"
+    "# Passband Demo\n",
+    "\n",
+    "A `Passband` object stores the information needed to transform the observed flux density over multiple wavelengths into a single band flux for a given filter. A `PassbandGroup` object implements a collection of `Passband` providing convenient helper functions for loading and processing multiple passbands."
    ]
   },
   {
@@ -27,7 +29,9 @@
    "source": [
     "### Set Up PassbandGroup\n",
     "\n",
-    "Load the default passbands for LSST and get its wavelengths."
+    "Both the `Passband` and `PassbandGroup` classes provide multiple mechanisms for loading in the passband information. Users can manually specify the passband values, load from given files, or load from a preset (which will download the files if needed).\n",
+    "\n",
+    "We start this notebook by loading the default passbands for LSST and printing basic information. "
    ]
   },
   {
@@ -42,6 +46,38 @@
     "wavelengths = passband_group.waves\n",
     "min_wave, max_wave = passband_group.wave_bounds()\n",
     "print(f\"Wavelengths range [{min_wave}, {max_wave}]\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can access individual `Passband` objects with the [] notation and plot them using `Passband`'s plot functionality."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "passband_group[\"LSST_g\"].plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can plot all of the passbands using `PassbandGroup`'s plot functionality."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "passband_group.plot()"
    ]
   },
   {

--- a/src/tdastro/__init__.py
+++ b/src/tdastro/__init__.py
@@ -2,5 +2,7 @@ from pathlib import Path
 
 # Define some global directory paths to use for testing, notebooks, etc.
 _TDASTRO_BASE_DIR = Path(__file__).parent.parent.parent
+_TDASTRO_BASE_DATA_DIR = _TDASTRO_BASE_DIR / "data"
+
 _TDASTRO_TEST_DIR = _TDASTRO_BASE_DIR / "tests" / "tdastro"
 _TDASTRO_TEST_DATA_DIR = _TDASTRO_TEST_DIR / "data"

--- a/tests/tdastro/astro_utils/test_passband_groups.py
+++ b/tests/tdastro/astro_utils/test_passband_groups.py
@@ -197,7 +197,7 @@ def test_passband_group_from_dir(tmp_path):
         assert wave_start == pb_group[filter]._loaded_table[0][0]
 
     # Check that we throw an error if we try to load a filter that does not exist.
-    with pytest.raises(FileNotFoundError):
+    with pytest.raises(ValueError):
         _ = PassbandGroup.from_dir(table_dir, filters=["a", "b", "z"])
 
 
@@ -235,8 +235,8 @@ def test_passband_group_from_list(tmp_path):
     )
 
 
-def test_passband_subset_passbands(tmp_path):
-    """Test that we can filter unneed passbands from the group."""
+def test_passband_load_subset_passbands(tmp_path):
+    """Test that we can load a subset of filters."""
     pb_list = [
         Passband(
             "my_survey",
@@ -263,17 +263,19 @@ def test_passband_subset_passbands(tmp_path):
             trim_quantile=None,
         ),
     ]
-    test_passband_group = PassbandGroup(given_passbands=pb_list)
-    assert len(test_passband_group) == 4
 
-    # Filter keep two of the passbands, one by full name and the other by filter name.
-    test_passband_group.subset(["my_survey_a", "c"])
+    # Load one filter by full name and the other by filter name.
+    test_passband_group = PassbandGroup(given_passbands=pb_list, filters_to_load=["my_survey_a", "c"])
     assert len(test_passband_group) == 2
 
     assert np.allclose(
         test_passband_group.waves,
         np.unique(np.concatenate([np.arange(100, 301, 5), np.arange(400, 601, 5)])),
     )
+
+    # We run into an error if we try to load a filter that does not exist.
+    with pytest.raises(ValueError):
+        _ = PassbandGroup(given_passbands=pb_list, filters_to_load=["my_survey_a", "z"])
 
 
 def test_passband_unique_waves():

--- a/tests/tdastro/astro_utils/test_passbands.py
+++ b/tests/tdastro/astro_utils/test_passbands.py
@@ -1,3 +1,4 @@
+import warnings
 from pathlib import Path
 from unittest.mock import patch
 
@@ -66,8 +67,6 @@ def test_passband_manual_create(tmp_path):
     assert test_pb.filter_name == "u"
     assert test_pb.full_name == "test_u"
     assert test_pb.units == "A"
-    assert test_pb.table_url is None
-    assert test_pb.table_path is None
     np.testing.assert_allclose(test_pb._loaded_table, transmission_table)
 
     # We can create an load a table in nm as well. It will auto-convert to Angstroms.
@@ -77,8 +76,6 @@ def test_passband_manual_create(tmp_path):
     assert test_pb2.filter_name == "g"
     assert test_pb2.full_name == "test_g"
     assert test_pb2.units == "A"
-    assert test_pb.table_url is None
-    assert test_pb.table_path is None
     np.testing.assert_allclose(test_pb2._loaded_table, transmission_table)
 
     # We raise an error if the data is not sorted.
@@ -90,7 +87,7 @@ def test_passband_manual_create(tmp_path):
         )
 
     # We raise an error when no data is given or when we given a path AND table.
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(ValueError):
         _ = Passband(survey="test", filter_name="u")
 
     with pytest.raises(ValueError):
@@ -118,24 +115,28 @@ def test_passband_load_transmission_table(passbands_dir, tmp_path):
 
     # Test that we raise an error if the transmission table is blank
     transmission_table = ""
-    with open(a_band.table_path, "w") as f:
+    test_pb_file_name = Path(tmp_path) / "r.dat"
+    with open(test_pb_file_name, "w") as f:
         f.write(transmission_table)
-    with pytest.raises(ValueError):
-        a_band._load_transmission_table()
+    with warnings.catch_warnings():
+        # Ignore the warning that we are loading an empty file.
+        warnings.simplefilter("ignore")
+        with pytest.raises(ValueError):
+            a_band.load_transmission_table(test_pb_file_name)
 
     # Test that we raise an error if the transmission table is not formatted correctly
     transmission_table = "1000\n1005 0.6\n1010 0.7"
-    with open(a_band.table_path, "w") as f:
+    with open(test_pb_file_name, "w") as f:
         f.write(transmission_table)
     with pytest.raises(ValueError):
-        a_band._load_transmission_table()
+        a_band.load_transmission_table(test_pb_file_name)
 
     # Test that we raise an error if the transmission table wavelengths are not sorted
     transmission_table = "1000 0.5\n900 0.6\n1010 0.7"
-    with open(a_band.table_path, "w") as f:
+    with open(test_pb_file_name, "w") as f:
         f.write(transmission_table)
     with pytest.raises(ValueError):
-        a_band._load_transmission_table()
+        a_band.load_transmission_table(test_pb_file_name)
 
 
 def test_passband_download_transmission_table(tmp_path):

--- a/tests/tdastro/astro_utils/test_passbands.py
+++ b/tests/tdastro/astro_utils/test_passbands.py
@@ -41,6 +41,17 @@ def test_passband_str(passbands_dir, tmp_path):
     assert str(a_band) == "Passband: TOY_a"
 
 
+def test_passband_eq(passbands_dir, tmp_path):
+    """Test the __str__ method of the Passband class."""
+    a_band = Passband("LSST", "a", table_values=np.array([[1000, 0.5], [1005, 0.6], [1010, 0.7]]))
+    b_band = Passband("LSST", "b", table_values=np.array([[1000, 0.5], [1005, 0.6], [1010, 0.7]]))
+    c_band = Passband("LSST", "c", table_values=np.array([[1000, 0.5], [1005, 0.7], [1010, 0.7]]))
+    d_band = Passband("LSST", "d", table_values=np.array([[1000, 0.5], [1005, 0.6], [1020, 0.7]]))
+    assert a_band == b_band
+    assert a_band != c_band
+    assert a_band != d_band
+
+
 def test_passband_manual_create(tmp_path):
     """Test that we can create a passband from the transmission table."""
     # Test we get a TypeError if we don't provide a survey and filter_name


### PR DESCRIPTION
Restructures the passband group based on how it is being used in the initial notebooks. Key changes:
- Cleanup: `Passband` no longer stores table URL or file path. Instead these are passed to the relevant loader functions.
- Cleanup: All passband data is stored in a top level data directory instead of in the src directory. This new directory is added to gitignore so the passbands are not committed to git.
- Ease of use: Added ability to lookup passband by filter name from the `PassbandGroup`.
- Ease of use: Added ability to load only a subset of the filters.
- Introduction: Extended the introduction notebook.