### PR TITLE
Fix bug in GraphState.to_dict

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -149,5 +149,6 @@ _html/
 # Project initialization script
 .initialize_new_project.sh
 
-# Default cached location for passband tables
+# Default cached location for data files
 src/tdastro/astro_utils/passbands/*
+data/*

--- a/src/tdastro/graph_state.py
+++ b/src/tdastro/graph_state.py
@@ -441,7 +441,10 @@ class GraphState:
         values = {}
         for node_name, node_params in self.states.items():
             for param_name, param_value in node_params.items():
-                values[self.extended_param_name(node_name, param_name)] = list(param_value)
+                if self.num_samples == 1:
+                    values[self.extended_param_name(node_name, param_name)] = param_value
+                else:
+                    values[self.extended_param_name(node_name, param_name)] = list(param_value)
         return values
 
     def save_to_file(self, filename, overwrite=False):

--- a/tests/tdastro/test_graph_state.py
+++ b/tests/tdastro/test_graph_state.py
@@ -349,6 +349,18 @@ def test_graph_state_to_dict():
         [6.0, 7.0, 8.0],
     )
 
+    # Everything still works if we have only a single value.
+    state2 = GraphState(num_samples=1)
+    state2.set("a", "v1", 1.0)
+    state2.set("a", "v2", 3.0)
+    state2.set("b", "v1", 6.0)
+
+    result2 = state2.to_dict()
+    assert len(result2) == 3
+    assert result2[GraphState.extended_param_name("a", "v1")] == 1.0
+    assert result2[GraphState.extended_param_name("a", "v2")] == 3.0
+    assert result2[GraphState.extended_param_name("b", "v1")] == 6.0
+
 
 def test_graph_state_to_table():
     """Test that we can create an AstroPy Table from a GraphState."""


### PR DESCRIPTION
Fix a small bug in `GraphState.to_dict()` where the code would throw an error if there was only one sample and thus the data is not iterable (to create a list).