### PR TITLE
Always store the internal GraphState as arrays.

### DIFF
--- a/src/tdastro/base_models.py
+++ b/src/tdastro/base_models.py
@@ -52,6 +52,8 @@ static functions.
 
 from functools import partial
 
+import numpy as np
+
 from tdastro.graph_state import GraphState
 
 
@@ -549,7 +551,7 @@ class ParameterizedNode:
                 if graph_state.num_samples == 1:
                     graph_state.set(self.node_string, name, setter.value)
                 else:
-                    repeated_value = [setter.value] * graph_state.num_samples
+                    repeated_value = np.array([setter.value] * graph_state.num_samples)
                     graph_state.set(self.node_string, name, repeated_value)
             elif setter.source_type == ParameterSource.MODEL_PARAMETER:
                 graph_state.set(

--- a/src/tdastro/graph_state.py
+++ b/src/tdastro/graph_state.py
@@ -274,9 +274,9 @@ class GraphState:
                 f"variable={var_name}: {self.num_samples} vs {len(value)}."
             )
         elif force_copy:
-            self.states[node_name][var_name] = value.copy()
+            self.states[node_name][var_name] = np.array(value.copy())
         else:
-            self.states[node_name][var_name] = value
+            self.states[node_name][var_name] = np.asarray(value)
 
         # Mark the variable as fixed if needed.
         if fixed:


### PR DESCRIPTION
Always store the internal `GraphState` data as arrays to enable vectorization of operations.