### PR TITLE
Standardize comment format.

### DIFF
--- a/src/tdastro/astro_utils/black_body.py
+++ b/src/tdastro/astro_utils/black_body.py
@@ -10,16 +10,16 @@ def black_body_luminosity_density_per_solid(temperature, radius, wavelengths):
 
     Parameters
     ----------
-    temperature : `float`
+    temperature : float
         The effective temperature of the star, in kelvins.
-    radius : `float`
+    radius : float
         The radius of the star, in cm.
-    wavelengths : `numpy.ndarray`
+    wavelengths : numpy.ndarray
         A length N array of wavelengths, in cm.
 
     Returns
     -------
-    luminosity_density : `numpy.ndarray`
+    luminosity_density : numpy.ndarray
         A length N array of luminosity density values.
         Output is in CGS units of erg/s/Hz/steradian.
 

--- a/src/tdastro/astro_utils/mag_flux.py
+++ b/src/tdastro/astro_utils/mag_flux.py
@@ -12,12 +12,12 @@ def mag2flux(mag: npt.ArrayLike) -> npt.ArrayLike:
 
     Parameters
     ----------
-    mag : ndarray of `float`
+    mag : ndarray of float
         The magnitude to convert to bandflux.
 
     Returns
     -------
-    bandflux : ndarray of `float`
+    bandflux : ndarray of float
         The bandflux corresponding to the input magnitude.
     """
     return np.power(10.0, -0.4 * (mag - MAG_AB_ZP_NJY))
@@ -28,12 +28,12 @@ def flux2mag(flux_njy: npt.ArrayLike) -> npt.ArrayLike:
 
     Parameters
     ----------
-    flux_njy : ndarray of `float`
+    flux_njy : ndarray of float
         The bandflux to convert to magnitude.
 
     Returns
     -------
-    mag : ndarray of `float`
+    mag : ndarray of float
         The magnitude corresponding to the input bandflux.
     """
     return MAG_AB_ZP_NJY - 2.5 * np.log10(flux_njy)

--- a/src/tdastro/astro_utils/obs_utils.py
+++ b/src/tdastro/astro_utils/obs_utils.py
@@ -7,12 +7,12 @@ def phot_eff_function(snr):
 
     Parameters
     ----------
-    snr: `list` or `numpy.ndarray`
+    snr: list or numpy.ndarray
         Signal to noise ratio of a list of observations.
 
     Returns
     -------
-    eff: `list` or `numpy.ndarray`
+    eff: list or numpy.ndarray
         The photometric detection efficiency given snr.
     """
 
@@ -28,12 +28,12 @@ def spec_eff_function(peak_imag):
 
     Parameters
     ----------
-    peak_imag: `list` or `numpy.ndarray`
+    peak_imag: list or numpy.ndarray
         Peak magnitude in i band.
 
     Returns
     -------
-    eff: `list` or `numpy.ndarray`
+    eff: list or numpy.ndarray
         The spectroscopic efficiency given peak i band magnitude.
         Based on Equation (17) in Kessler et al. 2019
         s0, s1, s2 are fitted using data from Figure 4 in Kessler et al. 2019

--- a/src/tdastro/astro_utils/opsim.py
+++ b/src/tdastro/astro_utils/opsim.py
@@ -54,55 +54,55 @@ class OpSim:  # noqa: D101
 
     Parameters
     ----------
-    table : `dict` or `pandas.core.frame.DataFrame`
+    table : dict or pandas.core.frame.DataFrame
         The table with all the OpSim information.
-    colmap : `dict`
+    colmap : dict
         A mapping of short column names to their names in the underlying table.
-        Defaults to the Rubin OpSim column names, stored in `_rubin_opsim_colnames`:
+        Defaults to the Rubin OpSim column names, stored in _rubin_opsim_colnames:
         {_rubin_opsim_colnames}
-    ext_coeff : `dict` or None, optional
+    ext_coeff : dict or None, optional
         Mapping of filter names to extinction coefficients. Defaults to
-        the Rubin OpSim values, stored in `_rubin_extinction_coeff`:
+        the Rubin OpSim values, stored in _rubin_extinction_coeff:
         {_lsstcam_extinction_coeff}
-    zp_per_sec : `dict` or None, optional
+    zp_per_sec : dict or None, optional
         Mapping of filter names to zeropoints at zenith. Defaults to
-        the Rubin OpSim values, stored in `_rubin_zeropoint_per_sec_zenith`:
+        the Rubin OpSim values, stored in _rubin_zeropoint_per_sec_zenith:
         {_lsstcam_zeropoint_per_sec_zenith}
-    pixel_scale : `float` or None, optional
+    pixel_scale : float or None, optional
         The pixel scale for the LSST camera in arcseconds per pixel. Defaults to
-        the Rubin OpSim value, see _rubin_pixel_scale, stored in `_rubin_pixel_scale`:
+        the Rubin OpSim value, see _rubin_pixel_scale, stored in _rubin_pixel_scale:
         {LSSTCAM_PIXEL_SCALE}
-    read_noise : `float` or None, optional
+    read_noise : float or None, optional
         The readout noise for the LSST camera in electrons per pixel. Defaults to
-        the Rubin OpSim value, stored in `_rubin_readout_noise`:
+        the Rubin OpSim value, stored in _rubin_readout_noise:
         {_lsstcam_readout_noise}
-    dark_current : `float` or None, optional
+    dark_current : float or None, optional
         The dark current for the LSST camera in electrons per second per pixel. Defaults to
-        the Rubin OpSim value, stored in `_rubin_dark_current`:
+        the Rubin OpSim value, stored in _rubin_dark_current:
         {_lsstcam_dark_current}
     radius : float or None, optional
         The angular radius of the observations (in degrees).
-        Defaults to the Rubin value, stored in `_lsstcam_view_radius`: {_lsstcam_view_radius}
+        Defaults to the Rubin value, stored in _lsstcam_view_radius: {_lsstcam_view_radius}
 
     Attributes
     ----------
-    table : `pandas.core.frame.DataFrame`
+    table : pandas.core.frame.DataFrame
         The table with all the OpSim information.
-    colmap : `dict`
+    colmap : dict
         A mapping of short column names to their names in the underlying table.
-    _kd_tree : `scipy.spatial.KDTree` or None
+    _kd_tree : scipy.spatial.KDTree or None
         A kd_tree of the OpSim pointings for fast spatial queries. We use the scipy
         kd-tree instead of astropy's functions so we can directly control caching.
-    pixel_scale : `float` or None, optional
+    pixel_scale : float or None, optional
         The pixel scale for the LSST camera in arcseconds per pixel.
-    read_noise : `float` or None, optional
+    read_noise : float or None, optional
         The readout noise for the LSST camera in electrons per pixel.
-    dark_current : `float` or None, optional
+    dark_current : float or None, optional
         The dark current for the LSST camera in electrons per second per pixel.
-    ext_coeff : `dict` or None, optional
+    ext_coeff : dict or None, optional
         Mapping of filter names to extinction coefficients. Defaults to
         the Rubin OpSim values.
-    zp_per_sec : `dict` or None, optional
+    zp_per_sec : dict or None, optional
         Mapping of filter names to zeropoints at zenith. Defaults to
         the Rubin OpSim values.
     radius : float
@@ -179,12 +179,12 @@ class OpSim:  # noqa: D101
 
         Parameters
         ----------
-        columns : `str` or iterable
+        columns : str or iterable
             The column name or column names to check.
 
         Returns
         -------
-        `bool`
+        bool
             True if and only if all the columns are contained in the table.
         """
         if isinstance(columns, str):
@@ -235,24 +235,24 @@ class OpSim:  # noqa: D101
 
         Parameters
         ----------
-        filename : `str`
+        filename : str
             The name of the opsim db file.
-        sql_query : `str`
+        sql_query : str
             The SQL query to use when loading the table.
             Default = "SELECT * FROM observations"
-        colmap : `dict`
+        colmap : dict
             A mapping of short column names to their names in the underlying table.
             Defaults to the Rubin opsim column names.
 
         Returns
         -------
-        opsim : `OpSim`
+        opsim : OpSim
             A table with all of the pointing data.
 
         Raise
         -----
-        ``FileNotFoundError`` if the file does not exist.
-        ``ValueError`` if unable to load the table.
+        FileNotFoundError if the file does not exist.
+        ValueError if unable to load the table.
         """
         if not Path(filename).is_file():
             raise FileNotFoundError(f"opsim file {filename} not found.")
@@ -274,11 +274,11 @@ class OpSim:  # noqa: D101
 
         Parameters
         ----------
-        colname : `str`
+        colname : str
             The name of the new column.
-        values : `int`, `float`, `str`, `list`, or `numpy.ndarray`
+        values : int, float, str, list, or numpy.ndarray
             The value(s) to add.
-        overwrite : `bool`
+        overwrite : bool
             Overwrite the column is it already exists.
             Default: False
         """
@@ -296,18 +296,18 @@ class OpSim:  # noqa: D101
 
         Parameters
         ----------
-        filename : `str`
+        filename : str
             The name of the opsim db file.
-        tablename : `str`
+        tablename : str
             The table to which to write.
             Default = "observations"
-        overwrite : `bool`
+        overwrite : bool
             Overwrite the existing DB file.
             Default = False
 
         Raise
         -----
-        ``FileExistsError`` if the file already exists and ``overwrite`` is ``False``.
+        FileExistsError if the file already exists and overwrite is False.
         """
         if_exists = "replace" if overwrite else "fail"
 
@@ -378,17 +378,17 @@ class OpSim:  # noqa: D101
 
         Parameters
         ----------
-        query_ra : `float` or `numpy.ndarray`
+        query_ra : float or numpy.ndarray
             The query right ascension (in degrees).
-        query_dec : `float` or `numpy.ndarray`
+        query_dec : float or numpy.ndarray
             The query declination (in degrees).
-        radius : `float` or None, optional
+        radius : float or None, optional
             The angular radius of the observation (in degrees). If None
             uses the default radius for the OpSim.
 
         Returns
         -------
-        inds : `list[int]` or `list[numpy.ndarray]`
+        inds : list[int] or list[numpy.ndarray]
             Depending on the input, this is either a list of indices for a single query point
             or a list of arrays (of indices) for an array of query points.
         """
@@ -414,20 +414,20 @@ class OpSim:  # noqa: D101
 
         Parameters
         ----------
-        query_ra : `float`
+        query_ra : float
             The query right ascension (in degrees).
-        query_dec : `float`
+        query_dec : float
             The query declination (in degrees).
-        radius : `float` or None, optional
+        radius : float or None, optional
             The angular radius of the observation (in degrees). If None
             uses the default radius for the OpSim.
-        cols : `list`
-            A list of the names of columns to extract. If `None` returns all the
+        cols : list
+            A list of the names of columns to extract. If None returns all the
             columns.
 
         Returns
         -------
-        results : `dict`
+        results : dict
             A dictionary mapping the given column name to a numpy array of values.
         """
         neighbors = self.range_search(query_ra, query_dec, radius)
@@ -539,12 +539,12 @@ def opsim_add_random_data(opsim_data, colname, min_val=0.0, max_val=1.0):
     ----------
     opsim_data : OpSim
         The OpSim data structure to modify.
-    colname : `str`
+    colname : str
         The name of the new column to add.
-    min_val : `float`
+    min_val : float
         The minimum value of the uniform range.
         Default: 0.0
-    max_val : `float`
+    max_val : float
         The maximum value of the uniform range.
         Default: 1.0
     """
@@ -581,7 +581,7 @@ def oversample_opsim(
         The time between observations in days.
     time_range : tuple or floats or Nones, optional
         The start and end times of the observations in MJD.
-        `None` means to use the minimum (maximum) time in
+        None means to use the minimum (maximum) time in
         all the observations found for the given pointing.
         Time is being samples as np.arange(*time_range, delta_t).
     bands : list of str or None, optional

--- a/src/tdastro/astro_utils/passbands.py
+++ b/src/tdastro/astro_utils/passbands.py
@@ -212,7 +212,7 @@ class PassbandGroup:
         delta_wave : float or None, optional
             The grid step of the wave grid, in angstroms.
             It is typically used to downsample transmission using linear interpolation.
-            Default is 5 angstroms. If `None` the original grid is used.
+            Default is 5 angstroms. If None the original grid is used.
         trim_quantile : float or None, optional
             The quantile to trim the transmission table by. For example, if trim_quantile is 1e-3, the
             transmission table will be trimmed to include only the central 99.8% of the area under the
@@ -491,7 +491,7 @@ class Passband:
         delta_wave : float or None, optional
             The grid step of the wave grid, in angstroms.
             It is typically used to downsample transmission using linear interpolation.
-            Default is 5 angstroms. If `None` the original grid is used.
+            Default is 5 angstroms. If None the original grid is used.
         trim_quantile : float or None, optional
             The quantile to trim the transmission table by. For example, if trim_quantile is 1e-3, the
             transmission table will be trimmed to include only the central 99.8% of the area under the

--- a/src/tdastro/astro_utils/pzflow_node.py
+++ b/src/tdastro/astro_utils/pzflow_node.py
@@ -36,7 +36,7 @@ class PZFlowNode(FunctionNode):
         ----------
         filename : str or Path
             The location of the saved flow.
-        node_label : `str`
+        node_label : str
             An optional human readable identifier (name) for the current node.
         """
         flow_to_use = Flow(file=filename)
@@ -47,13 +47,13 @@ class PZFlowNode(FunctionNode):
 
         Parameters
         ----------
-        graph_state : `GraphState`
+        graph_state : GraphState
             An object mapping graph parameters to their values. This object is modified
             in place as it is sampled.
         rng_info : numpy.random._generator.Generator, optional
             Unused in this function, but included to provide consistency with other
             compute functions.
-        **kwargs : `dict`, optional
+        **kwargs : dict, optional
             Additional function arguments.
 
         Returns

--- a/src/tdastro/astro_utils/redshift.py
+++ b/src/tdastro/astro_utils/redshift.py
@@ -41,14 +41,14 @@ def rest_to_obs_flux(flux_density, redshift):
 
     Parameters
     ----------
-    flux_density : `numpy.ndarray`
+    flux_density : numpy.ndarray
         A length T X N matrix of flux density values (in nJy).
     redshift : float
         The redshift of the object associated with given flux densities.
 
     Returns
     -------
-    flux_density : `numpy.ndarray`
+    flux_density : numpy.ndarray
         The observer frame flux (in nJy).
     """
     return flux_density * (1 + redshift)
@@ -60,14 +60,14 @@ def redshift_to_distance(redshift, cosmology):
 
     Parameters
     ----------
-    redshift : `float`
+    redshift : float
         The redshift value.
-    cosmology : `astropy.cosmology`
+    cosmology : astropy.cosmology
         The cosmology specification.
 
     Returns
     -------
-    distance : `float`
+    distance : float
         The luminosity distance (in pc)
     """
     z = redshift * cu.redshift
@@ -80,16 +80,16 @@ class RedshiftDistFunc(FunctionNode):
 
     Attributes
     ----------
-    cosmology : `astropy.cosmology`
+    cosmology : astropy.cosmology
         The cosmology specification.
 
     Parameters
     ----------
     redshift : function or constant
         The function or constant providing the redshift value.
-    cosmology : `astropy.cosmology`
+    cosmology : astropy.cosmology
         The cosmology specification.
-    **kwargs : `dict`, optional
+    **kwargs : dict, optional
         Any additional keyword arguments.
     """
 

--- a/src/tdastro/astro_utils/snia_utils.py
+++ b/src/tdastro/astro_utils/snia_utils.py
@@ -17,12 +17,12 @@ def snia_volumetric_rates(redshift):
 
     Parameters
     ----------
-    redshift: `float` or `numpy.ndarray`
+    redshift: float or numpy.ndarray
         The redshift of the supernova
 
     Returns
     -------
-    rate_vol: `float` or `numpy.ndarray`
+    rate_vol: float or numpy.ndarray
         The volumetric rate of the supernova given the redshift
     """
 
@@ -44,24 +44,24 @@ def num_snia_per_redshift_bin(zmin=0.001, zmax=10, znbins=20, solid_angle=None, 
 
     Parameters
     ----------
-    zmin: `float`
+    zmin: float
         Min redshift value for calculation.
-    zmax: `float`
+    zmax: float
         Max redshift value for calculation.
-    znbins: `int`
+    znbins: int
         Number of redshift bins for calculating SNe Ia numbers.
-    solid_angle: `float`
+    solid_angle: float
         Solid angle for calculating the number of SNe (in sr).
-    H0: `float`
+    H0: float
         The Hubble Constant.
-    Omega_m: `float`
+    Omega_m: float
         The matter density.
 
     Returns
     -------
-    num_sn: `numpy.ndarray`
+    num_sn: numpy.ndarray
         Number of SNe Ia in each zbin per year.
-    z_mean: `numpy.ndarray`
+    z_mean: numpy.ndarray
         Mean value for each redshift bin.
     """
 
@@ -92,12 +92,12 @@ class HostmassX1Distr:
 
     Attributes
     ----------
-    hostmass: `float`
+    hostmass: float
         The hostmass value.
 
     Parameters
     ----------
-    hostmass: `float`
+    hostmass: float
         The hostmass value.
     """
 
@@ -110,14 +110,14 @@ class HostmassX1Distr:
 
         Parameters
         ----------
-        x1: `numpy.ndarray`
+        x1: numpy.ndarray
             The x1 value.
-        hostmass: `float`
+        hostmass: float
             The hostmass value.
 
         Returns
         -------
-        p: `numpy.ndarray`
+        p: numpy.ndarray
             The probablity.
         """
 
@@ -133,9 +133,9 @@ class HostmassX1Distr:
 
         Parameters
         ----------
-        x1: `numpy.ndarray`
+        x1: numpy.ndarray
             The x1 value.
-        hostmass: `float`
+        hostmass: float
             The hostmass value.
 
         Returns
@@ -153,22 +153,22 @@ def _x0_from_distmod(distmod, x1, c, alpha, beta, m_abs):
 
     Parameters
     ----------
-    distmod : `float`
+    distmod : float
         The distance modulus value (in mag).
-    x1 : `float`
+    x1 : float
         The SALT3 x1 parameter.
-    c : `float`
+    c : float
         The SALT3 c parameter.
-    alpha : `float`
+    alpha : float
         The alpha parameter in the Tripp relation.
-    beta : `float`
+    beta : float
         The beta parameter in the Tripp relation.
-    m_abs : `float`
+    m_abs : float
         The absolute magnitude of SN Ia.
 
     Returns
     -------
-    x0 : `float`
+    x0 : float
         The x0 parameter
     """
     x0 = np.power(10.0, -0.4 * (distmod - alpha * x1 + beta * c + m_abs - 10.635))
@@ -183,7 +183,7 @@ class HostmassX1Func(NumericalInversePolynomialFunc):
     ----------
     hostmass : function or constant
         The function or constant providing the hostmass value.
-    **kwargs : `dict`, optional
+    **kwargs : dict, optional
         Any additional keyword arguments.
     """
 
@@ -208,13 +208,13 @@ class HostmassX1Func(NumericalInversePolynomialFunc):
 
         Parameters
         ----------
-        graph_state : `GraphState`
+        graph_state : GraphState
             An object mapping graph parameters to their values. This object is modified
             in place as it is sampled.
         rng_info : numpy.random._generator.Generator or None, optional
             A given numpy random number generator to use for this computation. If not
             provided, the function uses the node's random number generator.
-        **kwargs : `dict`, optional
+        **kwargs : dict, optional
             Additional function arguments.
 
         Returns
@@ -262,7 +262,7 @@ class X0FromDistMod(FunctionNode):
         The function or constant providing the beta value.
     m_abs : function or constant
         The function or constant providing the m_abs value.
-    **kwargs : `dict`, optional
+    **kwargs : dict, optional
         Any additional keyword arguments.
     """
 
@@ -291,7 +291,7 @@ class DistModFromRedshift(FunctionNode):
         The Hubble constant.
     Omega_m : constant
         The matter density Omega_m.
-    **kwargs : `dict`, optional
+    **kwargs : dict, optional
         Any additional keyword arguments.
     """
 
@@ -311,12 +311,12 @@ class DistModFromRedshift(FunctionNode):
 
         Parameters
         ----------
-        redshift : `float` or `numpy.ndarray`
+        redshift : float or numpy.ndarray
             The redshift value(s).
 
         Returns
         -------
-        distmod : `float` or `numpy.ndarray`
+        distmod : float or numpy.ndarray
             The distance modulus (in mag)
         """
         return self.cosmo.distmod(redshift).value

--- a/src/tdastro/astro_utils/unit_utils.py
+++ b/src/tdastro/astro_utils/unit_utils.py
@@ -29,23 +29,23 @@ def flam_to_fnu(flux_flam, wavelengths, *, wave_unit, flam_unit, fnu_unit):
 
     Parameters
     ----------
-    flux_flam : `list` or `numpy.ndarray`
+    flux_flam : list or numpy.ndarray
         The flux values in flam units. This can be a single N-length array
         or an M x N matrix.
-    wavelengths: `list` or `numpy.ndarray`
+    wavelengths: list or numpy.ndarray
         The wavelength values associated with the input flux values.
         This can be a single N-length array or an M x N matrix. If it is an
         N-length array, the same wavelength values are used for each flux_flam.
-    wave_unit: `astropy.units.Unit`
+    wave_unit: astropy.units.Unit
         The unit for the wavelength values.
-    flam_unit: `astropy.units.Unit`
+    flam_unit: astropy.units.Unit
         The unit for the input flux_flam values.
-    fnu_unit: `astropy.units.Unit`
+    fnu_unit: astropy.units.Unit
         The unit for the output flux_fnu values.
 
     Returns
     -------
-    flux_fnu : `list` or `np.array`
+    flux_fnu : list or np.array
         The flux values in fnu units.
     """
     flux_flam = np.asarray(flux_flam)
@@ -76,23 +76,23 @@ def fnu_to_flam(flux_fnu, wavelengths, *, wave_unit, flam_unit, fnu_unit):
 
     Parameters
     ----------
-    flux_fnu : `list` or `numpy.ndarray`
+    flux_fnu : list or numpy.ndarray
         The flux values in fnu units. This can be a single N-length array
         or an M x N matrix.
-    wavelengths: `list` or `numpy.ndarray`
+    wavelengths: list or numpy.ndarray
         The wavelength values associated with the input flux values.
         This can be a single N-length array or an M x N matrix. If it is an
         N-length array, the same wavelength values are used for each flux_fnu.
-    wave_unit: `astropy.units.Unit`
+    wave_unit: astropy.units.Unit
         The unit for the wavelength values.
-    flam_unit: `astropy.units.Unit`
+    flam_unit: astropy.units.Unit
         The unit for the output flux_flam values.
-    fnu_unit: `astropy.units.Unit`
+    fnu_unit: astropy.units.Unit
         The unit for the input flux_fnu values.
 
     Returns
     -------
-    flux_flam : `list` or `np.array`
+    flux_flam : list or np.array
         The flux values in flam units.
     """
     flux_fnu = np.asarray(flux_fnu)

--- a/src/tdastro/base_models.py
+++ b/src/tdastro/base_models.py
@@ -63,21 +63,21 @@ class ParameterSource:
 
     Attributes
     ----------
-    parameter_name : `str`
+    parameter_name : str
         The name of the parameter within the node (short name).
-    node_name : `str`
+    node_name : str
         The name of the parent node.
-    source_type : `int`
+    source_type : int
         The type of source as defined by the class variables.
         Default = 0
     value : any
         The information that actually sets the parameter. Either a constant
         or the attribute name of a dependency node.
-    dependency : `ParameterizedNode` or None
+    dependency : ParameterizedNode or None
         The node on which this parameter is dependent
-    allow_gradient : `bool`
+    allow_gradient : bool
         Allow gradients to be computed at this variable.
-        Default = ``False``
+        Default = False
     """
 
     # Class variables for the source enum.
@@ -104,7 +104,7 @@ class ParameterSource:
             The constant value to use.
         allow_gradient : bool
             Allow a gradient to be computed at this variable.
-            Default = ``True``
+            Default = True
         """
         if callable(value):
             raise ValueError(f"Using set_as_constant on callable {value}")
@@ -119,9 +119,9 @@ class ParameterSource:
 
         Parameters
         ----------
-        dependency : `ParameterizedNode`
+        dependency : ParameterizedNode
             The node in which to access the attribute.
-        param_name : `str`
+        param_name : str
             The name of the parameter to access.
         """
         self.source_type = ParameterSource.MODEL_PARAMETER
@@ -134,9 +134,9 @@ class ParameterSource:
 
         Parameters
         ----------
-        dependency : `ParameterizedNode`
+        dependency : ParameterizedNode
             The node in which to access the attribute.
-        param_name : `str`
+        param_name : str
             The name of where the result is stored in the FunctionNode.
         """
         self.source_type = ParameterSource.FUNCTION_NODE
@@ -149,9 +149,9 @@ class ParameterSource:
 
         Parameters
         ----------
-        dependency : `ParameterizedNode`
+        dependency : ParameterizedNode
             The node in which to access the attribute.
-        param_name : `str`
+        param_name : str
             The name of where the result is stored in the FunctionNode.
         """
         self.source_type = ParameterSource.COMPUTE_OUTPUT
@@ -165,24 +165,24 @@ class ParameterizedNode:
 
     Attributes
     ----------
-    node_label : `str`
+    node_label : str
         An optional human readable identifier (name) for the current node.
-    node_string : `str`
+    node_string : str
         The full string used to identify a node. This is a combination of the nodes position
         in the graph (if known), node_label (if provided), and class information.
-    setters : `dict`
+    setters : dict
         A dictionary mapping the parameters' names to information about the setters
         (ParameterSource). The model parameters are stored in the order in which they
         need to be set.
-    node_pos : `int` or None
+    node_pos : int or None
         A unique ID number for each node in the graph indicating its position.
-        Assigned during resampling or `set_graph_positions()`
+        Assigned during resampling or set_graph_positions()
 
     Parameters
     ----------
-    node_label : `str`, optional
+    node_label : str, optional
         An identifier (or name) for the current node.
-    **kwargs : `dict`, optional
+    **kwargs : dict, optional
         Any additional keyword arguments.
     """
 
@@ -227,7 +227,7 @@ class ParameterizedNode:
 
         Parameters
         ----------
-        seen_nodes : `set`, optional
+        seen_nodes : set, optional
             A set of nodes that have already been processed to prevent infinite loops.
             Caller should not set.
         """
@@ -290,9 +290,9 @@ class ParameterizedNode:
 
         Parameters
         ----------
-        graph_state : `dict`
+        graph_state : dict
             The dictionary of graph state information.
-        name : `str`
+        name : str
             The parameter name to query.
         default : any
             The default value to return if the parameter is not in GraphState.
@@ -304,7 +304,7 @@ class ParameterizedNode:
 
         Raises
         ------
-        ``ValueError`` if graph_state is None.
+        ValueError if graph_state is None.
         """
         if graph_state is None:
             raise ValueError(f"Unable to look up parameter={name}. No graph_state given.")
@@ -322,18 +322,18 @@ class ParameterizedNode:
 
         Parameters
         ----------
-        graph_state : `GraphState`
+        graph_state : GraphState
             An object mapping graph parameters to their values.
 
         Returns
         -------
-        result : `dict`
+        result : dict
             A dictionary mapping the parameter name to its value.
 
         Raises
         ------
-        ``KeyError`` if no parameters have been set for this node.
-        ``ValueError`` if graph_state is None.
+        KeyError if no parameters have been set for this node.
+        ValueError if graph_state is None.
         """
         if graph_state is None:
             raise ValueError("No graph_state given.")
@@ -350,19 +350,19 @@ class ParameterizedNode:
 
         Parameters
         ----------
-        name : `str`
+        name : str
             The parameter name to add.
         value : any, optional
             The information to use to set the parameter. Can be a constant,
             function, ParameterizedNode, or self.
-        **kwargs : `dict`, optional
+        **kwargs : dict, optional
            All other keyword arguments, possibly including the parameter setters.
 
         Raises
         ------
-        Raise a ``KeyError`` if there is a parameter collision or the parameter
+        Raise a KeyError if there is a parameter collision or the parameter
         cannot be found.
-        Raise a ``ValueError`` if the setter type is not supported.
+        Raise a ValueError if the setter type is not supported.
         """
         # Set the node's position in the graph to None to indicate that the
         # structure might have changed. It needs to be updated with set_graph_positions().
@@ -419,9 +419,9 @@ class ParameterizedNode:
 
         Parameters
         ----------
-        name : `str`
+        name : str
             The parameter name to modify.
-        allow_gradient : `bool`
+        allow_gradient : bool
             The new setting for allow_gradient.
         """
         self.setters[name].allow_gradient = allow_gradient
@@ -431,29 +431,29 @@ class ParameterizedNode:
 
         Notes
         -----
-        * Checks multiple sources in the following order: Manually specified ``value``,
-          an entry in ``kwargs``, or ``None``.
+        * Checks multiple sources in the following order: Manually specified value,
+          an entry in kwargs, or None.
         * Does NOT set an initial value for the model parameter. The user must
           sample the parameters for this to be set.
         * The model parameters are stored in the order in which they are added.
 
         Parameters
         ----------
-        name : `str`
+        name : str
             The parameter name to add.
         value : any, optional
             The information to use to set the parameter. Can be a constant,
             function, ParameterizedNode, or self.
-        allow_gradient : `bool` or None
+        allow_gradient : bool or None
             Allow gradients to be computed for this variable. If set to None uses the default
             for the setter type (True for constant and False for everything else).
             Default = None
-        **kwargs : `dict`, optional
+        **kwargs : dict, optional
            All other keyword arguments, possibly including the parameter setters.
 
         Raises
         ------
-        Raise a ``KeyError`` if there is a parameter collision or the parameter
+        Raise a KeyError if there is a parameter collision or the parameter
         cannot be found.
         """
         # Check for parameter collision and add a place holder value.
@@ -494,13 +494,13 @@ class ParameterizedNode:
 
         Parameters
         ----------
-        graph_state : `GraphState`
+        graph_state : GraphState
             An object mapping graph parameters to their values. This object is modified
             in place as it is sampled.
         rng_info : numpy.random._generator.Generator, optional
             A given numpy random number generator to use for this computation. If not
             provided, the function uses the node's random number generator.
-        **kwargs : `dict`, optional
+        **kwargs : dict, optional
             Additional function arguments.
         """
         return None
@@ -513,10 +513,10 @@ class ParameterizedNode:
 
         Parameters
         ----------
-        graph_state : `GraphState`
+        graph_state : GraphState
             An object mapping graph parameters to their values. This object is modified
             in place as it is sampled.
-        seen_nodes : `dict`
+        seen_nodes : dict
             A dictionary mapping nodes strings seen during this sampling run to their object.
             Used to avoid sampling nodes multiple times and to validity check the graph.
         rng_info : numpy.random._generator.Generator, optional
@@ -525,7 +525,7 @@ class ParameterizedNode:
 
         Raises
         ------
-        Raise a ``KeyError`` if the sampling encounters an error with the order of dependencies.
+        Raise a KeyError if the sampling encounters an error with the order of dependencies.
         """
         node_str = str(self)
         if node_str in seen_nodes:
@@ -582,10 +582,10 @@ class ParameterizedNode:
 
         Parameters
         ----------
-        given_args : `dict`, optional
+        given_args : dict, optional
             A dictionary representing the given arguments for this sample run.
             This can be used as the JAX PyTree for differentiation.
-        num_samples : `int`
+        num_samples : int
             A count of the number of samples to compute.
             Default: 1
         rng_info : numpy.random._generator.Generator, optional
@@ -594,14 +594,14 @@ class ParameterizedNode:
 
         Returns
         -------
-        graph_state : `GraphState`
+        graph_state : GraphState
             A dictionary of dictionaries mapping node->hash, variable_name to either a
             value or array of values. This data structure is modified in place to represent
             the model's state(s).
 
         Raises
         ------
-        Raise a ``ValueError`` the sampling encounters a problem with the order of dependencies.
+        Raise a ValueError the sampling encounters a problem with the order of dependencies.
         """
         # If the graph structure has never been set, do that now.
         if self.node_pos is None:
@@ -623,18 +623,18 @@ class ParameterizedNode:
 
         Parameters
         ----------
-        graph_state : `dict`
+        graph_state : dict
             A dictionary of dictionaries mapping node->hash, variable_name to value.
             This data structure is modified in place to represent the current state.
-        partial : `dict`
+        partial : dict
             The partial results so far. This is modified in place by the function.
             A dictionary mapping node name to a dictionary mapping each variable's name
             to its value.
-            Default : ``None``
+            Default : None
 
         Returns
         -------
-        values : `dict`
+        values : dict
             A dictionary mapping node name to a dictionary mapping each variable's name
             to its value.
         """
@@ -666,32 +666,32 @@ class ParameterizedNode:
 class FunctionNode(ParameterizedNode):
     """A class to wrap functions and their argument settings.
 
-    The node can compute the result using a given function (the ``func``
-    parameter) or through the ``compute()`` method. If no ``func=None``
-    then the user must override ``compute()``.
+    The node can compute the result using a given function (the func
+    parameter) or through the compute() method. If no func=None
+    then the user must override compute().
 
     Attributes
     ----------
-    func : `function` or `method` or `partial`
-        The function to call during an evaluation. If this is ``None``
-        you must override the ``compute()`` method directly.
-    args_names : `list`
+    func : function or method or partial
+        The function to call during an evaluation. If this is None
+        you must override the compute() method directly.
+    args_names : list
         A list of argument names to pass to the function.
-    outputs : `list` of `str`
+    outputs : list of str
         The output model parameters of this function.
 
     Parameters
     ----------
-    func : `function` or `method`
+    func : function or method
         The function to call during an evaluation.
-    node_label : `str`, optional
+    node_label : str, optional
         An identifier (or name) for the current node.
-    outputs : `list` of `str`, optional
-        The output model parameters of this function. If ``None`` uses
-        a single model parameter ``result``.
-    fixed_params : `dict`, optional
+    outputs : list of str, optional
+        The output model parameters of this function. If None uses
+        a single model parameter result.
+    fixed_params : dict, optional
         A dictionary mapping a parameter name in the function to its fixed value.
-    **kwargs : `dict`, optional
+    **kwargs : dict, optional
         Any additional keyword arguments.
 
     Examples
@@ -764,15 +764,15 @@ class FunctionNode(ParameterizedNode):
 
         Parameters
         ----------
-        graph_state : `GraphState`
+        graph_state : GraphState
             An object mapping graph parameters to their values. This object is modified
             in place as it is sampled.
-        **kwargs : `dict`, optional
+        **kwargs : dict, optional
             Additional function arguments.
 
         Returns
         -------
-        args : `dict`
+        args : dict
             A dictionary of input argument to value.
         """
         args = {}
@@ -790,7 +790,7 @@ class FunctionNode(ParameterizedNode):
         ----------
         results : iterable
             The function's results.
-        graph_state : `GraphState`
+        graph_state : GraphState
             An object mapping graph parameters to their values. This object is modified
             in place as it is sampled.
         """
@@ -813,13 +813,13 @@ class FunctionNode(ParameterizedNode):
 
         Parameters
         ----------
-        graph_state : `GraphState`
+        graph_state : GraphState
             An object mapping graph parameters to their values. This object is modified
             in place as it is sampled.
         rng_info : numpy.random._generator.Generator, optional
             A given numpy random number generator to use for this computation. If not
             provided, the function uses the node's random number generator.
-        **kwargs : `dict`, optional
+        **kwargs : dict, optional
             Additional function arguments.
 
         Returns
@@ -830,7 +830,7 @@ class FunctionNode(ParameterizedNode):
 
         Raises
         ------
-        ``ValueError`` is ``func`` attribute is ``None``.
+        ValueError is func attribute is None.
         """
         if self.func is None:
             raise ValueError(
@@ -853,16 +853,16 @@ class FunctionNode(ParameterizedNode):
 
         Parameters
         ----------
-        given_args : `dict`, optional
+        given_args : dict, optional
             A dictionary representing the given arguments for this sample run.
             This can be used as the JAX PyTree for differentiation.
-        num_samples : `int`
+        num_samples : int
             A count of the number of samples to compute.
             Default: 1
         rng_info : numpy.random._generator.Generator, optional
             A given numpy random number generator to use for this computation. If not
             provided, the function uses the node's random number generator.
-        **kwargs : `dict`, optional
+        **kwargs : dict, optional
             Additional function arguments.
         """
         state = self.sample_parameters(given_args, num_samples, rng_info)

--- a/src/tdastro/example_runs/simulate_snia.py
+++ b/src/tdastro/example_runs/simulate_snia.py
@@ -34,7 +34,7 @@ def construct_snia_source(oversampled_observations, zpdf):
 
     Returns
     -------
-    source : `PhysicalModel`
+    source : PhysicalModel
         The PhysicalModel to sample.
     """
     logger.info("Creating the source model.")

--- a/src/tdastro/graph_state.py
+++ b/src/tdastro/graph_state.py
@@ -35,14 +35,14 @@ class GraphState:
 
     Attributes
     ----------
-    states : `dict`
+    states : dict
         A dictionary of dictionaries mapping node->hash, variable_name to either a
         value or array of values.
-    num_samples : `int`
+    num_samples : int
         A count of the number of samples stored in the GraphState.
-    num_parameters : `int`
+    num_parameters : int
         The total number of parameters stored in a single sample within GraphState.
-    fixed_vars : `dict`
+    fixed_vars : dict
         A dictionary mapping the node name to a set of the variable names that
         are fixed in this GraphState instance.
     """
@@ -204,14 +204,14 @@ class GraphState:
 
         Parameters
         ----------
-        node_name : `str`
+        node_name : str
             The parent node whose variables to extract.
-        sample_num : `int`
+        sample_num : int
             The number of sample to extract.
 
         Returns
         -------
-        values : `dict`
+        values : dict
             A dictionary mapping the parameter name to its value.
         """
         if node_name not in self.states:
@@ -232,19 +232,19 @@ class GraphState:
 
         Parameters
         ----------
-        node_name : `str`
+        node_name : str
             The parent node holding this variable.
-        var_name : `str`
+        var_name : str
             The parameter's name.
         value : any
             The new value of the parameter.
-        force_copy : `bool`
-            Make a copy of data in an array. If set to ``False`` this will link
+        force_copy : bool
+            Make a copy of data in an array. If set to False this will link
             to the array, saving memory and computation time.
-            Default: ``False``
-        fixed : `bool`
+            Default: False
+        fixed : bool
             Treat this parameter as fixed and do not change it during subsequent calls to set.
-            Default: ``False``
+            Default: False
         """
         # Check that the names do not use the separator value.
         if "." in node_name or "." in var_name:
@@ -293,15 +293,15 @@ class GraphState:
 
         Parameters
         ----------
-        inputs : `GraphState` or `dict`
+        inputs : GraphState or dict
             Values to copy.
-        force_copy : `bool`
-            Make a copy of data in an array. If set to ``False`` this will link
+        force_copy : bool
+            Make a copy of data in an array. If set to False this will link
             to the array, saving memory and computation time.
-            Default: ``False``
-        all_fixed : `bool`
+            Default: False
+        all_fixed : bool
             Treat all the parameters in inputs as fixed.
-            Default: ``False``
+            Default: False
 
         Raises
         ------
@@ -329,7 +329,7 @@ class GraphState:
 
         Parameters
         ----------
-        sample_num : `int`
+        sample_num : int
             The number of sample to extract.
         """
         if self.num_samples <= 0:
@@ -473,20 +473,20 @@ def transpose_dict_of_list(input_dict, num_elem):
 
     Parameters
     ----------
-    input_dict : `dict`
+    input_dict : dict
         A dictionary of iterables, each of which is length num_elem.
-    num_elem : `int`
+    num_elem : int
         The length of the iterables.
 
     Returns
     -------
-    output_list : `list`
+    output_list : list
         A length num_elem list of dictionaries, each with the same keys mapping
         to a single value.
 
     Raises
     ------
-    ``ValueError`` if any of the iterables have different lengths.
+    ValueError if any of the iterables have different lengths.
     """
     if num_elem < 1:
         raise ValueError(f"Trying to transpose a dictionary with {num_elem} elements")

--- a/src/tdastro/math_nodes/basic_math_node.py
+++ b/src/tdastro/math_nodes/basic_math_node.py
@@ -33,20 +33,20 @@ class BasicMathNode(FunctionNode):
 
     Attributes
     ----------
-    expression : `str`
+    expression : str
         The expression to evaluate.
-    backend : `str`
+    backend : str
         The math libary to use. Must be one of: math, numpy, or jax.
 
     Parameters
     ----------
-    expression : `str`
+    expression : str
         The expression to evaluate.
-    backend : `str`
+    backend : str
         The math libary to use. Must be one of: math, numpy, or jax.
-    node_label : `str`, optional
+    node_label : str, optional
         An identifier (or name) for the current node.
-    **kwargs : `dict`, optional
+    **kwargs : dict, optional
         Any additional keyword arguments. Every variable in the expression
         must be included as a kwarg.
     """
@@ -147,7 +147,7 @@ class BasicMathNode(FunctionNode):
 
         Parameters
         ----------
-        **kwargs : `dict`, optional
+        **kwargs : dict, optional
             The keyword arguments, including every variable in the expression.
 
         Returns
@@ -172,13 +172,13 @@ class BasicMathNode(FunctionNode):
 
         Parameters
         ----------
-        **kwargs : `dict`, optional
+        **kwargs : dict, optional
             Any additional keyword arguments, including the variable
             assignments.
 
         Returns
         -------
-        tree : `ast.*`
+        tree : ast.*
             The root node of the parsed syntax tree.
         """
         tree = ast.parse(self.expression)

--- a/src/tdastro/math_nodes/distribution_sampler.py
+++ b/src/tdastro/math_nodes/distribution_sampler.py
@@ -62,7 +62,7 @@ class DistributionSampler(FunctionNode):
 
         Parameters
         ----------
-        new_seed : `int`
+        new_seed : int
             The given seed
         """
         self._rng = np.random.default_rng(seed=new_seed)
@@ -75,13 +75,13 @@ class DistributionSampler(FunctionNode):
 
         Parameters
         ----------
-        graph_state : `GraphState`
+        graph_state : GraphState
             An object mapping graph parameters to their values. This object is modified
             in place as it is sampled.
         rng_info : numpy.random._generator.Generator, optional
             A given numpy random number generator to use for this computation. If not
             provided, the function uses the node's random number generator.
-        **kwargs : `dict`, optional
+        **kwargs : dict, optional
             Additional function arguments.
 
         Returns

--- a/src/tdastro/math_nodes/given_sampler.py
+++ b/src/tdastro/math_nodes/given_sampler.py
@@ -16,7 +16,7 @@ class GivenValueList(FunctionNode):
 
     Attributes
     ----------
-    values : `float`, `list, or `numpy.ndarray`
+    values : float, list, or numpy.ndarray
         The values to return.
     next_ind : int
         The index of the next value.
@@ -39,13 +39,13 @@ class GivenValueList(FunctionNode):
 
         Parameters
         ----------
-        graph_state : `GraphState`
+        graph_state : GraphState
             An object mapping graph parameters to their values. This object is modified
             in place as it is sampled.
         rng_info : numpy.random._generator.Generator, optional
             Unused in this function, but included to provide consistency with other
             compute functions.
-        **kwargs : `dict`, optional
+        **kwargs : dict, optional
             Additional function arguments.
 
         Returns
@@ -98,13 +98,13 @@ class GivenValueSampler(NumpyRandomFunc):
 
         Parameters
         ----------
-        graph_state : `GraphState`
+        graph_state : GraphState
             An object mapping graph parameters to their values. This object is modified
             in place as it is sampled.
         rng_info : numpy.random._generator.Generator, optional
             A given numpy random number generator to use for this computation. If not
             provided, the function uses the node's random number generator.
-        **kwargs : `dict`, optional
+        **kwargs : dict, optional
             Additional function arguments.
 
         Returns
@@ -179,13 +179,13 @@ class TableSampler(NumpyRandomFunc):
 
         Parameters
         ----------
-        graph_state : `GraphState`
+        graph_state : GraphState
             An object mapping graph parameters to their values. This object is modified
             in place as it is sampled.
         rng_info : numpy.random._generator.Generator, optional
             A given numpy random number generator to use for this computation. If not
             provided, the function uses the node's random number generator.
-        **kwargs : `dict`, optional
+        **kwargs : dict, optional
             Additional function arguments.
 
         Returns

--- a/src/tdastro/math_nodes/np_random.py
+++ b/src/tdastro/math_nodes/np_random.py
@@ -77,7 +77,7 @@ class NumpyRandomFunc(FunctionNode):
 
         Parameters
         ----------
-        new_seed : `int`
+        new_seed : int
             The given seed
         """
         self._rng = np.random.default_rng(seed=new_seed)
@@ -91,13 +91,13 @@ class NumpyRandomFunc(FunctionNode):
 
         Parameters
         ----------
-        graph_state : `GraphState`
+        graph_state : GraphState
             An object mapping graph parameters to their values. This object is modified
             in place as it is sampled.
         rng_info : numpy.random._generator.Generator, optional
             A given numpy random number generator to use for this computation. If not
             provided, the function uses the node's random number generator.
-        **kwargs : `dict`, optional
+        **kwargs : dict, optional
             Additional function arguments.
 
         Returns
@@ -108,7 +108,7 @@ class NumpyRandomFunc(FunctionNode):
 
         Raises
         ------
-        ``ValueError`` is ``func`` attribute is ``None``.
+        ValueError is func attribute is None.
         """
         args = self._build_inputs(graph_state, **kwargs)
 

--- a/src/tdastro/math_nodes/ra_dec_sampler.py
+++ b/src/tdastro/math_nodes/ra_dec_sampler.py
@@ -30,13 +30,13 @@ class UniformRADEC(NumpyRandomFunc):
 
         Parameters
         ----------
-        graph_state : `GraphState`
+        graph_state : GraphState
             An object mapping graph parameters to their values. This object is modified
             in place as it is sampled.
         rng_info : numpy.random._generator.Generator, optional
             A given numpy random number generator to use for this computation. If not
             provided, the function uses the node's random number generator.
-        **kwargs : `dict`, optional
+        **kwargs : dict, optional
             Additional function arguments.
 
         Returns
@@ -104,13 +104,13 @@ class OpSimRADECSampler(TableSampler):
 
         Parameters
         ----------
-        graph_state : `GraphState`
+        graph_state : GraphState
             An object mapping graph parameters to their values. This object is modified
             in place as it is sampled.
         rng_info : numpy.random._generator.Generator, optional
             A given numpy random number generator to use for this computation. If not
             provided, the function uses the node's random number generator.
-        **kwargs : `dict`, optional
+        **kwargs : dict, optional
             Additional function arguments.
 
         Returns

--- a/src/tdastro/math_nodes/scipy_random.py
+++ b/src/tdastro/math_nodes/scipy_random.py
@@ -24,12 +24,12 @@ class NumericalInversePolynomialFunc(FunctionNode):
     _dist : object or class
         An object or class with either a pdf() or logpdf() method that defines
         the distribution from which to sample.
-    _inv_poly: `scipy.stats.sampling.NumericalInversePolynomial`
-        The scipy object to use for sampling. Set to ``None`` if _dist is a class.
-    _vect_sample : `numpy.vectorize`
+    _inv_poly: scipy.stats.sampling.NumericalInversePolynomial
+        The scipy object to use for sampling. Set to None if _dist is a class.
+    _vect_sample : numpy.vectorize
         The vectorized function to create a distribution from a class and sample it.
-        Set to ``None`` if _dist is an object.
-    _rng : `numpy.random._generator.Generator`
+        Set to None if _dist is an object.
+    _rng : numpy.random._generator.Generator
         This object's random number generator.
 
     Parameters
@@ -37,7 +37,7 @@ class NumericalInversePolynomialFunc(FunctionNode):
     dist : object or class
         An object or class with either a pdf() or logpdf() method that defines
         the distribution from which to sample.
-    seed : `int`, optional
+    seed : int, optional
         The seed to use.
     """
 
@@ -75,7 +75,7 @@ class NumericalInversePolynomialFunc(FunctionNode):
 
         Parameters
         ----------
-        new_seed : `int`
+        new_seed : int
             The given seed
         """
         self._rng = np.random.default_rng(seed=new_seed)
@@ -87,14 +87,14 @@ class NumericalInversePolynomialFunc(FunctionNode):
 
         Parameters
         ----------
-        args : `dict`
+        args : dict
             A dictionary mapping argument name to individual values.
-        rng : `numpy.random._generator.Generator`
+        rng : numpy.random._generator.Generator
             The random number generator to use.
 
         Returns
         -------
-        sample : `float`
+        sample : float
             The result of sampling the function.
         """
         dist = self._dist(**args)
@@ -109,13 +109,13 @@ class NumericalInversePolynomialFunc(FunctionNode):
 
         Parameters
         ----------
-        graph_state : `GraphState`
+        graph_state : GraphState
             An object mapping graph parameters to their values. This object is modified
             in place as it is sampled.
         rng_info : numpy.random._generator.Generator, optional
             A given numpy random number generator to use for this computation. If not
             provided, the function uses the node's random number generator.
-        **kwargs : `dict`, optional
+        **kwargs : dict, optional
             Additional function arguments.
 
         Returns

--- a/src/tdastro/math_nodes/single_value_node.py
+++ b/src/tdastro/math_nodes/single_value_node.py
@@ -12,11 +12,11 @@ class SingleVariableNode(ParameterizedNode):
 
     Parameters
     ----------
-    name : `str`
+    name : str
         The parameter name.
     value : any
         The parameter value.
-    **kwargs : `dict`, optional
+    **kwargs : dict, optional
         Any additional keyword arguments.
     """
 

--- a/src/tdastro/sources/basic_sources.py
+++ b/src/tdastro/sources/basic_sources.py
@@ -19,9 +19,9 @@ class StaticSource(PhysicalModel):
 
     Parameters
     ----------
-    brightness : `float`
+    brightness : float
         The inherent brightness
-    **kwargs : `dict`, optional
+    **kwargs : dict, optional
         Any additional keyword arguments.
     """
 
@@ -34,18 +34,18 @@ class StaticSource(PhysicalModel):
 
         Parameters
         ----------
-        times : `numpy.ndarray`
+        times : numpy.ndarray
             A length T array of rest frame timestamps.
-        wavelengths : `numpy.ndarray`, optional
+        wavelengths : numpy.ndarray, optional
             A length N array of wavelengths (in angstroms).
-        graph_state : `GraphState`
+        graph_state : GraphState
             An object mapping graph parameters to their values.
-        **kwargs : `dict`, optional
+        **kwargs : dict, optional
             Any additional keyword arguments.
 
         Returns
         -------
-        flux_density : `numpy.ndarray`
+        flux_density : numpy.ndarray
             A length T x N matrix of SED values (in nJy).
         """
         params = self.get_local_params(graph_state)
@@ -67,13 +67,13 @@ class StepSource(StaticSource):
 
     Parameters
     ----------
-    brightness : `float`
+    brightness : float
         The inherent brightness
-    t0 : `float`
+    t0 : float
         The time the step function starts, in MJD.
-    t1 : `float`
+    t1 : float
         The time the step function ends, in MJD.
-    **kwargs : `dict`, optional
+    **kwargs : dict, optional
         Any additional keyword arguments.
     """
 
@@ -88,18 +88,18 @@ class StepSource(StaticSource):
 
         Parameters
         ----------
-        times : `numpy.ndarray`
+        times : numpy.ndarray
             A length T array of rest frame timestamps.
-        wavelengths : `numpy.ndarray`, optional
+        wavelengths : numpy.ndarray, optional
             A length N array of wavelengths (in angstroms).
-        graph_state : `GraphState`
+        graph_state : GraphState
             An object mapping graph parameters to their values.
-        **kwargs : `dict`, optional
+        **kwargs : dict, optional
            Any additional keyword arguments.
 
         Returns
         -------
-        flux_density : `numpy.ndarray`
+        flux_density : numpy.ndarray
             A length T x N matrix of SED values (in nJy).
         """
         flux_density = np.zeros((len(times), len(wavelengths)))
@@ -127,11 +127,11 @@ class SinWaveSource(PhysicalModel):
 
     Parameters
     ----------
-    brightness : `float`
+    brightness : float
         The inherent brightness
-    frequency : `float`
+    frequency : float
         The frequence of the sine wave.
-    **kwargs : `dict`, optional
+    **kwargs : dict, optional
         Any additional keyword arguments.
     """
 
@@ -145,18 +145,18 @@ class SinWaveSource(PhysicalModel):
 
         Parameters
         ----------
-        times : `numpy.ndarray`
+        times : numpy.ndarray
             A length T array of rest frame timestamps.
-        wavelengths : `numpy.ndarray`, optional
+        wavelengths : numpy.ndarray, optional
             A length N array of wavelengths (in angstroms).
-        graph_state : `GraphState`
+        graph_state : GraphState
             An object mapping graph parameters to their values.
-        **kwargs : `dict`, optional
+        **kwargs : dict, optional
             Any additional keyword arguments.
 
         Returns
         -------
-        flux_density : `numpy.ndarray`
+        flux_density : numpy.ndarray
             A length T x N matrix of SED values (in nJy).
         """
         params = self.get_local_params(graph_state)

--- a/src/tdastro/sources/galaxy_models.py
+++ b/src/tdastro/sources/galaxy_models.py
@@ -20,12 +20,12 @@ class GaussianGalaxy(PhysicalModel):
 
     Parameters
     ----------
-    brightness : `float`
+    brightness : float
         The inherent brightness at the center of the galaxy.
-    radius : `float`
+    radius : float
         The standard deviation of the brightness as we move away
         from the galaxy's center (in degrees).
-    **kwargs : `dict`, optional
+    **kwargs : dict, optional
         Any additional keyword arguments.
     """
 
@@ -39,22 +39,22 @@ class GaussianGalaxy(PhysicalModel):
 
         Parameters
         ----------
-        times : `numpy.ndarray`
+        times : numpy.ndarray
             A length T array of rest frame timestamps.
-        wavelengths : `numpy.ndarray`, optional
+        wavelengths : numpy.ndarray, optional
             A length N array of wavelengths (in angstroms).
-        graph_state : `GraphState`
+        graph_state : GraphState
             An object mapping graph parameters to their values.
-        ra : `float`, optional
+        ra : float, optional
             The right ascension of the observations in degrees.
-        dec : `float`, optional
+        dec : float, optional
             The declination of the observations in degrees.
-        **kwargs : `dict`, optional
+        **kwargs : dict, optional
            Any additional keyword arguments.
 
         Returns
         -------
-        flux_density : `numpy.ndarray`
+        flux_density : numpy.ndarray
             A length T x N matrix of SED values (in nJy).
         """
         params = self.get_local_params(graph_state)

--- a/src/tdastro/sources/periodic_source.py
+++ b/src/tdastro/sources/periodic_source.py
@@ -17,9 +17,9 @@ class PeriodicSource(PhysicalModel, ABC):
 
     Parameters
     ----------
-    period : `float`
+    period : float
         The period of the source, in days.
-    **kwargs : `dict`, optional
+    **kwargs : dict, optional
         Any additional keyword arguments.
     """
 
@@ -35,18 +35,18 @@ class PeriodicSource(PhysicalModel, ABC):
 
         Parameters
         ----------
-        phases : `numpy.ndarray`
+        phases : numpy.ndarray
             A length T array of phases, in the range [0, 1].
-        wavelengths : `numpy.ndarray`, optional
+        wavelengths : numpy.ndarray, optional
             A length N array of wavelengths.
-        graph_state : `GraphState`
+        graph_state : GraphState
             An object mapping graph parameters to their values.
-        **kwargs : `dict`, optional
+        **kwargs : dict, optional
               Any additional keyword arguments.
 
         Returns
         -------
-        flux_density : `numpy.ndarray`
+        flux_density : numpy.ndarray
             A length T x N matrix of SED values.
         """
         raise NotImplementedError()
@@ -56,18 +56,18 @@ class PeriodicSource(PhysicalModel, ABC):
 
         Parameters
         ----------
-        times : `numpy.ndarray`
+        times : numpy.ndarray
             A length T array of rest frame timestamps.
-        wavelengths : `numpy.ndarray`, optional
+        wavelengths : numpy.ndarray, optional
             A length N array of wavelengths.
-        graph_state : `GraphState`
+        graph_state : GraphState
             An object mapping graph parameters to their values.
-        **kwargs : `dict`, optional
+        **kwargs : dict, optional
            Any additional keyword arguments.
 
         Returns
         -------
-        flux_density : `numpy.ndarray`
+        flux_density : numpy.ndarray
             A length T x N matrix of SED values.
         """
         params = self.get_local_params(graph_state)

--- a/src/tdastro/sources/periodic_variable_star.py
+++ b/src/tdastro/sources/periodic_variable_star.py
@@ -21,12 +21,12 @@ class PeriodicVariableStar(PeriodicSource, ABC):
 
     Attributes
     ----------
-    period : `float`
+    period : float
         The period of the source, in days.
-    t0 : `float`
+    t0 : float
         The t0 of the zero phase, date. Could be date of the minimum or maximum light
         or any other reference time point.
-    distance : `float`
+    distance : float
         The distance to the source, in pc.
     """
 
@@ -40,18 +40,18 @@ class PeriodicVariableStar(PeriodicSource, ABC):
 
         Parameters
         ----------
-        phases : `numpy.ndarray`
+        phases : numpy.ndarray
             A length T array of phases, in the range [0, 1].
-        wavelengths : `numpy.ndarray`, optional
+        wavelengths : numpy.ndarray, optional
             A length N array of wavelengths, in angstroms.
-        graph_state : `dict`, optional
+        graph_state : dict, optional
             A given setting of all the parameters and their values.
-        **kwargs : `dict`, optional
+        **kwargs : dict, optional
               Any additional keyword arguments.
 
         Returns
         -------
-        flux_density : `numpy.ndarray`
+        flux_density : numpy.ndarray
             A length T x N matrix of SED values, in nJy.
         """
         distance_cm = self.get_param(graph_state, "distance") * PARSEC_TO_CM
@@ -72,18 +72,18 @@ class PeriodicVariableStar(PeriodicSource, ABC):
 
         Parameters
         ----------
-        phases : `numpy.ndarray`
+        phases : numpy.ndarray
             A length T array of phases, in the range [0, 1].
-        wavelengths_cm : `numpy.ndarray`, optional
+        wavelengths_cm : numpy.ndarray, optional
             A length N array of wavelengths in cm.
-        graph_state : `dict`, optional
+        graph_state : dict, optional
             A given setting of all the parameters and their values.
-        **kwargs : `dict`, optional
+        **kwargs : dict, optional
               Any additional keyword arguments.
 
         Returns
         -------
-        luminosity_density_per_solid_angle : `numpy.ndarray`
+        luminosity_density_per_solid_angle : numpy.ndarray
             A length T x N matrix of luminosity density per unit solid angle values.
             Units are CGS, erg/s/Hz/steradian.
         """
@@ -113,19 +113,19 @@ class EclipsingBinaryStar(PeriodicVariableStar):
 
     Attributes
     ----------
-    period : `float`
+    period : float
         The period of the source, in days.
-    major_semiaxis : `float`
+    major_semiaxis : float
         The major semiaxis of the orbit, in AU.
-    inclination : `float`
+    inclination : float
         The inclination of the orbit, in degrees.
-    primary_radius : `float`
+    primary_radius : float
         The radius of the primary star, in solar radii.
-    secondary_radius : `float`
+    secondary_radius : float
         The radius of the secondary star, in solar radii.
-    primary_temperature : `float`
+    primary_temperature : float
         The effective temperature of the primary star, in kelvins.
-    secondary_temperature : `float`
+    secondary_temperature : float
         The effective temperature of the secondary star, in kelvins.
     """
 
@@ -143,18 +143,18 @@ class EclipsingBinaryStar(PeriodicVariableStar):
 
         Parameters
         ----------
-        phases : `numpy.ndarray`
+        phases : numpy.ndarray
             A length T array of phases, in the range [0, 1].
-        wavelengths_cm : `numpy.ndarray`, optional
+        wavelengths_cm : numpy.ndarray, optional
             A length N array of wavelengths, in cm.
-        graph_state : `GraphState`
+        graph_state : GraphState
             An object mapping graph parameters to their values.
-        **kwargs : `dict`, optional
+        **kwargs : dict, optional
               Any additional keyword arguments.
 
         Returns
         -------
-        luminosity_density : `numpy.ndarray`
+        luminosity_density : numpy.ndarray
             A length T x N matrix of luminosity density values.
             Output is in CGS units of erg/s/Hz/steradian.
         """
@@ -206,14 +206,14 @@ class EclipsingBinaryStar(PeriodicVariableStar):
 
         Parameters
         ----------
-        phase_fraction : `np.ndarray`
+        phase_fraction : np.ndarray
             The phase of the orbit, in the range [0, 1].
-        inclination_degree : `float`
+        inclination_degree : float
             The inclination of the orbit, in degrees.
 
         Returns
         -------
-        distance : `np.ndarray`
+        distance : np.ndarray
             The distance between the centers of the stars on the plane of the sky,
             normalized by the major semiaxis.
         """
@@ -227,16 +227,16 @@ class EclipsingBinaryStar(PeriodicVariableStar):
 
         Parameters
         ----------
-        d : `np.ndarray`
+        d : np.ndarray
             The distance between the centers of the circles.
-        r1 : `float`
+        r1 : float
             The radius of the first circle.
-        r2 : `float`
+        r2 : float
             The radius of the second circle.
 
         Returns
         -------
-        overlap_area : `np.ndarray`
+        overlap_area : np.ndarray
             The area of overlap between the two circles.
         """
 

--- a/src/tdastro/sources/physical_model.py
+++ b/src/tdastro/sources/physical_model.py
@@ -33,32 +33,32 @@ class PhysicalModel(ParameterizedNode):
 
     Attributes
     ----------
-    background : `PhysicalModel`
+    background : PhysicalModel
         A source of background flux such as a host galaxy.
-    apply_redshift : `bool`
+    apply_redshift : bool
         Indicates whether to apply the redshift.
 
     Parameters
     ----------
-    ra : `float`
+    ra : float
         The object's right ascension (in degrees)
-    dec : `float`
+    dec : float
         The object's declination (in degrees)
-    redshift : `float`
+    redshift : float
         The object's redshift.
-    t0 : `float`
+    t0 : float
         The phase offset in MJD. For non-time-varying phenomena, this has no effect.
-    distance : `float`
+    distance : float
         The object's luminosity distance (in pc). If no value is provided and
-        a ``cosmology`` parameter is given, the model will try to derive from
+        a cosmology parameter is given, the model will try to derive from
         the redshift and the cosmology.
     white_noise_sigma : float
         The standard deviation of the white noise to add to the flux density.
-    background : `PhysicalModel`
+    background : PhysicalModel
         A source of background flux such as a host galaxy.
     seed : int, optional
         The seed for a random number generator.
-    **kwargs : `dict`, optional
+    **kwargs : dict, optional
         Any additional keyword arguments.
     """
 
@@ -110,7 +110,7 @@ class PhysicalModel(ParameterizedNode):
 
         Parameters
         ----------
-        seen_nodes : `set`, optional
+        seen_nodes : set, optional
             A set of nodes that have already been processed to prevent infinite loops.
             Caller should not set.
         """
@@ -127,7 +127,7 @@ class PhysicalModel(ParameterizedNode):
 
         Parameters
         ----------
-        apply_redshift : `bool`
+        apply_redshift : bool
             The new value for apply_redshift.
         """
         self.apply_redshift = apply_redshift
@@ -158,16 +158,16 @@ class PhysicalModel(ParameterizedNode):
 
         Parameters
         ----------
-        times : `numpy.ndarray`
+        times : numpy.ndarray
             A length T array of rest frame timestamps in MJD.
-        wavelengths : `numpy.ndarray`, optional
+        wavelengths : numpy.ndarray, optional
             A length N array of rest frame wavelengths (in angstroms).
-        graph_state : `GraphState`
+        graph_state : GraphState
             An object mapping graph parameters to their values.
 
         Returns
         -------
-        flux_density : `numpy.ndarray`
+        flux_density : numpy.ndarray
             A length T x N matrix of rest frame SED values (in nJy).
         """
         raise NotImplementedError()
@@ -177,24 +177,24 @@ class PhysicalModel(ParameterizedNode):
 
         Parameters
         ----------
-        times : `numpy.ndarray`
+        times : numpy.ndarray
             A length T array of observer frame timestamps in MJD.
-        wavelengths : `numpy.ndarray`, optional
+        wavelengths : numpy.ndarray, optional
             A length N array of wavelengths (in angstroms).
-        graph_state : `GraphState`, optional
+        graph_state : GraphState, optional
             An object mapping graph parameters to their values.
-        given_args : `dict`, optional
+        given_args : dict, optional
             A dictionary representing the given arguments for this sample run.
             This can be used as the JAX PyTree for differentiation.
         rng_info : numpy.random._generator.Generator, optional
             A given numpy random number generator to use for this computation. If not
             provided, the function uses the node's random number generator.
-        **kwargs : `dict`, optional
+        **kwargs : dict, optional
             All the other keyword arguments.
 
         Returns
         -------
-        flux_density : `numpy.ndarray`
+        flux_density : numpy.ndarray
             A length S x T x N matrix of SED values (in nJy), where S is the number of samples,
             T is the number of time steps, and N is the number of wavelengths.
             If S=1 then the function returns a T x N matrix.
@@ -266,22 +266,22 @@ class PhysicalModel(ParameterizedNode):
 
         Parameters
         ----------
-        given_args : `dict`, optional
+        given_args : dict, optional
             A dictionary representing the given arguments for this sample run.
             This can be used as the JAX PyTree for differentiation.
-        num_samples : `int`
+        num_samples : int
             A count of the number of samples to compute.
             Default: 1
         rng_info : numpy.random._generator.Generator, optional
             A given numpy random number generator to use for this computation. If not
             provided, the function uses the node's random number generator.
-        **kwargs : `dict`, optional
+        **kwargs : dict, optional
             All the keyword arguments, including the values needed to sample
             parameters.
 
         Returns
         -------
-        graph_state : `GraphState`
+        graph_state : GraphState
             An object mapping graph parameters to their values.
         """
         # If the graph has not been sampled ever, update the node positions for
@@ -307,19 +307,19 @@ class PhysicalModel(ParameterizedNode):
 
         Parameters
         ----------
-        passband_or_group : `Passband` or `PassbandGroup`
+        passband_or_group : Passband or PassbandGroup
             The passband (or passband group) to use.
-        times : `numpy.ndarray`
+        times : numpy.ndarray
             A length T array of observer frame timestamps in MJD.
-        filters : `numpy.ndarray` or None
+        filters : numpy.ndarray or None
             A length T array of filter names. It may be None if
             passband_or_group is a Passband.
-        state : `GraphState`
+        state : GraphState
             An object mapping graph parameters to their values.
 
         Returns
         -------
-        band_fluxes : `numpy.ndarray`
+        band_fluxes : numpy.ndarray
             A matrix of the band fluxes. If only one sample is provided in the GraphState,
             then returns a length T array. Otherwise returns a size S x T array where S is the
             number of samples in the graph state.

--- a/src/tdastro/sources/salt2_jax.py
+++ b/src/tdastro/sources/salt2_jax.py
@@ -57,19 +57,19 @@ class SALT2JaxModel(PhysicalModel):
         The SALT2 x1 parameter.
     c : parameter
         The SALT2 c parameter.
-    model_dir : `str`
+    model_dir : str
         The path for the model file directory.
         Default: ""
-    m0_filename : `str`
+    m0_filename : str
         The file name for the m0 model component.
         Default: "salt2_template_0.dat"
-    m1_filename : `str`
+    m1_filename : str
         The file name for the m1 model component.
         Default: "salt2_template_1.dat"
-    cl_filename : `str`
+    cl_filename : str
         The file name of the color law correction coefficients.
         Default: "salt2_color_correction.dat",
-    **kwargs : `dict`, optional
+    **kwargs : dict, optional
         Any additional keyword arguments.
     """
 
@@ -146,19 +146,19 @@ class SALT2JaxModel(PhysicalModel):
 
         Parameters
         ----------
-        phase : `numpy.ndarray`
+        phase : numpy.ndarray
             A length T array of rest frame timestamps.
-        wavelengths : `numpy.ndarray`, optional
+        wavelengths : numpy.ndarray, optional
             A length N array of wavelengths (in angstroms).
-        graph_state : `GraphState`
+        graph_state : GraphState
             An object mapping graph parameters to their values.
 
-        **kwargs : `dict`, optional
+        **kwargs : dict, optional
            Any additional keyword arguments.
 
         Returns
         -------
-        flux_density : `numpy.ndarray`
+        flux_density : numpy.ndarray
             A length T x N matrix of SED values (in nJy).
         """
         m0_vals = self._m0_model(phase, wavelengths)

--- a/src/tdastro/sources/sncomso_models.py
+++ b/src/tdastro/sources/sncomso_models.py
@@ -26,20 +26,20 @@ class SncosmoWrapperModel(PhysicalModel):
 
     Attributes
     ----------
-    source : `sncosmo.Source`
+    source : sncosmo.Source
         The underlying source model.
-    source_name : `str`
+    source_name : str
         The name used to set the source.
-    source_param_names : `list`
+    source_param_names : list
         A list of the source model's parameters that we need to set.
 
     Parameters
     ----------
-    source_name : `str`
+    source_name : str
         The name used to set the source.
-    node_label : `str`, optional
+    node_label : str, optional
         An identifier (or name) for the current node.
-    **kwargs : `dict`, optional
+    **kwargs : dict, optional
         Any additional keyword arguments.
     """
 
@@ -82,7 +82,7 @@ class SncosmoWrapperModel(PhysicalModel):
 
         Parameters
         ----------
-        name : `str`
+        name : str
             The name of the parameter.
 
         Returns
@@ -98,7 +98,7 @@ class SncosmoWrapperModel(PhysicalModel):
 
         Parameters
         ----------
-        **kwargs : `dict`
+        **kwargs : dict
             The parameters to set and their values.
         """
         for key, value in kwargs.items():
@@ -119,13 +119,13 @@ class SncosmoWrapperModel(PhysicalModel):
 
         Parameters
         ----------
-        graph_state : `GraphState`
+        graph_state : GraphState
             An object mapping graph parameters to their values. This object is modified
             in place as it is sampled.
-        seen_nodes : `dict`
+        seen_nodes : dict
             A dictionary mapping nodes seen during this sampling run to their ID.
             Used to avoid sampling nodes multiple times and to validity check the graph.
-        num_samples : `int`
+        num_samples : int
             A count of the number of samples to compute.
             Default: 1
         rng_info : numpy.random._generator.Generator, optional
@@ -134,7 +134,7 @@ class SncosmoWrapperModel(PhysicalModel):
 
         Raises
         ------
-        Raise a ``ValueError`` the sampling encounters a problem with the order of dependencies.
+        Raise a ValueError the sampling encounters a problem with the order of dependencies.
         """
         super()._sample_helper(graph_state, seen_nodes, rng_info)
         self._update_sncosmo_model_parameters(graph_state)
@@ -178,18 +178,18 @@ class SncosmoWrapperModel(PhysicalModel):
 
         Parameters
         ----------
-        times : `numpy.ndarray`
+        times : numpy.ndarray
             A length T array of rest frame timestamps.
-        wavelengths : `numpy.ndarray`, optional
+        wavelengths : numpy.ndarray, optional
             A length N array of wavelengths (in angstroms).
-        graph_state : `GraphState`
+        graph_state : GraphState
             An object mapping graph parameters to their values.
-        **kwargs : `dict`, optional
+        **kwargs : dict, optional
            Any additional keyword arguments.
 
         Returns
         -------
-        flux_density : `numpy.ndarray`
+        flux_density : numpy.ndarray
             A length T x N matrix of SED values (in nJy).
         """
         params = self.get_local_params(graph_state)

--- a/src/tdastro/sources/spline_model.py
+++ b/src/tdastro/sources/spline_model.py
@@ -26,35 +26,35 @@ class SplineModel(PhysicalModel):
 
     Attributes
     ----------
-    _times : `numpy.ndarray`
+    _times : numpy.ndarray
         A length T array containing the times at which the data was sampled.
-    _wavelengths : `numpy.ndarray`
+    _wavelengths : numpy.ndarray
         A length W array containing the wavelengths at which the data was sampled
         (in angstroms).
-    _spline : `RectBivariateSpline`
+    _spline : RectBivariateSpline
         The spline object for predicting the flux from a given (time, wavelength).
-    name : `str`
+    name : str
         The name of the model being used.
 
     Parameters
     ----------
-    times : `numpy.ndarray`
+    times : numpy.ndarray
         A length T array containing the times at which the data was sampled.
-    wavelengths : `numpy.ndarray`
+    wavelengths : numpy.ndarray
         A length W array containing the wavelengths at which the data was sampled
         (in angstroms).
-    flux : `numpy.ndarray`
+    flux : numpy.ndarray
         A shape (T, W) matrix with flux values for each pair of time and wavelength.
         Fluxes provided in erg / s / cm^2 / Angstrom.
-    amplitude : `float`, `function`, `ParameterizedModel`, or `None`
+    amplitude : float, function, ParameterizedModel, or None
         A unitless scaling parameter for the flux density values. Default = 1.0
-    time_degree : `int`
+    time_degree : int
         The polynomial degree to use in the time dimension.
-    wave_degree : `int`
+    wave_degree : int
         The polynomial degree to use in the wavelength dimension.
-    name : `str`, optional
+    name : str, optional
         The name of the model.
-    **kwargs : `dict`, optional
+    **kwargs : dict, optional
         Any additional keyword arguments.
     """
 
@@ -85,18 +85,18 @@ class SplineModel(PhysicalModel):
 
         Parameters
         ----------
-        times : `numpy.ndarray`
+        times : numpy.ndarray
             A length T array of rest frame timestamps.
-        wavelengths : `numpy.ndarray`, optional
+        wavelengths : numpy.ndarray, optional
             A length N array of wavelengths (in angstroms).
-        graph_state : `GraphState`
+        graph_state : GraphState
             An object mapping graph parameters to their values.
-        **kwargs : `dict`, optional
+        **kwargs : dict, optional
            Any additional keyword arguments.
 
         Returns
         -------
-        flux_density : `numpy.ndarray`
+        flux_density : numpy.ndarray
             A length T x N matrix of SED values (in nJy).
         """
         params = self.get_local_params(graph_state)

--- a/src/tdastro/utils/bicubic_interp.py
+++ b/src/tdastro/utils/bicubic_interp.py
@@ -202,7 +202,7 @@ class BicubicInterpolator:
 
         Returns
         -------
-        results : `jaxlib.xla_extension.ArrayImpl`
+        results : jaxlib.xla_extension.ArrayImpl
             An N x M array of interpolated values for each (x, y) pair.
         """
         x_q = jnp.asarray(x_q)

--- a/src/tdastro/utils/io_utils.py
+++ b/src/tdastro/utils/io_utils.py
@@ -14,29 +14,29 @@ def read_grid_data(input_file, format="ascii", validate=False):
 
     Parameters
     ----------
-    input_file : `str` or file-like object
+    input_file : str or file-like object
         The input data file.
-    format : `str`
+    format : str
         The file format. Should be one of the formats supported by
         astropy Tables such as 'ascii', 'ascii.ecsv', or 'fits'.
         Default = 'ascii'
-    validate : `bool`
+    validate : bool
         Perform additional validation on the input data.
         Default = False
 
     Returns
     -------
-    x0 : `numpy.ndarray`
+    x0 : numpy.ndarray
         A 1-d array with the values along the x-axis of the grid.
-    x1 : `numpy.ndarray`
+    x1 : numpy.ndarray
         A 1-d array with the values along the y-axis of the grid.
-    values : `numpy.ndarray`
+    values : numpy.ndarray
         A 2-d array with the values at each point in the grid with
         shape (len(x0), len(x1)).
 
     Raises
     ------
-    ``ValueError`` if any data validation fails.
+    ValueError if any data validation fails.
     """
     logging.debug(f"Loading file {input_file} (format={format})")
     if not Path(input_file).is_file():


### PR DESCRIPTION
TDAstro uses a mix of formats in the doc string comments for variable types (no quotes, single quote, etc.). This standardizes to use no quotes for everything for consistency.