### PR TITLE
Add a check that the cosmology parameters are constants

### DIFF
--- a/src/tdastro/astro_utils/snia_utils.py
+++ b/src/tdastro/astro_utils/snia_utils.py
@@ -297,6 +297,8 @@ class DistModFromRedshift(FunctionNode):
 
     def __init__(self, redshift, H0=73.0, Omega_m=0.3, **kwargs):
         # Create the cosmology once for this node.
+        if not isinstance(H0, float) or not isinstance(Omega_m, float):
+            raise ValueError("H0 and Omega_m must be constants.")
         self.cosmo = FlatLambdaCDM(H0=H0, Om0=Omega_m)
 
         # Call the super class's constructor with the needed information.

--- a/tests/tdastro/astro_utils/test_snia_utils.py
+++ b/tests/tdastro/astro_utils/test_snia_utils.py
@@ -107,3 +107,10 @@ def test_dist_mod_from_redshift():
         node = DistModFromRedshift(redshift=z, H0=73.0, Omega_m=0.3)
         state = node.sample_parameters(num_samples=1)
         assert node.get_param(state, "function_node_result") == pytest.approx(expected[idx])
+
+    # Both H0 and Omega_m must be constants.
+    rand_node = NumpyRandomFunc("uniform", low=0.0, high=1.0)
+    with pytest.raises(ValueError):
+        DistModFromRedshift(redshift=0.3, H0=rand_node, Omega_m=0.3)
+    with pytest.raises(ValueError):
+        DistModFromRedshift(redshift=0.3, H0=73.0, Omega_m=rand_node)


### PR DESCRIPTION
While writing the tutorial for statistical sampling I ran into a bug where the cosmology code throws an error if given multiple parameters. This PR tests that they are constants.