### PR TITLE
Re-add the ability to specify a list of effects

### DIFF
--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -12,6 +12,7 @@ from tdastro.astro_utils.passbands import PassbandGroup
 from tdastro.astro_utils.snia_utils import DistModFromRedshift, HostmassX1Func, X0FromDistMod
 from tdastro.astro_utils.unit_utils import fnu_to_flam
 from tdastro.base_models import FunctionNode
+from tdastro.effects.white_noise import WhiteNoise
 from tdastro.math_nodes.np_random import NumpyRandomFunc
 from tdastro.sources.sncomso_models import SncosmoWrapperModel
 
@@ -80,6 +81,8 @@ class TimeSuite:
         self.graph_state = self.salt3_model.sample_parameters()
         self.fluxes = self.salt3_model.evaluate(self.times, self.wavelengths, graph_state=self.graph_state)
 
+        self.white_noise = WhiteNoise(white_noise_sigma=0.1)
+
     def time_chained_evaluate(self):
         """Time the generation of random numbers with an numpy generation node."""
 
@@ -95,6 +98,10 @@ class TimeSuite:
 
         # Generate 100,000 samples.
         _ = val_node.sample_parameters(num_samples=100_000)
+
+    def time_apply_white_noise(self):
+        """Time the application of white noise to a sample."""
+        _ = self.white_noise.apply(self.fluxes, white_noise_sigma=0.1)
 
     def time_make_x1_from_hostmass(self):
         """Time the creation of the X1 function."""

--- a/src/tdastro/effects/effect_model.py
+++ b/src/tdastro/effects/effect_model.py
@@ -1,0 +1,25 @@
+"""The base EffectModel class used for all effects."""
+
+
+class EffectModel:
+    """A physical or systematic effect to apply to an observation."""
+
+    def __init__(self, **kwargs):
+        pass
+
+    def apply(self, flux_density, **kwargs):
+        """Apply the effect to observations (flux_density values)
+
+        Parameters
+        ----------
+        flux_density : numpy.ndarray
+            A length T X N matrix of flux density values (in nJy).
+        **kwargs : `dict`, optional
+           Any additional keyword arguments.
+
+        Returns
+        -------
+        flux_density : numpy.ndarray
+            A length T x N matrix of flux densities after the effect is applied (in nJy).
+        """
+        raise NotImplementedError()

--- a/src/tdastro/effects/effect_model.py
+++ b/src/tdastro/effects/effect_model.py
@@ -1,13 +1,12 @@
 """The base EffectModel class used for all effects."""
 
-import numpy as np
-
 
 class EffectModel:
     """A physical or systematic effect to apply to an observation.
 
-    Effects are not ParameterizedNodes, but rather get their arguments
-    from the PhysicalObject's parameters via the kwargs in apply().
+    Effects are not ParameterizedNodes by can have arguments that are
+    ParameterizedNodes. All settable parameters of the EffectModel
+    must be passed as keyword arguments to the apply() method.
 
     Attributes
     ----------
@@ -37,33 +36,6 @@ class EffectModel:
             A function that sets the parameter value.
         """
         self.parameters[name] = setter
-
-        # If we are just setting a scalar, set the attribute directly.
-        if np.isscalar(setter):
-            setattr(self, name, setter)
-
-    def lookup_effect_parameter(self, name, **kwargs):
-        """Look up a parameter value from either the keyword arguments
-        or the effect's attributes.
-
-        Parameters
-        ----------
-        name : str
-            The name of the parameter.
-        **kwargs : dict
-            Additional keyword arguments to search for the parameter.
-
-        Returns
-        -------
-        value : object
-            The value of the parameter.
-        """
-        if name in kwargs:
-            return kwargs[name]
-        elif hasattr(self, name):
-            return getattr(self, name)
-        else:
-            raise ValueError(f"{self.__class__.__name__} effect requires {name} parameter.")
 
     def apply(self, flux_density, rng_info=None, **kwargs):
         """Apply the effect to observations (flux_density values)

--- a/src/tdastro/effects/effect_model.py
+++ b/src/tdastro/effects/effect_model.py
@@ -1,21 +1,83 @@
 """The base EffectModel class used for all effects."""
 
+import numpy as np
+
 
 class EffectModel:
-    """A physical or systematic effect to apply to an observation."""
+    """A physical or systematic effect to apply to an observation.
 
-    def __init__(self, **kwargs):
-        pass
+    Effects are not ParameterizedNodes, but rather get their arguments
+    from the PhysicalObject's parameters via the kwargs in apply().
 
-    def apply(self, flux_density, **kwargs):
+    Attributes
+    ----------
+    rest_frame : bool
+        Whether the effect is applied in the rest frame of the observation (True)
+        or in the observed frame (False).
+    parameters : dict
+        A dictionary of parameters for the effect. Mapps parameter names to
+        their setters.
+    """
+
+    def __init__(self, rest_frame=True, **kwargs):
+        self.rest_frame = rest_frame
+
+        self.parameters = {}
+        for key, value in kwargs.items():
+            self.add_effect_parameter(key, value)
+
+    def add_effect_parameter(self, name, setter):
+        """Add a parameter to the effect.
+
+        Parameters
+        ----------
+        name : str
+            The name of the parameter.
+        setter : function
+            A function that sets the parameter value.
+        """
+        self.parameters[name] = setter
+
+        # If we are just setting a scalar, set the attribute directly.
+        if np.isscalar(setter):
+            setattr(self, name, setter)
+
+    def lookup_effect_parameter(self, name, **kwargs):
+        """Look up a parameter value from either the keyword arguments
+        or the effect's attributes.
+
+        Parameters
+        ----------
+        name : str
+            The name of the parameter.
+        **kwargs : dict
+            Additional keyword arguments to search for the parameter.
+
+        Returns
+        -------
+        value : object
+            The value of the parameter.
+        """
+        if name in kwargs:
+            return kwargs[name]
+        elif hasattr(self, name):
+            return getattr(self, name)
+        else:
+            raise ValueError(f"{self.__class__.__name__} effect requires {name} parameter.")
+
+    def apply(self, flux_density, rng_info=None, **kwargs):
         """Apply the effect to observations (flux_density values)
 
         Parameters
         ----------
         flux_density : numpy.ndarray
             A length T X N matrix of flux density values (in nJy).
+        rng_info : numpy.random._generator.Generator, optional
+            A given numpy random number generator to use for this computation. If not
+            provided, the function uses the node's random number generator.
         **kwargs : `dict`, optional
-           Any additional keyword arguments.
+           Any additional keyword arguments. This includes all of the
+           parameters needed to apply the effect.
 
         Returns
         -------

--- a/src/tdastro/effects/effect_model.py
+++ b/src/tdastro/effects/effect_model.py
@@ -4,7 +4,7 @@
 class EffectModel:
     """A physical or systematic effect to apply to an observation.
 
-    Effects are not ParameterizedNodes by can have arguments that are
+    Effects are not ParameterizedNodes but can have arguments that are
     ParameterizedNodes. All settable parameters of the EffectModel
     must be passed as keyword arguments to the apply() method.
 
@@ -14,7 +14,7 @@ class EffectModel:
         Whether the effect is applied in the rest frame of the observation (True)
         or in the observed frame (False).
     parameters : dict
-        A dictionary of parameters for the effect. Mapps parameter names to
+        A dictionary of parameters for the effect. Maps the parameter names to
         their setters.
     """
 
@@ -38,7 +38,7 @@ class EffectModel:
         self.parameters[name] = setter
 
     def apply(self, flux_density, rng_info=None, **kwargs):
-        """Apply the effect to observations (flux_density values)
+        """Apply the effect to observations (flux_density values).
 
         Parameters
         ----------

--- a/src/tdastro/effects/white_noise.py
+++ b/src/tdastro/effects/white_noise.py
@@ -8,33 +8,34 @@ class WhiteNoise(EffectModel):
 
     Attributes
     ----------
-    scale : `float`
+    white_noise_sigma : parameter
         The scale of the noise.
     """
 
-    def __init__(self, scale, **kwargs):
+    def __init__(self, white_noise_sigma, **kwargs):
         super().__init__(**kwargs)
-        self.scale = scale
+        self.add_effect_parameter("white_noise_sigma", white_noise_sigma)
 
-    def apply(self, flux_density, rng=None, **kwargs):
+    def apply(self, flux_density, rng_info=None, **kwargs):
         """Apply the effect to observations (flux_density values)
 
         Parameters
         ----------
         flux_density : numpy.ndarray
             A length T X N matrix of flux density values (in nJy).
-        rng : numpy.random._generator.Generator, optional
-            A random number generator to use for this evaluation. Override
-            only for testing purposes.
-            Default: None.
+        rng_info : numpy.random._generator.Generator, optional
+            A given numpy random number generator to use for this computation. If not
+            provided, the function uses the node's random number generator.
         **kwargs : `dict`, optional
-           Any additional keyword arguments.
+           Any additional keyword arguments. This includes all of the
+           parameters needed to apply the effect.
 
         Returns
         -------
         flux_density : numpy.ndarray
             A length T x N matrix of flux densities after the effect is applied (in nJy).
         """
-        if rng is None:
-            rng = np.random.default_rng()
-        return rng.normal(loc=flux_density, scale=self.scale)
+        scale = self.lookup_effect_parameter("white_noise_sigma", **kwargs)
+        if rng_info is None:
+            rng_info = np.random.default_rng()
+        return rng_info.normal(loc=flux_density, scale=scale)

--- a/src/tdastro/effects/white_noise.py
+++ b/src/tdastro/effects/white_noise.py
@@ -16,13 +16,15 @@ class WhiteNoise(EffectModel):
         super().__init__(**kwargs)
         self.add_effect_parameter("white_noise_sigma", white_noise_sigma)
 
-    def apply(self, flux_density, rng_info=None, **kwargs):
+    def apply(self, flux_density, white_noise_sigma=None, rng_info=None, **kwargs):
         """Apply the effect to observations (flux_density values)
 
         Parameters
         ----------
         flux_density : numpy.ndarray
             A length T X N matrix of flux density values (in nJy).
+        white_noise_sigma : float, optional
+            The scale of the noise. Raises an error if None is provided.
         rng_info : numpy.random._generator.Generator, optional
             A given numpy random number generator to use for this computation. If not
             provided, the function uses the node's random number generator.
@@ -35,7 +37,9 @@ class WhiteNoise(EffectModel):
         flux_density : numpy.ndarray
             A length T x N matrix of flux densities after the effect is applied (in nJy).
         """
-        scale = self.lookup_effect_parameter("white_noise_sigma", **kwargs)
+        if white_noise_sigma is None:
+            raise ValueError("white_noise_sigma must be provided")
+
         if rng_info is None:
             rng_info = np.random.default_rng()
-        return rng_info.normal(loc=flux_density, scale=scale)
+        return rng_info.normal(loc=flux_density, scale=white_noise_sigma)

--- a/src/tdastro/effects/white_noise.py
+++ b/src/tdastro/effects/white_noise.py
@@ -1,0 +1,40 @@
+import numpy as np
+
+from tdastro.effects.effect_model import EffectModel
+
+
+class WhiteNoise(EffectModel):
+    """A white noise model.
+
+    Attributes
+    ----------
+    scale : `float`
+        The scale of the noise.
+    """
+
+    def __init__(self, scale, **kwargs):
+        super().__init__(**kwargs)
+        self.scale = scale
+
+    def apply(self, flux_density, rng=None, **kwargs):
+        """Apply the effect to observations (flux_density values)
+
+        Parameters
+        ----------
+        flux_density : numpy.ndarray
+            A length T X N matrix of flux density values (in nJy).
+        rng : numpy.random._generator.Generator, optional
+            A random number generator to use for this evaluation. Override
+            only for testing purposes.
+            Default: None.
+        **kwargs : `dict`, optional
+           Any additional keyword arguments.
+
+        Returns
+        -------
+        flux_density : numpy.ndarray
+            A length T x N matrix of flux densities after the effect is applied (in nJy).
+        """
+        if rng is None:
+            rng = np.random.default_rng()
+        return rng.normal(loc=flux_density, scale=self.scale)

--- a/src/tdastro/effects/white_noise.py
+++ b/src/tdastro/effects/white_noise.py
@@ -17,7 +17,7 @@ class WhiteNoise(EffectModel):
         self.add_effect_parameter("white_noise_sigma", white_noise_sigma)
 
     def apply(self, flux_density, white_noise_sigma=None, rng_info=None, **kwargs):
-        """Apply the effect to observations (flux_density values)
+        """Apply the effect to observations (flux_density values).
 
         Parameters
         ----------

--- a/src/tdastro/sources/basic_sources.py
+++ b/src/tdastro/sources/basic_sources.py
@@ -15,7 +15,6 @@ class StaticSource(PhysicalModel):
       * ra - The object's right ascension in degrees. [from PhysicalModel]
       * redshift - The object's redshift. [from PhysicalModel]
       * t0 - No effect for static model. [from PhysicalModel]
-      * white_noise_sigma - The standard deviation of the white noise. [from PhysicalModel]
 
     Parameters
     ----------
@@ -63,7 +62,6 @@ class StepSource(StaticSource):
       * redshift - The object's redshift. [from PhysicalModel]
       * t0 - The time the step function starts, in MJD.
       * t1- The time the step function ends, in MJD.
-      * white_noise_sigma - The standard deviation of the white noise. [from PhysicalModel]
 
     Parameters
     ----------
@@ -123,7 +121,6 @@ class SinWaveSource(PhysicalModel):
       * ra - The object's right ascension in degrees. [from PhysicalModel]
       * redshift - The object's redshift. [from PhysicalModel]
       * t0 - The start of the sine wave's period. [from PhysicalModel]
-      * white_noise_sigma - The standard deviation of the white noise. [from PhysicalModel]
 
     Parameters
     ----------

--- a/src/tdastro/sources/galaxy_models.py
+++ b/src/tdastro/sources/galaxy_models.py
@@ -16,7 +16,6 @@ class GaussianGalaxy(PhysicalModel):
       * ra - The object's right ascension in degrees. [from PhysicalModel]
       * redshift - The object's redshift. [from PhysicalModel]
       * t0 - No effect for a GuassianGalaxy [from PhysicalModel]
-      * white_noise_sigma - The standard deviation of the white noise. [from PhysicalModel]
 
     Parameters
     ----------

--- a/src/tdastro/sources/periodic_source.py
+++ b/src/tdastro/sources/periodic_source.py
@@ -13,7 +13,6 @@ class PeriodicSource(PhysicalModel, ABC):
       * ra - The object's right ascension in degrees. [from PhysicalModel]
       * redshift - The object's redshift. [from PhysicalModel]
       * t0 - The t0 of the zero phase, date. [from PhysicalModel]
-      * white_noise_sigma - The standard deviation of the white noise. [from PhysicalModel]
 
     Parameters
     ----------

--- a/src/tdastro/sources/periodic_variable_star.py
+++ b/src/tdastro/sources/periodic_variable_star.py
@@ -17,7 +17,6 @@ class PeriodicVariableStar(PeriodicSource, ABC):
       * ra - The object's right ascension in degrees. [from PhysicalModel]
       * redshift - The object's redshift. [from PhysicalModel]
       * t0 - The t0 of the zero phase, date. [from PhysicalModel]
-      * white_noise_sigma - The standard deviation of the white noise. [from PhysicalModel]
 
     Attributes
     ----------

--- a/src/tdastro/sources/physical_model.py
+++ b/src/tdastro/sources/physical_model.py
@@ -29,7 +29,6 @@ class PhysicalModel(ParameterizedNode):
       * ra - The object's right ascension in degrees.
       * redshift - The object's redshift.
       * t0 - The t0 of the zero phase (if applicable), date.
-      * white_noise_sigma - The standard deviation of the white noise.
 
     Attributes
     ----------
@@ -37,6 +36,10 @@ class PhysicalModel(ParameterizedNode):
         A source of background flux such as a host galaxy.
     apply_redshift : bool
         Indicates whether to apply the redshift.
+    rest_frame_effects : list of EffectModel
+        A list of effects to apply in the rest frame.
+    obs_frame_effects : list of EffectModel
+        A list of effects to apply in the observer frame.
 
     Parameters
     ----------
@@ -52,10 +55,10 @@ class PhysicalModel(ParameterizedNode):
         The object's luminosity distance (in pc). If no value is provided and
         a cosmology parameter is given, the model will try to derive from
         the redshift and the cosmology.
-    white_noise_sigma : float
-        The standard deviation of the white noise to add to the flux density.
     background : PhysicalModel
         A source of background flux such as a host galaxy.
+    effects : list of EffectModel, optional
+        A list of effects to apply to the flux density.
     seed : int, optional
         The seed for a random number generator.
     **kwargs : dict, optional
@@ -70,7 +73,7 @@ class PhysicalModel(ParameterizedNode):
         t0=None,
         distance=None,
         background=None,
-        white_noise_sigma=0.0,
+        effects=None,
         seed=None,
         **kwargs,
     ):
@@ -81,7 +84,6 @@ class PhysicalModel(ParameterizedNode):
         self.add_parameter("dec", dec, allow_gradient=False)
         self.add_parameter("redshift", redshift, allow_gradient=False)
         self.add_parameter("t0", t0)
-        self.add_parameter("white_noise_sigma", white_noise_sigma, allow_gradient=False)
 
         # If the luminosity distance is provided, use that. Otherwise try the
         # redshift value using the cosmology (if given). Finally, default to None.
@@ -98,6 +100,22 @@ class PhysicalModel(ParameterizedNode):
 
         # Initialize the effect settings to their default values.
         self.apply_redshift = redshift is not None
+
+        # Process the effects.
+        self.rest_frame_effects = []
+        self.obs_frame_effects = []
+        if effects is not None and len(effects) > 0:
+            for effect in effects:
+                # Add any effect parameters that are not already in the model.
+                for param_name, setter in effect.parameters.items():
+                    if param_name not in self.setters:
+                        self.add_parameter(param_name, setter, allow_gradient=False)
+
+                # Add the effect to the appropriate list.
+                if effect.rest_frame:
+                    self.rest_frame_effects.append(effect)
+                else:
+                    self.obs_frame_effects.append(effect)
 
         # Get a default random number generator for this object, using the
         # given seed if one is provided.
@@ -224,20 +242,9 @@ class PhysicalModel(ParameterizedNode):
                     times, wavelengths, params["redshift"], params["t0"]
                 )
 
-            # Compute the flux density for the current object, then add white noise,
-            # and then add in anything behind the object, such as a host galaxy.
+            # Compute the flux density for the current object, add in anything behind
+            # the object, such as a host galaxy, and then apply rest frame effects.
             flux_density = self.compute_flux(times, wavelengths, state, **kwargs)
-
-            if params["white_noise_sigma"] != 0.0:
-                if rng_info is None:
-                    flux_density += self._rng.normal(
-                        scale=params["white_noise_sigma"], size=flux_density.shape
-                    )
-                else:
-                    flux_density += rng_info.normal(
-                        scale=params["white_noise_sigma"], size=flux_density.shape
-                    )
-
             if self.background is not None:
                 flux_density += self.background.compute_flux(
                     times,
@@ -247,11 +254,17 @@ class PhysicalModel(ParameterizedNode):
                     dec=params["dec"],
                     **kwargs,
                 )
+            for effect in self.rest_frame_effects:
+                flux_density = effect.apply(flux_density, rng_info=rng_info, **params)
 
             # Post-effects are adjustments done to the flux density after computation.
             if self.apply_redshift and params["redshift"] != 0.0:
                 # We have alread checked that redshift is not None.
                 flux_density = rest_to_obs_flux(flux_density, params["redshift"])
+
+            # Apply observer frame effects.
+            for effect in self.obs_frame_effects:
+                flux_density = effect.apply(flux_density, rng_info=rng_info, **params)
 
             # Save the result.
             results[sample_num, :, :] = flux_density

--- a/src/tdastro/sources/salt2_jax.py
+++ b/src/tdastro/sources/salt2_jax.py
@@ -36,7 +36,6 @@ class SALT2JaxModel(PhysicalModel):
       * ra - The object's right ascension in degrees. [from PhysicalModel]
       * redshift - The object's redshift. [from PhysicalModel]
       * t0 - The t0 of the zero phase, date. [from PhysicalModel]
-      * white_noise_sigma - The standard deviation of the white noise. [from PhysicalModel]
       * x0 - The SALT2 x0 parameter.
       * x1 - The SALT2 x0 parameter.
 

--- a/src/tdastro/sources/sncomso_models.py
+++ b/src/tdastro/sources/sncomso_models.py
@@ -21,7 +21,6 @@ class SncosmoWrapperModel(PhysicalModel):
       * ra - The object's right ascension in degrees. [from PhysicalModel]
       * redshift - The object's redshift. [from PhysicalModel]
       * t0 - The t0 of the zero phase, date. [from PhysicalModel]
-      * white_noise_sigma - The standard deviation of the white noise. [from PhysicalModel]
     Additional parameterized values are used for specific sncosmo models.
 
     Attributes

--- a/src/tdastro/sources/snia_host.py
+++ b/src/tdastro/sources/snia_host.py
@@ -11,7 +11,6 @@ class SNIaHost(PhysicalModel):
       * ra - The object's right ascension in degrees. [from PhysicalModel]
       * redshift - The object's redshift. [from PhysicalModel]
       * t0 - The t0 of the zero phase, date. [from PhysicalModel]
-      * white_noise_sigma - The standard deviation of the white noise. [from PhysicalModel]
     """
 
     def __init__(self, **kwargs):

--- a/src/tdastro/sources/spline_model.py
+++ b/src/tdastro/sources/spline_model.py
@@ -22,7 +22,6 @@ class SplineModel(PhysicalModel):
       * ra - The object's right ascension in degrees. [from PhysicalModel]
       * redshift - The object's redshift. [from PhysicalModel]
       * t0 - The t0 of the zero phase, date. [from PhysicalModel]
-      * white_noise_sigma - The standard deviation of the white noise. [from PhysicalModel]
 
     Attributes
     ----------

--- a/tests/tdastro/effects/test_effect_model.py
+++ b/tests/tdastro/effects/test_effect_model.py
@@ -1,0 +1,16 @@
+import numpy as np
+import pytest
+from tdastro.effects.effect_model import EffectModel
+
+
+def test_effect_model() -> None:
+    """The base effect model is able to extract the parameters."""
+    model = EffectModel(param1=1.0, param2=2.0)
+    assert "param1" in model.parameters
+    assert "param2" in model.parameters
+    assert model.parameters["param1"] == 1.0
+    assert model.parameters["param2"] == 2.0
+
+    # We cannot call apply on the base EffectModel
+    with pytest.raises(NotImplementedError):
+        _ = model.apply(np.zeros((5, 3)))

--- a/tests/tdastro/effects/test_white_noise.py
+++ b/tests/tdastro/effects/test_white_noise.py
@@ -8,7 +8,7 @@ def test_white_noise() -> None:
     """Test that we can sample and create a WhiteNoise object."""
     values = np.full((5, 3), 100.0)
 
-    # We can apply noise the noise.
+    # We can apply the noise.
     white_noise = WhiteNoise(white_noise_sigma=0.1)
     values = white_noise.apply(values, white_noise_sigma=0.1)
     assert not np.all(values == 100.0)

--- a/tests/tdastro/effects/test_white_noise.py
+++ b/tests/tdastro/effects/test_white_noise.py
@@ -1,0 +1,21 @@
+import numpy as np
+from tdastro.effects.white_noise import WhiteNoise
+from tdastro.sources.basic_sources import StaticSource
+
+
+def test_white_noise() -> None:
+    """Test that we can sample and create a WhiteNoise object."""
+    model = StaticSource(brightness=100.0)
+    times = np.array([1, 2, 3, 5, 10])
+    wavelengths = np.array([100.0, 200.0, 300.0])
+
+    # We start with noiseless fluxes.
+    values = model.evaluate(times, wavelengths)
+    assert values.shape == (5, 3)
+    assert np.all(values == 100.0)
+
+    # We can apply noise.
+    white_noise = WhiteNoise(scale=0.1)
+    values = white_noise.apply(values)
+    assert not np.all(values == 100.0)
+    assert np.all(np.abs(values - 100.0) <= 1.0)

--- a/tests/tdastro/effects/test_white_noise.py
+++ b/tests/tdastro/effects/test_white_noise.py
@@ -1,21 +1,55 @@
 import numpy as np
+import pytest
 from tdastro.effects.white_noise import WhiteNoise
+from tdastro.math_nodes.single_value_node import SingleVariableNode
 from tdastro.sources.basic_sources import StaticSource
 
 
 def test_white_noise() -> None:
     """Test that we can sample and create a WhiteNoise object."""
-    model = StaticSource(brightness=100.0)
-    times = np.array([1, 2, 3, 5, 10])
-    wavelengths = np.array([100.0, 200.0, 300.0])
+    values = np.full((5, 3), 100.0)
 
-    # We start with noiseless fluxes.
-    values = model.evaluate(times, wavelengths)
-    assert values.shape == (5, 3)
-    assert np.all(values == 100.0)
-
-    # We can apply noise.
-    white_noise = WhiteNoise(scale=0.1)
+    # We can apply noise using the default value.
+    white_noise = WhiteNoise(white_noise_sigma=0.1)
     values = white_noise.apply(values)
     assert not np.all(values == 100.0)
     assert np.all(np.abs(values - 100.0) <= 1.0)
+
+    # We can override the default value using the parameters.
+    values = white_noise.apply(values, white_noise_sigma=20.0)
+    assert not np.all(values == 100.0)
+    assert not np.all(np.abs(values - 100.0) <= 1.0)
+
+    # We fail if we do not pass in the correct parameters. Here we use
+    # a non-constant setter and not override of the default value.
+    wn_sigma = SingleVariableNode("white_noise_sigma", 0.1)
+    white_noise = WhiteNoise(white_noise_sigma=wn_sigma)
+    with pytest.raises(ValueError):
+        _ = white_noise.apply(values)
+
+
+def test_static_source_white_noise() -> None:
+    """Test that we can sample and create a StaticSource object with white noise."""
+    white_noise = WhiteNoise(white_noise_sigma=0.1)
+    model = StaticSource(
+        brightness=10.0,
+        node_label="my_static_source",
+        effects=[white_noise],
+        seed=100,
+    )
+    state = model.sample_parameters()
+
+    times = np.array([1, 2, 3, 4, 5, 10])
+    wavelengths = np.array([100.0, 200.0, 300.0])
+    values = model.evaluate(times, wavelengths, state)
+    assert values.shape == (6, 3)
+
+    # We get noisy values around 10.0.
+    assert len(np.unique(values)) > 10
+    assert np.all(np.abs(values - 10.0) < 3.0)
+
+    # Test that if we pass in an rng, we control the randomness.
+    values1 = model.evaluate(times, wavelengths, state, rng_info=np.random.default_rng(100))
+    values2 = model.evaluate(times, wavelengths, state, rng_info=np.random.default_rng(100))
+    assert not np.any(values1 == 10.0)
+    assert np.all(values1 == values2)

--- a/tests/tdastro/effects/test_white_noise.py
+++ b/tests/tdastro/effects/test_white_noise.py
@@ -1,7 +1,6 @@
 import numpy as np
 import pytest
 from tdastro.effects.white_noise import WhiteNoise
-from tdastro.math_nodes.single_value_node import SingleVariableNode
 from tdastro.sources.basic_sources import StaticSource
 
 
@@ -9,9 +8,9 @@ def test_white_noise() -> None:
     """Test that we can sample and create a WhiteNoise object."""
     values = np.full((5, 3), 100.0)
 
-    # We can apply noise using the default value.
+    # We can apply noise the noise.
     white_noise = WhiteNoise(white_noise_sigma=0.1)
-    values = white_noise.apply(values)
+    values = white_noise.apply(values, white_noise_sigma=0.1)
     assert not np.all(values == 100.0)
     assert np.all(np.abs(values - 100.0) <= 1.0)
 
@@ -20,10 +19,7 @@ def test_white_noise() -> None:
     assert not np.all(values == 100.0)
     assert not np.all(np.abs(values - 100.0) <= 1.0)
 
-    # We fail if we do not pass in the correct parameters. Here we use
-    # a non-constant setter and not override of the default value.
-    wn_sigma = SingleVariableNode("white_noise_sigma", 0.1)
-    white_noise = WhiteNoise(white_noise_sigma=wn_sigma)
+    # We fail if we do not pass in the expected parameters.
     with pytest.raises(ValueError):
         _ = white_noise.apply(values)
 

--- a/tests/tdastro/sources/test_basic_sources.py
+++ b/tests/tdastro/sources/test_basic_sources.py
@@ -56,32 +56,6 @@ def test_static_source_pytree():
     assert len(pytree) == 1
 
 
-def test_static_source_white_noise() -> None:
-    """Test that we can sample and create a StaticSource object with white noise."""
-    model = StaticSource(
-        brightness=10.0,
-        white_noise_sigma=1.0,
-        node_label="my_static_source",
-        seed=100,
-    )
-    state = model.sample_parameters()
-
-    times = np.array([1, 2, 3, 4, 5, 10])
-    wavelengths = np.array([100.0, 200.0, 300.0])
-    values = model.evaluate(times, wavelengths, state)
-    assert values.shape == (6, 3)
-
-    # We get noisy values around 10.0.
-    assert len(np.unique(values)) > 10
-    assert np.all(np.abs(values - 10.0) < 3.0)
-
-    # Test that if we pass in an rng, we control the randomness.
-    values1 = model.evaluate(times, wavelengths, state, rng_info=np.random.default_rng(100))
-    values2 = model.evaluate(times, wavelengths, state, rng_info=np.random.default_rng(100))
-    assert not np.any(values1 == 10.0)
-    assert np.all(values1 == values2)
-
-
 def test_static_source_host() -> None:
     """Test that we can sample and create a StaticSource object with properties
     derived from the host object."""


### PR DESCRIPTION
Add the ability to pass a list of effects into the `PhysicalModel`. These effects are automatically broken into "rest frame" effects (which are applied before the results are redshifted back) and "observer frame" effects, which are applied afterward.

The PR also moves the white noise effect back into an `EffectModel` (instead of being hard coded into `PhysicalModel`).