### PR TITLE
Fix the redshift computation with multiple samples

### DIFF
--- a/src/tdastro/effects/effect_model.py
+++ b/src/tdastro/effects/effect_model.py
@@ -37,13 +37,17 @@ class EffectModel:
         """
         self.parameters[name] = setter
 
-    def apply(self, flux_density, rng_info=None, **kwargs):
+    def apply(self, flux_density, times=None, wavelengths=None, rng_info=None, **kwargs):
         """Apply the effect to observations (flux_density values).
 
         Parameters
         ----------
         flux_density : numpy.ndarray
             A length T X N matrix of flux density values (in nJy).
+        times : numpy.ndarray, optional
+            A length T array of times (in MJD).
+        wavelengths : numpy.ndarray, optional
+            A length N array of wavelengths (in angstroms).
         rng_info : numpy.random._generator.Generator, optional
             A given numpy random number generator to use for this computation. If not
             provided, the function uses the node's random number generator.

--- a/src/tdastro/effects/white_noise.py
+++ b/src/tdastro/effects/white_noise.py
@@ -16,13 +16,25 @@ class WhiteNoise(EffectModel):
         super().__init__(**kwargs)
         self.add_effect_parameter("white_noise_sigma", white_noise_sigma)
 
-    def apply(self, flux_density, white_noise_sigma=None, rng_info=None, **kwargs):
+    def apply(
+        self,
+        flux_density,
+        times=None,
+        wavelengths=None,
+        white_noise_sigma=None,
+        rng_info=None,
+        **kwargs,
+    ):
         """Apply the effect to observations (flux_density values).
 
         Parameters
         ----------
         flux_density : numpy.ndarray
             A length T X N matrix of flux density values (in nJy).
+        times : numpy.ndarray, optional
+            A length T array of times (in MJD). Not used for this effect.
+        wavelengths : numpy.ndarray, optional
+            A length N array of wavelengths (in angstroms). Not used for this effect.
         white_noise_sigma : float, optional
             The scale of the noise. Raises an error if None is provided.
         rng_info : numpy.random._generator.Generator, optional

--- a/tests/tdastro/sources/test_physical_models.py
+++ b/tests/tdastro/sources/test_physical_models.py
@@ -108,7 +108,7 @@ def test_physical_model_evaluate():
 
 
 def test_physical_model_evaluate_redshift():
-    """Test that is we apply redshift to a model we get different flux values."""
+    """Test that if we apply redshift to a model we get different flux values."""
     times = np.array([0.0, 1.0, 2.0, 3.0, 4.0])
     waves = np.array([4000.0, 5000.0])
     static_source = StaticSource(brightness=10.0, redshift=0.5, t0=0.0)

--- a/tests/tdastro/sources/test_physical_models.py
+++ b/tests/tdastro/sources/test_physical_models.py
@@ -58,6 +58,18 @@ def test_physical_model():
     assert model4.get_param(state, "distance") is None
 
 
+def test_physical_mode_multi_samples():
+    """Test that we generate multiple samples from a PhysicalModel."""
+    # Everything is specified.
+    model1 = PhysicalModel(ra=1.0, dec=2.0, redshift=0.5, t0=1.0)
+    state = model1.sample_parameters(num_samples=10)
+
+    assert np.all(model1.get_param(state, "ra") == 1.0)
+    assert np.all(model1.get_param(state, "dec") == 2.0)
+    assert np.all(model1.get_param(state, "redshift") == 0.5)
+    assert np.all(model1.get_param(state, "t0") == 1.0)
+
+
 def test_physical_model_mask_by_time():
     """Test that we can use the default mask_by_time() function."""
     model = PhysicalModel(ra=1.0, dec=2.0, redshift=0.0)
@@ -93,6 +105,21 @@ def test_physical_model_evaluate():
     assert np.all(flux[0, :, :] == 10.0)
     assert np.all(flux[1, :, :] == 20.0)
     assert np.all(flux[2, :, :] == 30.0)
+
+
+def test_physical_model_evaluate_redshift():
+    """Test that is we apply redshift to a model we get different flux values."""
+    times = np.array([0.0, 1.0, 2.0, 3.0, 4.0])
+    waves = np.array([4000.0, 5000.0])
+    static_source = StaticSource(brightness=10.0, redshift=0.5, t0=0.0)
+
+    state = static_source.sample_parameters(num_samples=3)
+    flux = static_source.evaluate(times, waves, graph_state=state)
+    assert flux.shape == (3, 5, 2)
+    assert not np.any(flux[:, :, :] == 10.0)
+
+    # The flux should be the same for all samples (not double applying redshift).
+    assert len(np.unique(flux)) == 1
 
 
 def test_physical_model_get_band_fluxes(passbands_dir):


### PR DESCRIPTION
The current redshift computation is broken for multiple samples because it does not maintain a constant observer frame copy of wavelengths or time. Instead both arrays are redshifted on each iteration. This fixes that problem by creating new `rest_time` and `rest_wave` copies to represent the redshifted values.

It also passes times (optionally) to the `EffectsModels` (which is how I found the problem).