### PR TITLE
Add a dust map wrapper

### DIFF
--- a/docs/notebooks/addings_effects.ipynb
+++ b/docs/notebooks/addings_effects.ipynb
@@ -1,0 +1,257 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# EffectModels\n",
+    "\n",
+    "In this tutorial we look at how a user can add effects to our objects to make their sampled flux more realistic.\n",
+    "\n",
+    "TDAstro supports multiple source-level effects including:\n",
+    "  * Dust extinction\n",
+    "  * White Noise\n",
+    "\n",
+    "In addition, as shown below, users can create their own effects.\n",
+    "\n",
+    "\n",
+    "## Applying Effects \n",
+    "\n",
+    "We add effects to our objects, using the `PhysicalModel.add_effect()` function, before generating samples. For example if we want to apply a basic white noise effect to a static source we would use"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "\n",
+    "from tdastro.effects.white_noise import WhiteNoise\n",
+    "from tdastro.sources.basic_sources import StaticSource\n",
+    "\n",
+    "# Create the static source model with the white noise effect.\n",
+    "model = StaticSource(\n",
+    "    brightness=10.0,\n",
+    "    node_label=\"my_static_source\",\n",
+    "    seed=100,\n",
+    ")\n",
+    "\n",
+    "# Create the white noise effect.\n",
+    "white_noise = WhiteNoise(white_noise_sigma=0.1)\n",
+    "model.add_effect(white_noise)\n",
+    "\n",
+    "# Sample the flux.\n",
+    "state = model.sample_parameters()\n",
+    "times = np.array([1, 2, 3, 4, 5, 10])\n",
+    "wavelengths = np.array([100.0, 200.0, 300.0])\n",
+    "model.evaluate(times, wavelengths, state)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Dust Maps\n",
+    "\n",
+    "Dust extinction represents a more complex effect since it requires the user to specify both a dust map and an extinction function. The dust map is stored in a `ParameterizedNode` that uses the source's (RA, dec) to compute ebv values. The `ExtinctionEffect` then links these together by creating a new \"ebv\" parameter in the source node. This \"ebv\" parameter is the output of the dustmap and the input to the extinction event."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from tdastro.astro_utils.dustmap import ConstantHemisphereDustMap\n",
+    "from tdastro.effects.extinction import ExtinctionEffect\n",
+    "\n",
+    "model2 = StaticSource(\n",
+    "    brightness=100.0,\n",
+    "    ra=45.0,\n",
+    "    dec=20.0,\n",
+    "    redshift=0.0,\n",
+    "    node_label=\"source\",\n",
+    ")\n",
+    "\n",
+    "# Create a dust map that pulls ebv values using the source's (RA, dec) values.\n",
+    "dust_map_node = ConstantHemisphereDustMap(\n",
+    "    north_ebv=0.8,\n",
+    "    south_ebv=0.5,\n",
+    "    ra=model2.ra,\n",
+    "    dec=model2.dec,\n",
+    "    node_label=\"dust_map\",\n",
+    ")\n",
+    "\n",
+    "# Create an add an extinction effect.\n",
+    "ext_effect = ExtinctionEffect(extinction_model=\"CCM89\", ebv=dust_map_node, Rv=3.1)\n",
+    "model2.add_effect(ext_effect)\n",
+    "\n",
+    "# Sample the model.\n",
+    "times = np.array([1.0, 2.0, 3.0, 4.0, 5.0])\n",
+    "wavelengths = np.array([7000.0, 5200.0])\n",
+    "states2 = model2.sample_parameters(num_samples=3)\n",
+    "model2.evaluate(times, wavelengths, states2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "By printing the information in the `states` variable, we can see a sampled ebv for each different model (RA, dec)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(states2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Most users will want to use a more realistic dust map, such as those from the `dustmaps` library. For example if you had that package installed, you could create the dust map node as:\n",
+    "\n",
+    "```\n",
+    "from dustmaps.config import config as dm_config\n",
+    "import dustmaps.sfd\n",
+    "\n",
+    "from tdastro.astro_utils.dustmap import DustmapWrapper\n",
+    "\n",
+    "dm_config[\"data_dir\"] = \"../../data/dustmaps\"\n",
+    "dustmaps.sfd.fetch()\n",
+    "dust_map_node = DustmapWrapper(dustmaps.sfd.SFDQuery())\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Custom Effects\n",
+    "\n",
+    "Users can also create their own custom effect by inheriting from the `EffectModel` class and overriding the `apply()` function. \n",
+    "\n",
+    "An `EffectModel` object can have its own parameters (defined with a `add_effect_parameter()` function). Unlike a `ParameterizedNode`, these parameters will be added to the source object and passed to the effect as input. This means that all effect parameters will be computed during the parameter sampling phase, which keeps them consistent with the model parameters. These parameters *must* also be listed in the argument list for the `apply()` function because that is how the effect will get them.\n",
+    "\n",
+    "Let’s consider the example of an effect that adds sinusoidal dimming to the flux."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from tdastro.effects.effect_model import EffectModel\n",
+    "\n",
+    "\n",
+    "class SinDimming(EffectModel):\n",
+    "    \"\"\"A sinusoidal dimming model.\n",
+    "\n",
+    "    Attributes\n",
+    "    ----------\n",
+    "    period : parameter\n",
+    "        The period of the sinusoidal dimming.\n",
+    "    \"\"\"\n",
+    "\n",
+    "    def __init__(self, period, **kwargs):\n",
+    "        super().__init__(**kwargs)\n",
+    "        self.add_effect_parameter(\"period\", period)\n",
+    "\n",
+    "    def apply(\n",
+    "        self,\n",
+    "        flux_density,\n",
+    "        times=None,\n",
+    "        wavelengths=None,\n",
+    "        period=None,\n",
+    "        rng_info=None,\n",
+    "        **kwargs,\n",
+    "    ):\n",
+    "        \"\"\"Apply the effect to observations (flux_density values).\n",
+    "\n",
+    "        Parameters\n",
+    "        ----------\n",
+    "        flux_density : numpy.ndarray\n",
+    "            A length T X N matrix of flux density values (in nJy).\n",
+    "        times : numpy.ndarray, optional\n",
+    "            A length T array of times (in MJD). Not used for this effect.\n",
+    "        wavelengths : numpy.ndarray, optional\n",
+    "            A length N array of wavelengths (in angstroms). Not used for this effect.\n",
+    "        period : float, optional\n",
+    "            The period of the dimming. Raises an error if None is provided.\n",
+    "        rng_info : numpy.random._generator.Generator, optional\n",
+    "            A given numpy random number generator to use for this computation. If not\n",
+    "            provided, the function uses the node's random number generator.\n",
+    "        **kwargs : `dict`, optional\n",
+    "           Any additional keyword arguments. This includes all of the\n",
+    "           parameters needed to apply the effect.\n",
+    "\n",
+    "        Returns\n",
+    "        -------\n",
+    "        flux_density : numpy.ndarray\n",
+    "            A length T x N matrix of flux densities after the effect is applied (in nJy).\n",
+    "        \"\"\"\n",
+    "        if period is None:\n",
+    "            raise ValueError(\"period must be provided\")\n",
+    "\n",
+    "        scale = 0.5 * (1.0 + np.sin(2 * np.pi * times / period))\n",
+    "        return flux_density * scale[:, None]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "model3 = StaticSource(\n",
+    "    brightness=100.0,\n",
+    "    ra=45.0,\n",
+    "    dec=20.0,\n",
+    "    redshift=0.0,\n",
+    "    node_label=\"source\",\n",
+    ")\n",
+    "sin_effect = SinDimming(period=10.0)\n",
+    "model3.add_effect(sin_effect)\n",
+    "\n",
+    "# Construct one same of the model and its output flux.\n",
+    "times = np.arange(50.0)\n",
+    "wavelengths = np.array([7000.0, 5200.0])\n",
+    "fluxes = model3.evaluate(times, wavelengths)\n",
+    "\n",
+    "plt.plot(times, fluxes[:, 0])\n",
+    "plt.xlabel(\"Time (MJD)\")\n",
+    "plt.ylabel(\"Flux Density (nJy)\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "tdastro",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/src/tdastro/astro_utils/dustmap.py
+++ b/src/tdastro/astro_utils/dustmap.py
@@ -82,7 +82,8 @@ class DustmapWrapper(DustEBV):
 
 
 class ConstantHemisphereDustMap(DustEBV):
-    """A DustMap with a constant value in each hemisphere.
+    """A DustMap with a constant value in each hemisphere for testing
+    and debugging purposes.
 
     Attributes
     ----------

--- a/src/tdastro/astro_utils/dustmap.py
+++ b/src/tdastro/astro_utils/dustmap.py
@@ -115,8 +115,7 @@ class ConstantHemisphereDustMap(DustEBV):
         if np.isscalar(ra):
             return self.north_ebv if dec >= 0 else self.south_ebv
 
-        ebv = np.full_like(ra, self.north_ebv)
-        ebv[np.asarray(dec) < 0] = self.south_ebv
+        ebv = np.where(np.asarray(dec) < 0, self.south_ebv, self.north_ebv)
         return ebv
 
     def query(self, coords):

--- a/src/tdastro/astro_utils/dustmap.py
+++ b/src/tdastro/astro_utils/dustmap.py
@@ -1,0 +1,142 @@
+"""A wrapper for querying dust maps and returning E(B-V) values.
+
+This module supports a variety of external dustmaps libaries, but
+was primarily designed to work with the dustmaps package:
+https://github.com/gregreen/dustmaps
+"""
+
+import numpy as np
+from astropy.coordinates import SkyCoord
+
+from tdastro.base_models import FunctionNode
+
+
+class DustEBV(FunctionNode):
+    """A wrapper that queries a dust map and returns the ebv for each location.
+
+    Attributes
+    ----------
+    query_fn : function
+        The function to query the dust map ebv value given (RA, dec).
+
+    Parameters
+    ----------
+    query_fn : function
+        The function to query the dust map ebv value given (RA, dec).
+    **kwargs : `dict`, optional
+        Any additional keyword arguments.
+    """
+
+    def __init__(self, query_fn, **kwargs):
+        super().__init__(query_fn, outputs=["ebv"], **kwargs)
+
+
+class DustmapWrapper(DustEBV):
+    """A convenience wrapper for the dustmap package
+    https://github.com/gregreen/dustmaps
+
+    Citation: Green 2018, JOSS, 3(26), 695.
+
+    Parameters
+    ----------
+    dust_map : DustMap object
+        The dust map. Since different dustmap's query function may produce different
+        outputs, you should include the corresponding ebv_func to transform the result
+        into ebv if needed.
+    ebv_func : function, optional
+        A function to translate the result of the dustmap query into an ebv.
+    **kwargs : `dict`, optional
+        Any additional keyword arguments.
+    """
+
+    def __init__(self, dust_map, ebv_func=None, **kwargs):
+        super().__init__(self.compute_ebv, **kwargs)
+        self._ebv_func = ebv_func
+        self._dust_map = dust_map
+
+    def compute_ebv(self, ra, dec):
+        """Compute the E(B-V) value for a given location.
+
+        Parameters
+        ----------
+        ra : float or np.array
+            The object's right ascension (in degrees).
+        dec : float or np.array
+            The object's declination (in degrees).
+
+        Returns
+        -------
+        ebv : float or np.array
+            The E(B-V) value or array of values.
+        """
+        if self._dust_map is None:
+            raise ValueError("A dust map must be provided to compute E(B-V) values.")
+
+        # Wrap the RA and dec in a SkyCoord object
+        coord = SkyCoord(ra, dec, frame="icrs", unit="deg")
+        dustmap_value = self._dust_map.query(coord)
+
+        if self._ebv_func is not None:
+            return self._ebv_func(dustmap_value)
+        return dustmap_value
+
+
+class ConstantHemisphereDustMap(DustEBV):
+    """A DustMap with a constant value in each hemisphere.
+
+    Attributes
+    ----------
+    north_ebv : `float`
+        The DustMap's ebv value at all points in the Northern Hemisphere.
+    south_ebv : `float`
+        The DustMap's ebv value at all points in the Southern Hemisphere.
+    """
+
+    def __init__(self, north_ebv, south_ebv, **kwargs):
+        super().__init__(self.compute_ebv, **kwargs)
+        self.north_ebv = north_ebv
+        self.south_ebv = south_ebv
+
+    def compute_ebv(self, ra, dec):
+        """Compute the E(B-V) value for a given location.
+
+        Parameters
+        ----------
+        ra : float or np.array
+            The object's right ascension (in degrees).
+        dec : float or np.array
+            The object's declination (in degrees).
+
+        Returns
+        -------
+        ebv : float or np.array
+            The E(B-V) value or array of values.
+        """
+        if np.isscalar(ra):
+            return self.north_ebv if dec >= 0 else self.south_ebv
+
+        ebv = np.full_like(ra, self.north_ebv)
+        ebv[np.asarray(dec) < 0] = self.south_ebv
+        return ebv
+
+    def query(self, coords):
+        """A query function to match the DustMap interface so that
+        we can pass ConstantHemisphereDustMap into DustmapWrapper
+        for testing purposes.
+
+        Note
+        ----
+        This shouldn't be used in production code. Use the compute_ebv()
+        function directly.
+
+        Parameters
+        ----------
+        coords : SkyCoord
+            The object's coordinates.
+
+        Returns
+        -------
+        ebv : float or np.array
+            The E(B-V) value or array of values.
+        """
+        return self.compute_ebv(coords.ra.deg, coords.dec.deg)

--- a/src/tdastro/base_models.py
+++ b/src/tdastro/base_models.py
@@ -401,6 +401,7 @@ class ParameterizedNode:
                 self.setters[name].set_as_function(func_node)
         elif isinstance(value, FunctionNode):
             # Case 2: We are using the result of a computation of the function node.
+            # If the FunctionNode has names outputs that match the variable, use that.
             output_name = name if name in value.outputs else "function_node_result"
             self.setters[name].set_as_function(value, output_name)
         elif isinstance(value, ParameterizedNode):

--- a/src/tdastro/base_models.py
+++ b/src/tdastro/base_models.py
@@ -401,7 +401,8 @@ class ParameterizedNode:
                 self.setters[name].set_as_function(func_node)
         elif isinstance(value, FunctionNode):
             # Case 2: We are using the result of a computation of the function node.
-            self.setters[name].set_as_function(value)
+            output_name = name if name in value.outputs else "function_node_result"
+            self.setters[name].set_as_function(value, output_name)
         elif isinstance(value, ParameterizedNode):
             # Case 3: We are trying to access a parameter of a ParameterizedNode
             # with the same name.

--- a/src/tdastro/sources/physical_model.py
+++ b/src/tdastro/sources/physical_model.py
@@ -7,6 +7,7 @@ import numpy as np
 from tdastro.astro_utils.passbands import Passband
 from tdastro.astro_utils.redshift import RedshiftDistFunc, obs_to_rest_times_waves, rest_to_obs_flux
 from tdastro.base_models import ParameterizedNode
+from tdastro.effects.extinction import ExtinctionEffect
 from tdastro.graph_state import GraphState
 
 
@@ -149,6 +150,26 @@ class PhysicalModel(ParameterizedNode):
             The new value for apply_redshift.
         """
         self.apply_redshift = apply_redshift
+
+    def add_dust_extinction(self, dust_model, extinction_model="F99", **kwargs):
+        """Add a dust extinction effect to the model.
+
+        Parameters
+        ----------
+        dust_model : DustEBV
+            The dust extinction model to use.
+        extinction_model : str
+            The extinction effect to add.
+        **kwargs : dict, optional
+            Any additional keyword arguments to pass to the extinction effect.
+        """
+        # Generate the ebv value from the dust model.
+        if not self.has_valid_param("ebv"):
+            self.add_parameter("ebv", dust_model)
+
+        # Create an extinction effect and add it to the model.
+        ext_effect = ExtinctionEffect(extinction_model, self.ebv, **kwargs)
+        self.rest_frame_effects.append(ext_effect)
 
     def mask_by_time(self, times, graph_state=None):
         """Compute a mask for whether a given time is of interest for a given object.

--- a/tests/tdastro/astro_utils/test_dustmap.py
+++ b/tests/tdastro/astro_utils/test_dustmap.py
@@ -1,0 +1,55 @@
+import numpy as np
+from tdastro.astro_utils.dustmap import ConstantHemisphereDustMap, DustmapWrapper
+from tdastro.math_nodes.given_sampler import GivenValueList
+
+
+def test_constant_hemisphere_dust_map():
+    """Test that we can create and directly query a ConstantHemisphereDustMap object."""
+    dust_map = ConstantHemisphereDustMap(north_ebv=0.5, south_ebv=0.4)
+    assert dust_map.north_ebv == 0.5
+    assert dust_map.south_ebv == 0.4
+
+    # Check that the dust map returns the correct values for different locations.
+    assert dust_map.compute_ebv(0.0, 45.0) == 0.5
+    assert dust_map.compute_ebv(-10.0, 70.0) == 0.5
+    assert dust_map.compute_ebv(5.0, 0.001) == 0.5
+    assert dust_map.compute_ebv(0.0, -45.0) == 0.4
+    assert dust_map.compute_ebv(20.0, -0.001) == 0.4
+
+    ebvs = dust_map.compute_ebv(
+        [0.0, 0.0, 20.0, 340.0, 250.0, 180.0],
+        [45.0, -45.0, 15.0, -70.0, -90.0, 0.0],
+    )
+    assert np.array_equal(ebvs, [0.5, 0.4, 0.5, 0.4, 0.4, 0.5])
+
+
+def test_dust_map_wrapper():
+    """Test that we can create and sample a wrapped dust map."""
+    dec_vals = np.arange(-90.0, 90.0, 15.0)
+    ra_vals = np.arange(0.0, 360.0, 30.0)
+    fake_dust_map = ConstantHemisphereDustMap(north_ebv=0.8, south_ebv=0.1)
+
+    dust_node1 = DustmapWrapper(
+        dust_map=fake_dust_map,
+        ra=GivenValueList(ra_vals),
+        dec=GivenValueList(dec_vals),
+        node_label="dust",
+    )
+    samples = dust_node1.sample_parameters(num_samples=len(dec_vals))
+    assert np.all(samples["dust"]["ebv"][dec_vals >= 0] == 0.8)
+    assert np.all(samples["dust"]["ebv"][dec_vals < 0] == 0.1)
+
+    # Try adding an adjustment function to the dust map.
+    def _ebv_adjust(value):
+        return value + 0.1
+
+    dust_node2 = DustmapWrapper(
+        dust_map=fake_dust_map,
+        ebv_func=_ebv_adjust,
+        ra=GivenValueList(ra_vals),
+        dec=GivenValueList(dec_vals),
+        node_label="dust",
+    )
+    samples = dust_node2.sample_parameters(num_samples=len(dec_vals))
+    assert np.all(samples["dust"]["ebv"][dec_vals >= 0] == 0.9)
+    assert np.all(samples["dust"]["ebv"][dec_vals < 0] == 0.2)

--- a/tests/tdastro/effects/test_extinction.py
+++ b/tests/tdastro/effects/test_extinction.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from tdastro.astro_utils.dustmap import ConstantHemisphereDustMap
 from tdastro.effects.extinction import ExtinctionEffect
 from tdastro.math_nodes.given_sampler import GivenValueList
 from tdastro.sources.basic_sources import StaticSource
@@ -69,3 +70,35 @@ def test_constant_dust_extinction():
     assert np.all(fluxes < 100.0)
     assert np.all(fluxes[0, :, :] > fluxes[1, :, :])
     assert np.all(fluxes[1, :, :] > fluxes[2, :, :])
+
+
+def test_dustmap_chain():
+    """Test that we can chain the dustmap computation and extinction effect."""
+    model = StaticSource(
+        brightness=100.0,
+        ra=GivenValueList([45.0, 45.0, 45.0]),
+        dec=GivenValueList([20.0, -20.0, 10.0]),
+        redshift=0.0,
+        node_label="source",
+    )
+
+    # Create a constant dust map for testing and add an extinction effect.
+    dust_map_node = ConstantHemisphereDustMap(
+        north_ebv=0.8,
+        south_ebv=0.5,
+        ra=model.ra,
+        dec=model.dec,
+        node_label="dust_map",
+    )
+    model.add_dust_extinction(dust_map_node, extinction_model="CCM89", Rv=3.1)
+
+    # Sample the model.
+    times = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+    wavelengths = np.array([7000.0, 5200.0])
+    states = model.sample_parameters(num_samples=3)
+    fluxes = model.evaluate(times, wavelengths, states)
+
+    assert fluxes.shape == (3, 5, 2)
+    assert np.all(fluxes < 100.0)
+    assert np.allclose(fluxes[0, :, :], fluxes[2, :, :])
+    assert np.all(fluxes[1, :, :] > fluxes[0, :, :])

--- a/tests/tdastro/effects/test_extinction.py
+++ b/tests/tdastro/effects/test_extinction.py
@@ -58,8 +58,8 @@ def test_constant_dust_extinction():
         ra=0.0,
         dec=40.0,
         redshift=0.0,
-        effects=[dust_effect],
     )
+    model.add_effect(dust_effect)
 
     times = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
     wavelengths = np.array([7000.0, 5200.0, 4800.0])  # Red, green, blue
@@ -82,7 +82,7 @@ def test_dustmap_chain():
         node_label="source",
     )
 
-    # Create a constant dust map for testing and add an extinction effect.
+    # Create a constant dust map for testing.
     dust_map_node = ConstantHemisphereDustMap(
         north_ebv=0.8,
         south_ebv=0.5,
@@ -90,7 +90,10 @@ def test_dustmap_chain():
         dec=model.dec,
         node_label="dust_map",
     )
-    model.add_dust_extinction(dust_map_node, extinction_model="CCM89", Rv=3.1)
+
+    # Create an extinction effect using the EBVs from that dust map.
+    ext_effect = ExtinctionEffect(extinction_model="CCM89", ebv=dust_map_node, Rv=3.1)
+    model.add_effect(ext_effect)
 
     # Sample the model.
     times = np.array([1.0, 2.0, 3.0, 4.0, 5.0])

--- a/tests/tdastro/effects/test_white_noise.py
+++ b/tests/tdastro/effects/test_white_noise.py
@@ -26,13 +26,17 @@ def test_white_noise() -> None:
 
 def test_static_source_white_noise() -> None:
     """Test that we can sample and create a StaticSource object with white noise."""
-    white_noise = WhiteNoise(white_noise_sigma=0.1)
     model = StaticSource(
         brightness=10.0,
         node_label="my_static_source",
-        effects=[white_noise],
         seed=100,
     )
+    assert len(model.rest_frame_effects) == 0
+    assert len(model.obs_frame_effects) == 0
+
+    # We can add the white noise effect.
+    white_noise = WhiteNoise(white_noise_sigma=0.1)
+    model.add_effect(white_noise)
     assert len(model.rest_frame_effects) == 1
     assert len(model.obs_frame_effects) == 0
 
@@ -57,13 +61,16 @@ def test_static_source_white_noise_obs_frame() -> None:
     """Test that we can make the WhiteNoise an observer frame effect.
     While this does not make physical sense, it allows us to test that code path.
     """
-    white_noise = WhiteNoise(rest_frame=False, white_noise_sigma=0.1)
     model = StaticSource(
         brightness=10.0,
         node_label="my_static_source",
-        effects=[white_noise],
         seed=100,
     )
+    assert len(model.rest_frame_effects) == 0
+    assert len(model.obs_frame_effects) == 0
+
+    white_noise = WhiteNoise(rest_frame=False, white_noise_sigma=0.1)
+    model.add_effect(white_noise)
     assert len(model.rest_frame_effects) == 0
     assert len(model.obs_frame_effects) == 1
 


### PR DESCRIPTION
Add a wrapper for the dustmap package (without directly depending on that package). Include a test (constant) dustmap and a notebook of how to use effects in general.

The PR also:
- Fixes a small bug that would cause an error when the name of the output of a function node was not "function_node_result".
- Moves the effects from a list passed in the constructor to an `add_effect` function. This allows easier setup for effects that depend on model parameters, such as RA and dec.