### PR TITLE
Add a basic sampler to do (RA, dec) sampling from an opsim

### DIFF
--- a/src/tdastro/astro_utils/opsim.py
+++ b/src/tdastro/astro_utils/opsim.py
@@ -372,6 +372,32 @@ class OpSim:  # noqa: D101
         )
         return new_opsim
 
+    def is_observed(self, query_ra, query_dec, radius=None):
+        """Check if the query point(s) fall within the field of view of any
+        pointing in the survey.
+
+        Parameters
+        ----------
+        query_ra : float or numpy.ndarray
+            The query right ascension (in degrees).
+        query_dec : float or numpy.ndarray
+            The query declination (in degrees).
+        radius : float or None, optional
+            The angular radius of the observation (in degrees). If None
+            uses the default radius for the OpSim.
+
+        Returns
+        -------
+        seen : bool or list[bool]
+            Depending on the input, this is either a single bool to indicate
+            whether the query point is observed or a list of bools for an array
+            of query points.
+        """
+        inds = self.range_search(query_ra, query_dec, radius)
+        if np.isscalar(query_ra):
+            return len(inds) > 0
+        return [len(entry) > 0 for entry in inds]
+
     def range_search(self, query_ra, query_dec, radius=None):
         """Return the indices of the opsim pointings that fall within the field
         of view of the query point(s).

--- a/src/tdastro/math_nodes/ra_dec_sampler.py
+++ b/src/tdastro/math_nodes/ra_dec_sampler.py
@@ -203,17 +203,16 @@ class OpSimUniformRADECSampler(NumpyRandomFunc):
 
         Returns
         -------
-        results : any
-            The result of the computation. This return value is provided so that testing
-            functions can easily access the results.
+        (ra, dec) : tuple of floats or np.ndarray
+            If a single sample is generated, returns a tuple of floats. Otherwise,
+            returns a tuple of np.ndarrays.
         """
         rng = rng_info if rng_info is not None else self._rng
 
-        # Generate the random (RA, dec) lists and see how many are not covered.
-        ra = np.degrees(rng.uniform(0.0, 2.0 * np.pi, size=graph_state.num_samples))
-        dec = np.degrees(np.arcsin(rng.uniform(-1.0, 1.0, size=graph_state.num_samples)))
-        mask = np.asarray(self.data.is_observed(ra, dec, self.radius))
-        num_missing = np.sum(~mask)
+        ra = np.zeros(graph_state.num_samples)
+        dec = np.zeros(graph_state.num_samples)
+        mask = np.full(graph_state.num_samples, False)
+        num_missing = graph_state.num_samples
 
         # Rejection sampling to ensure the samples are within the OpSim coverage.
         # This can take many iterations if the coverage is small.
@@ -237,4 +236,4 @@ class OpSimUniformRADECSampler(NumpyRandomFunc):
         # function node's _save_results() function because we know the outputs.
         graph_state.set(self.node_string, "ra", ra)
         graph_state.set(self.node_string, "dec", dec)
-        return [ra, dec]
+        return (ra, dec)

--- a/tests/tdastro/astro_utils/test_opsim.py
+++ b/tests/tdastro/astro_utils/test_opsim.py
@@ -238,6 +238,10 @@ def test_opsim_range_search():
     assert set(ops_data.range_search(15.0, 10.0)) == set([1, 2, 3])
     assert set(ops_data.range_search(25.0, 10.0)) == set([4, 5])
 
+    # Test is_observed() with single queries.
+    assert ops_data.is_observed(15.0, 10.0, 0.5)
+    assert not ops_data.is_observed(15.02, 10.0, 1e-6)
+
     # Test a batched query.
     query_ra = np.array([15.0, 25.0, 15.0])
     query_dec = np.array([10.0, 10.0, 5.0])
@@ -246,6 +250,12 @@ def test_opsim_range_search():
     assert set(neighbors[0]) == set([1, 2, 3])
     assert set(neighbors[1]) == set([4, 5])
     assert set(neighbors[2]) == set()
+
+    # Test is_observed() with batched queries.
+    assert np.array_equal(
+        ops_data.is_observed(query_ra, query_dec, 0.5),
+        np.array([True, True, False]),
+    )
 
     # Test that we fail if bad query arrays are provided.
     with pytest.raises(ValueError):


### PR DESCRIPTION
Add a placeholder sampler to sample uniformly by the region covered by an OpSim. This uses rejection sampling and will be infeasibly slow for OpSims with small coverage. This is primarily a placeholder until we can add an approach that does some pre-computation of the OpSim region (which will be in a later PR).