### PR TITLE
Add the ability to sample from an OpSim's coverage

### DIFF
--- a/docs/notebooks/sampling_positions.ipynb
+++ b/docs/notebooks/sampling_positions.ipynb
@@ -113,7 +113,7 @@
     "\n",
     "### Sampling Coverage\n",
     "\n",
-    "If we instead would like to sample uniformly from the area covered by the survey, we have two options. The `OpSimUniformRADECSampler` uses rejection sampling to generate positions. This approach can be slow for surveys with small coverage. However, since it requires no pre-computation, it is a viable option for generating a small number samples from a survey with high coverage."
+    "If we instead would like to sample uniformly from the area covered by the survey, we have two options. The `OpSimUniformRADECSampler` uses rejection sampling to generate positions. This approach can be slow for surveys with small coverage. However, since it requires no pre-computation, it is a viable option for generating a small number of samples from a survey with high coverage."
    ]
   },
   {

--- a/docs/notebooks/sampling_positions.ipynb
+++ b/docs/notebooks/sampling_positions.ipynb
@@ -15,7 +15,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import healpy as hp\n",
     "import numpy as np\n",
     "from tdastro.math_nodes.ra_dec_sampler import (\n",
     "    CoverageMapRADECSampler,\n",
@@ -47,9 +46,8 @@
     "uniform_sampler = UniformRADEC(node_label=\"uniform\")\n",
     "(ra, dec) = uniform_sampler.generate(num_samples=500)\n",
     "\n",
-    "hp.mollview(hold=True)\n",
-    "hp.visufunc.projscatter(ra, dec, lonlat=True)\n",
-    "hp.graticule()"
+    "plt.scatter(ra, dec, s=1)\n",
+    "plt.show()"
    ]
   },
   {
@@ -100,9 +98,8 @@
     "pointing_sampler = OpSimRADECSampler(opsim, radius=30.0, node_label=\"opsim\")\n",
     "(ra, dec, time) = pointing_sampler.generate(num_samples=100)\n",
     "\n",
-    "hp.mollview(hold=True)\n",
-    "hp.visufunc.projscatter(ra, dec, lonlat=True)\n",
-    "hp.graticule()"
+    "plt.scatter(ra, dec, s=1)\n",
+    "plt.show()"
    ]
   },
   {
@@ -125,9 +122,8 @@
     "coverage_sampler1 = OpSimUniformRADECSampler(opsim, radius=30.0, node_label=\"coverage1\")\n",
     "(ra, dec) = coverage_sampler1.generate(num_samples=100)\n",
     "\n",
-    "hp.mollview(hold=True)\n",
-    "hp.visufunc.projscatter(ra, dec, lonlat=True)\n",
-    "hp.graticule()"
+    "plt.scatter(ra, dec, s=1)\n",
+    "plt.show()"
    ]
   },
   {
@@ -146,9 +142,8 @@
     "coverage_sampler2 = CoverageMapRADECSampler(opsim, radius=30.0, node_label=\"coverage2\")\n",
     "(ra, dec) = coverage_sampler2.generate(num_samples=100)\n",
     "\n",
-    "hp.mollview(hold=True)\n",
-    "hp.visufunc.projscatter(ra, dec, lonlat=True)\n",
-    "hp.graticule()"
+    "plt.scatter(ra, dec, s=1)\n",
+    "plt.show()"
    ]
   },
   {

--- a/docs/notebooks/sampling_positions.ipynb
+++ b/docs/notebooks/sampling_positions.ipynb
@@ -1,0 +1,203 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Sampling (RA, dec)\n",
+    "\n",
+    "TDAstro provides multiple mechanisms for sampling (RA, dec). In this notebook we discuss several of the approaches and their relative tradeoffs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import healpy as hp\n",
+    "import numpy as np\n",
+    "from tdastro.math_nodes.ra_dec_sampler import (\n",
+    "    CoverageMapRADECSampler,\n",
+    "    OpSimRADECSampler,\n",
+    "    OpSimUniformRADECSampler,\n",
+    "    UniformRADEC,\n",
+    ")\n",
+    "from tdastro.opsim.opsim import OpSim\n",
+    "from tdastro.sources.basic_sources import StaticSource\n",
+    "\n",
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Uniform Sampling\n",
+    "\n",
+    "The simplest sampling approach is to uniformly sample (RA, dec) from the unit sphere. The `UniformRADEC` node does exactly this."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "uniform_sampler = UniformRADEC(node_label=\"uniform\")\n",
+    "(ra, dec) = uniform_sampler.generate(num_samples=500)\n",
+    "\n",
+    "hp.mollview(hold=True)\n",
+    "hp.visufunc.projscatter(ra, dec, lonlat=True)\n",
+    "hp.graticule()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "However this approach has limited use when simulating a specific survey. Depending on the survey's coverage, a significant number of (RA, dec) points may fall outside the viewing area.\n",
+    "\n",
+    "## Sampling from a Survey\n",
+    "\n",
+    "We can sample (RA, dec) coordinates from a survey (an `OpSim` object) in two ways. First we could sample a pointing from the survey and then a point from that field of view. Second, we could sample uniformly from the region coverage by the survey.\n",
+    "\n",
+    "We consider each of these approaches below.\n",
+    "\n",
+    "### Sampling Pointings\n",
+    "\n",
+    "Sampling pointings from the survey provides a visit-weighted sampling of positions covered by the survey. For concreteness let's start with a survey that visits two fields: one centered at (45.0, -15.0) and the other at (315.0, 15.0). The first field is visited once and the second field is visited four times on four consecutive nights."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "values = {\n",
+    "    \"observationStartMJD\": np.array([0.0, 1.0, 2.0, 3.0, 4.0]),\n",
+    "    \"fieldRA\": np.array([45.0, 315.0, 315.0, 315.0, 315.0]),\n",
+    "    \"fieldDec\": np.array([-15.0, 15.0, 15.0, 15.0, 15.0]),\n",
+    "    \"zp_nJy\": np.ones(5),\n",
+    "}\n",
+    "opsim = OpSim(values, radius=30.0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can sample from these pointings using the `OpSimRADECSampler` node."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pointing_sampler = OpSimRADECSampler(opsim, radius=30.0, node_label=\"opsim\")\n",
+    "(ra, dec, time) = pointing_sampler.generate(num_samples=100)\n",
+    "\n",
+    "hp.mollview(hold=True)\n",
+    "hp.visufunc.projscatter(ra, dec, lonlat=True)\n",
+    "hp.graticule()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As we can see, the field centered in the Northern hemisphere is sampled significantly more than the one centered in the Southern hemisphere.\n",
+    "\n",
+    "### Sampling Coverage\n",
+    "\n",
+    "If we instead would like to sample uniformly from the area covered by the survey, we have two options. The `OpSimUniformRADECSampler` uses rejection sampling to generate positions. This approach can be slow for surveys with small coverage. However, since it requires no pre-computation, it is a viable option for generating a small number samples from a survey with high coverage."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "coverage_sampler1 = OpSimUniformRADECSampler(opsim, radius=30.0, node_label=\"coverage1\")\n",
+    "(ra, dec) = coverage_sampler1.generate(num_samples=100)\n",
+    "\n",
+    "hp.mollview(hold=True)\n",
+    "hp.visufunc.projscatter(ra, dec, lonlat=True)\n",
+    "hp.graticule()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `CoverageMapRADECSampler` pre-computes a coverage map using [HealSparse](https://healsparse.readthedocs.io/en/stable/index.html). This requires pre-computing the coverage map, which takes initial time and memory but can be significantly faster when generating many samples or sampling from a survey with a small on-sky coverage."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "coverage_sampler2 = CoverageMapRADECSampler(opsim, radius=30.0, node_label=\"coverage2\")\n",
+    "(ra, dec) = coverage_sampler2.generate(num_samples=100)\n",
+    "\n",
+    "hp.mollview(hold=True)\n",
+    "hp.visufunc.projscatter(ra, dec, lonlat=True)\n",
+    "hp.graticule()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Linking (RA, dec) to Sources\n",
+    "\n",
+    "To be useful, the (RA, dec) locations that we generate must be linked into our source objects. To support this all the generators above produce a pair of named outputs \"ra\" and \"dec\". This means we can use TDAstro's reference functionality to set the source's position based on the samples."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from tdastro.sources.basic_sources import StaticSource\n",
+    "\n",
+    "source = StaticSource(\n",
+    "    ra=uniform_sampler.ra,\n",
+    "    dec=uniform_sampler.dec,\n",
+    "    brightness=100.0,\n",
+    "    node_label=\"source\",\n",
+    ")\n",
+    "state = source.sample_parameters(num_samples=10)\n",
+    "print(state)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "tdastro",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,8 @@ dependencies = [
     "astropy",
     "citation-compass>=0.0.3",
     "dust_extinction",
+    "healpy",
+    "healsparse",
     "jax",
     "matplotlib",
     "nested-pandas",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,9 +18,9 @@ dynamic = ["version"]
 requires-python = ">=3.9"
 dependencies = [
     "astropy",
+    "cdshealpix",
     "citation-compass>=0.0.3",
     "dust_extinction",
-    "healpy",
     "healsparse",
     "jax",
     "matplotlib",

--- a/src/tdastro/math_nodes/ra_dec_sampler.py
+++ b/src/tdastro/math_nodes/ra_dec_sampler.py
@@ -240,7 +240,7 @@ class OpSimUniformRADECSampler(NumpyRandomFunc):
 
 class CoverageMapRADECSampler(NumpyRandomFunc, CiteClass):
     """A FunctionNode that samples RA and dec uniformly from the area covered
-    by a survey as provided by either a opsim of a healsparse coverage map.
+    by a survey as provided by either an opsim or a healsparse coverage map.
 
     Note
     ----

--- a/src/tdastro/math_nodes/ra_dec_sampler.py
+++ b/src/tdastro/math_nodes/ra_dec_sampler.py
@@ -2,6 +2,7 @@
 
 import healsparse as hsp
 import numpy as np
+from citation_compass import CiteClass
 
 from tdastro.math_nodes.given_sampler import TableSampler
 from tdastro.math_nodes.np_random import NumpyRandomFunc
@@ -237,7 +238,7 @@ class OpSimUniformRADECSampler(NumpyRandomFunc):
         return (ra, dec)
 
 
-class CoverageMapRADECSampler(NumpyRandomFunc):
+class CoverageMapRADECSampler(NumpyRandomFunc, CiteClass):
     """A FunctionNode that samples RA and dec uniformly from the area covered
     by a survey as provided by either a opsim of a healsparse coverage map.
 
@@ -247,6 +248,10 @@ class CoverageMapRADECSampler(NumpyRandomFunc):
     at a given depth. A few points may be generated that fall outside the actual
     coverage of the survey. A higher healpix nside can be used to reduce this
     effect at the cost of more computation.
+
+    Citation
+    --------
+    HealSparse by Eli Rykoff and Javier Sanchez - https://github.com/LSSTDESC/healsparse
 
     Attributes
     ----------

--- a/src/tdastro/math_nodes/ra_dec_sampler.py
+++ b/src/tdastro/math_nodes/ra_dec_sampler.py
@@ -251,7 +251,9 @@ class CoverageMapRADECSampler(NumpyRandomFunc, CiteClass):
 
     Citation
     --------
-    HealSparse by Eli Rykoff and Javier Sanchez - https://github.com/LSSTDESC/healsparse
+        HealSparse by Eli Rykoff and Javier Sanchez
+        https://healsparse.readthedocs.io/en/stable/
+        https://github.com/LSSTDESC/healsparse
 
     Attributes
     ----------

--- a/src/tdastro/math_nodes/ra_dec_sampler.py
+++ b/src/tdastro/math_nodes/ra_dec_sampler.py
@@ -1,9 +1,11 @@
 """Samplers used for generating (RA, dec) coordinates."""
 
+import healsparse as hsp
 import numpy as np
 
 from tdastro.math_nodes.given_sampler import TableSampler
 from tdastro.math_nodes.np_random import NumpyRandomFunc
+from tdastro.opsim.opsim import OpSim
 
 
 class UniformRADEC(NumpyRandomFunc):
@@ -146,16 +148,12 @@ class OpSimUniformRADECSampler(NumpyRandomFunc):
     """A FunctionNode that samples RA and dec uniformly from the area covered
     by an OpSim.  RA and dec are returned in degrees.
 
-    TODO: Implement a more efficient sampling method that precompiles the
-    opsim coverage and samples from that.
-
     Note
     ----
-    * This is a place holder class until we can implement a more efficient
-      sampling method (with precomputation of the opsim coverage).
-    * This uses rejection sampling and can be quite slow for small coverage.
-    * The sample will terminate after a maximum number of iterations to
-      prevent infinite loops. Some out of coverage samples may be returned.
+    This uses rejection sampling and can be quite slow for small coverage. For
+    moderate to large number of samples, most users will want to use the
+    CoverageMapRADECSampler node instead. That node precomputes a coverage map
+    and samples uniformly from it.
 
     Attributes
     ----------
@@ -226,6 +224,93 @@ class OpSimUniformRADECSampler(NumpyRandomFunc):
             mask = np.asarray(self.data.is_observed(ra, dec, self.radius))
             num_missing = np.sum(~mask)
             iter_num += 1
+
+        # If we are generating a single sample, return floats.
+        if graph_state.num_samples == 1:
+            ra = ra[0]
+            dec = dec[0]
+
+        # Set the outputs and return the results. This takes the place of
+        # function node's _save_results() function because we know the outputs.
+        graph_state.set(self.node_string, "ra", ra)
+        graph_state.set(self.node_string, "dec", dec)
+        return (ra, dec)
+
+
+class CoverageMapRADECSampler(NumpyRandomFunc):
+    """A FunctionNode that samples RA and dec uniformly from the area covered
+    by a survey as provided by either a opsim of a healsparse coverage map.
+
+    Note
+    ----
+    This is approximate since the coverage map is only generated from healpixels
+    at a given depth. A few points may be generated that fall outside the actual
+    coverage of the survey. A higher healpix nside can be used to reduce this
+    effect at the cost of more computation.
+
+    Attributes
+    ----------
+    cov_map : healsparse.HealSparseMap
+        The coverage map used for sampling.
+    radius : float, optional
+        The radius of the observations in degrees.
+
+    Parameters
+    ----------
+    data : OpSim or healsparse.HealSparseMap
+        The OpSim object or coverage map to use for sampling.
+    radius : float, optional
+        The radius of the observations in degrees. If not provided and an OpSim
+        is provided, use the default radius of the OpSim.
+        Default: None
+    """
+
+    def __init__(self, data, radius=1.0, outputs=None, seed=None, **kwargs):
+        if isinstance(data, OpSim):
+            if len(data) == 0:
+                raise ValueError("OpSim data cannot be empty.")
+            if radius is None:
+                radius = data.radius
+            self.cov_map = data.make_coverage_map(radius=radius)
+        elif isinstance(data, hsp.HealSparseMap):
+            self.cov_map = data
+        else:
+            raise ValueError("Invalid data type: {type(data)}")
+
+        if radius is None or radius <= 0.0:
+            raise ValueError("Invalid radius: {radius}")
+        self.radius = radius
+
+        # Override key arguments. We create a uniform sampler function, but
+        # won't need it because the subclass overloads compute().
+        func_name = "uniform"
+        outputs = ["ra", "dec"]
+        super().__init__(func_name, outputs=outputs, seed=seed, **kwargs)
+
+    def compute(self, graph_state, rng_info=None, **kwargs):
+        """Return the given values.
+
+        Parameters
+        ----------
+        graph_state : GraphState
+            An object mapping graph parameters to their values. This object is modified
+            in place as it is sampled.
+        rng_info : numpy.random._generator.Generator, optional
+            A given numpy random number generator to use for this computation. If not
+            provided, the function uses the node's random number generator.
+        **kwargs : dict, optional
+            Additional function arguments.
+
+        Returns
+        -------
+        (ra, dec) : tuple of floats or np.ndarray
+            If a single sample is generated, returns a tuple of floats. Otherwise,
+            returns a tuple of np.ndarrays.
+        """
+        rng = rng_info if rng_info is not None else self._rng
+
+        # Generate the random (RA, dec) lists.
+        ra, dec = hsp.make_uniform_randoms(self.cov_map, graph_state.num_samples, rng=rng)
 
         # If we are generating a single sample, return floats.
         if graph_state.num_samples == 1:

--- a/src/tdastro/opsim/opsim.py
+++ b/src/tdastro/opsim/opsim.py
@@ -486,6 +486,7 @@ class OpSim:  # noqa: D101
         Citation
         --------
         HealSparse by Eli Rykoff and Javier Sanchez
+        https://healsparse.readthedocs.io/en/stable/
         https://github.com/LSSTDESC/healsparse
 
         Parameters


### PR DESCRIPTION
This PR adds the ability for users to generate a healsparse coverage map from an `OpSim` and to sample (RA, dec) points from that coverage map. It also adds a notebook tutorial demonstrating the different approaches for sampling (RA, dec) points.