### PR TITLE
Add support for ZTF passbands

### DIFF
--- a/docs/notebooks/passband-demo.ipynb
+++ b/docs/notebooks/passband-demo.ipynb
@@ -147,9 +147,9 @@
     ")\n",
     "\n",
     "toy_passband = Passband(\n",
+    "    values,  # The matrix of transmission data\n",
     "    \"toy_survey\",  # Survey name.\n",
     "    \"a\",  # Filter name\n",
-    "    table_values=values,  # The matrix of transmission data\n",
     ")\n",
     "toy_passband.plot()"
    ]

--- a/src/tdastro/astro_utils/passbands.py
+++ b/src/tdastro/astro_utils/passbands.py
@@ -6,7 +6,8 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pooch
 import scipy.integrate
-import sncosmo
+from citation_compass import cite_function
+from sncosmo import Bandpass, get_bandpass
 
 from tdastro import _TDASTRO_BASE_DATA_DIR
 
@@ -284,7 +285,7 @@ class PassbandGroup:
                 self.passbands[pb.full_name] = pb
         elif preset == "ZTF":
             for filter_name in ["g", "r", "i"]:
-                sn_pb = sncosmo.get_bandpass(f"ztf{filter_name}")
+                sn_pb = get_bandpass(f"ztf{filter_name}")
                 pb = Passband.from_sncosmo("ZTF", filter_name, sn_pb)
                 self.passbands[pb.full_name] = pb
         else:
@@ -649,7 +650,8 @@ class Passband:
         )
 
     @classmethod
-    def from_sncosmo(cls, survey: str, filter_name: str, bandpass: sncosmo.Bandpass):
+    @cite_function("https://sncosmo.readthedocs.io/en/stable/api/sncosmo.Bandpass.html")
+    def from_sncosmo(cls, survey: str, filter_name: str, bandpass: Bandpass):
         """Create a Passband object from an sncosmo.Bandpass object.
 
         Parameters
@@ -660,6 +662,11 @@ class Passband:
             The filter_name of the passband: eg, "u".
         bandpass : sncosmo.Bandpass
             The bandpass object from which to create the Passband object.
+
+        Reference
+        ---------
+        snocosmo.Bandpass:
+        https://sncosmo.readthedocs.io/en/stable/api/sncosmo.Bandpass.html
         """
         table = np.column_stack([bandpass.wave, bandpass.trans])
         return Passband(

--- a/src/tdastro/astro_utils/passbands.py
+++ b/src/tdastro/astro_utils/passbands.py
@@ -262,9 +262,8 @@ class PassbandGroup:
         preset : str
             The name of the pre-defined set of passbands to load.
         table_dir : str, optional
-            The path to the directory containing the passband tables. If no table_path has been specified in
-            the PassbandGroup's passband_parameters and table_dir is not None, table paths will be set to
-            table_dir/{survey}/{filter_name}.dat.
+            The path to the base directory containing the passband tables. The full path to the tables
+            will be {table_dir}/{survey}/{filter_name}.dat.
         **kwargs
             Additional keyword arguments to pass to the Passband constructor.
         """
@@ -272,6 +271,9 @@ class PassbandGroup:
         if preset == "LSST":
             if table_dir is None:
                 table_dir = Path(_TDASTRO_BASE_DATA_DIR, "passbands", "LSST")
+            else:
+                table_dir = Path(table_dir) / "LSST"
+
             for filter_name in ["u", "g", "r", "i", "z", "y"]:
                 url = (
                     f"https://github.com/lsst/throughputs/blob/main/baseline/total_{filter_name}.dat?raw=true"
@@ -281,12 +283,13 @@ class PassbandGroup:
                     filter_name,
                     table_path=Path(table_dir, f"{filter_name}.dat"),
                     table_url=url,
+                    **kwargs,
                 )
                 self.passbands[pb.full_name] = pb
         elif preset == "ZTF":
             for filter_name in ["g", "r", "i"]:
                 sn_pb = get_bandpass(f"ztf{filter_name}")
-                pb = Passband.from_sncosmo("ZTF", filter_name, sn_pb)
+                pb = Passband.from_sncosmo("ZTF", filter_name, sn_pb, **kwargs)
                 self.passbands[pb.full_name] = pb
         else:
             raise ValueError(f"Unknown passband preset: {preset}")

--- a/src/tdastro/astro_utils/passbands.py
+++ b/src/tdastro/astro_utils/passbands.py
@@ -6,8 +6,9 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pooch
 import scipy.integrate
+import sncosmo
 
-import tdastro
+from tdastro import _TDASTRO_BASE_DATA_DIR
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(__name__)
@@ -103,7 +104,7 @@ class PassbandGroup:
             )
 
         if preset is not None:
-            self._load_preset(preset, table_dir=table_dir, **kwargs)
+            self.add_preset(preset, table_dir=table_dir, **kwargs)
 
         elif passband_parameters is not None:
             for parameters in passband_parameters:
@@ -123,7 +124,7 @@ class PassbandGroup:
                 elif isinstance(parameters["table_path"], str):
                     parameters["table_path"] = Path(parameters["table_path"])
 
-                passband = Passband(**parameters)
+                passband = Passband.from_file(**parameters)
                 self.passbands[passband.full_name] = passband
 
         # Load any additional passbands from the given list.
@@ -241,8 +242,19 @@ class PassbandGroup:
         # Do the actual loading. The subsetting of filters happens here.
         return PassbandGroup(passband_parameters=all_params, filters_to_load=filters)
 
-    def _load_preset(self, preset: str, table_dir: Optional[str], **kwargs) -> None:
-        """Load a pre-defined set of passbands.
+    def add_passband(self, passband) -> None:
+        """Manually add a passband to the group.
+
+        Parameters
+        ----------
+        passband : Passband
+            The passband to add to the group.
+        """
+        self.passbands[passband.full_name] = passband
+        self._update_internal_data()
+
+    def add_preset(self, preset: str, table_dir: Optional[str], **kwargs) -> None:
+        """Load a pre-defined set of passbands and add it to the group.
 
         Parameters
         ----------
@@ -257,19 +269,28 @@ class PassbandGroup:
         """
         logger.info(f"Loading passbands from preset {preset}")
         if preset == "LSST":
+            if table_dir is None:
+                table_dir = Path(_TDASTRO_BASE_DATA_DIR, "passbands", "LSST")
             for filter_name in ["u", "g", "r", "i", "z", "y"]:
-                if table_dir is None:
-                    self.passbands[f"LSST_{filter_name}"] = Passband("LSST", filter_name, **kwargs)
-                else:
-                    table_path = Path(table_dir, "LSST", f"{filter_name}.dat")
-                    self.passbands[f"LSST_{filter_name}"] = Passband(
-                        "LSST",
-                        filter_name,
-                        table_path=table_path,
-                        **kwargs,
-                    )
+                url = (
+                    f"https://github.com/lsst/throughputs/blob/main/baseline/total_{filter_name}.dat?raw=true"
+                )
+                pb = Passband.from_file(
+                    "LSST",
+                    filter_name,
+                    table_path=Path(table_dir, f"{filter_name}.dat"),
+                    table_url=url,
+                )
+                self.passbands[pb.full_name] = pb
+        elif preset == "ZTF":
+            for filter_name in ["g", "r", "i"]:
+                sn_pb = sncosmo.get_bandpass(f"ztf{filter_name}")
+                pb = Passband.from_sncosmo("ZTF", filter_name, sn_pb)
+                self.passbands[pb.full_name] = pb
         else:
             raise ValueError(f"Unknown passband preset: {preset}")
+
+        self._update_internal_data()
 
     def _update_internal_data(self) -> None:
         """Update the cached internal data."""
@@ -365,24 +386,6 @@ class PassbandGroup:
         full_name_mask = np.isin(filters, list(self.passbands.keys()))
         filter_name_mask = np.isin(filters, list(self._filter_to_name.keys()))
         return full_name_mask | filter_name_mask
-
-    def process_transmission_tables(
-        self, delta_wave: Optional[float] = 5.0, trim_quantile: Optional[float] = 1e-3
-    ):
-        """Process the transmission tables for all passbands in the group; recalculate group's wave attribute.
-
-        Parameters
-        ----------
-        delta_wave : float or None, optional
-            The grid step of the wave grid. Default is 5.0.
-        trim_quantile : float or None, optional
-            The quantile to trim the transmission table by. For example, if trim_quantile is 1e-3, the
-            transmission table will be trimmed to include only the central 99.8% of rows.
-        """
-        for passband in self.passbands.values():
-            passband.process_transmission_table(delta_wave, trim_quantile)
-
-        self._update_internal_data()
 
     def fluxes_to_bandflux(self, flux_density_matrix: np.ndarray, filter: str) -> np.ndarray:
         """Calculate bandfluxes for a single passband in the group.
@@ -494,20 +497,19 @@ class Passband:
 
     def __init__(
         self,
+        table_values: np.array,
         survey: str,
         filter_name: str,
         delta_wave: Optional[float] = 5.0,
         trim_quantile: Optional[float] = 1e-3,
-        table_path: Optional[Union[str, Path]] = None,
-        table_url: Optional[str] = None,
-        table_values: Optional[np.array] = None,
         units: Optional[Literal["nm", "A"]] = "A",
-        force_download: bool = False,
     ):
         """Construct a Passband object.
 
         Parameters
         ----------
+        table_values : np.ndarray, optional
+            A 2D array of wavelengths and transmissions.
         survey : str
             The survey to which the passband belongs: eg, "LSST".
         filter_name : str
@@ -520,60 +522,25 @@ class Passband:
             The quantile to trim the transmission table by. For example, if trim_quantile is 1e-3, the
             transmission table will be trimmed to include only the central 99.8% of the area under the
             transmission curve.
-        table_path : str, optional
-            The path to the transmission table file. If None, the table path will be set to a default path;
-            if no file exists at this location, the file will be downloaded from table_url.
-        table_url : str, optional
-            The URL to download the transmission table file. If None, the table URL will be set to
-            a default URL based on the survey and filter_name. Default is None.
-        table_values : np.ndarray, optional
-            A 2D array of wavelengths and transmissions. Used to provide a given table.
         units : Literal['nm','A'], optional
             Denotes whether the wavelength units of the table are nanometers ('nm') or Angstroms ('A').
             By default 'A'. Does not affect the output units of the class, only the interpretation of the
             provided passband table.
         force_download : bool, optional
-            If True, the transmission table will be downloaded even if it already exists locally. Default is
-            False.
+            If True, the transmission table will be downloaded even if it already exists locally.
+            Default is False.
         """
         self.survey = survey
         self.filter_name = filter_name
         self.full_name = f"{survey}_{filter_name}"
         self.units = units
 
-        if table_values is not None:
-            # If the data values are given directly, use those.
-            if table_values.shape[1] != 2:
-                raise ValueError("Passband requires an input table with exactly two columns.")
-            if table_path is not None or table_url is not None:
-                raise ValueError("Multiple inputs given for passband table.")
-            self._loaded_table = np.copy(table_values)
-        else:
-            # Load the data from a file, possibly downloading it if needed.
-            if table_path is None:
-                # If no path is given, use the default.
-                table_path = Path(
-                    tdastro._TDASTRO_BASE_DATA_DIR,
-                    "passbands",
-                    self.survey,
-                    f"{self.filter_name}.dat",
-                )
-            else:
-                table_path = Path(table_path)
-
-            # If no URL is given, try loading a default.
-            if table_url is None:
-                table_url = _get_passband_url(self.survey, self.filter_name)
-
-            self._loaded_table = Passband.load_transmission_table(
-                table_path,
-                table_url=table_url,
-                force_download=force_download,
-            )
-
-        # Check that wavelengths are strictly increasing
-        if not np.all(np.diff(self._loaded_table[:, 0]) > 0):
+        # Perform validation of the transmission table.
+        if table_values.shape[1] != 2:
+            raise ValueError("Passband requires an input table with exactly two columns.")
+        if np.any(np.diff(table_values[:, 0]) <= 0):
             raise ValueError("Wavelengths in transmission table must be strictly increasing.")
+        self._loaded_table = np.copy(table_values)
 
         # Preprocess the passband.
         self._standardize_units()
@@ -611,13 +578,102 @@ class Passband:
             raise ValueError(f"Unknown Passband units {self.units}")
         self.units = "A"
 
-    @staticmethod
-    def load_transmission_table(
-        table_path: Union[str, Path],
+    @classmethod
+    def from_file(
+        cls,
+        survey: str,
+        filter_name: str,
+        delta_wave: Optional[float] = 5.0,
+        trim_quantile: Optional[float] = 1e-3,
+        table_path: Optional[Union[str, Path]] = None,
         table_url: Optional[str] = None,
+        units: Optional[Literal["nm", "A"]] = "A",
         force_download: bool = False,
-    ) -> np.ndarray:
-        """Load a transmission table from a file (or download it if it doesn't exist).
+    ):
+        """Construct a Passband object from a file, downloading it if needed.
+
+        Parameters
+        ----------
+        survey : str
+            The survey to which the passband belongs: eg, "LSST".
+        filter_name : str
+            The filter_name of the passband: eg, "u".
+        delta_wave : float or None, optional
+            The grid step of the wave grid, in angstroms.
+            It is typically used to downsample transmission using linear interpolation.
+            Default is 5 angstroms. If None the original grid is used.
+        trim_quantile : float or None, optional
+            The quantile to trim the transmission table by. For example, if trim_quantile is 1e-3, the
+            transmission table will be trimmed to include only the central 99.8% of the area under the
+            transmission curve.
+        table_path : str, optional
+            The path to the transmission table file. If None, the table path will be set to a default path;
+            if no file exists at this location, the file will be downloaded from table_url.
+        table_url : str, optional
+            The URL to download the transmission table file. If None, the table URL will be set to
+            a default URL based on the survey and filter_name. Default is None.
+        units : Literal['nm','A'], optional
+            Denotes whether the wavelength units of the table are nanometers ('nm') or Angstroms ('A').
+            By default 'A'. Does not affect the output units of the class, only the interpretation of the
+            provided passband table.
+        force_download : bool, optional
+            If True, the transmission table will be downloaded even if it already exists locally. Default is
+            False.
+        """
+        if table_path is None:
+            # If no path is given, use the default.
+            table_path = Path(
+                _TDASTRO_BASE_DATA_DIR,
+                "passbands",
+                survey,
+                f"{filter_name}.dat",
+            )
+        else:
+            table_path = Path(table_path)
+
+        # Download the table if it does not exist or if force_download is True.
+        if force_download or not table_path.exists():
+            success = Passband.download_transmission_table(table_path, table_url)
+            if not success:
+                raise RuntimeError(f"Failed to download passband table from {table_url}.")
+
+        # Load the table and create the passband./
+        loaded_table = Passband.load_transmission_table(table_path)
+        return Passband(
+            loaded_table,
+            survey,
+            filter_name,
+            delta_wave,
+            trim_quantile,
+            units=units,
+        )
+
+    @classmethod
+    def from_sncosmo(cls, survey: str, filter_name: str, bandpass: sncosmo.Bandpass):
+        """Create a Passband object from an sncosmo.Bandpass object.
+
+        Parameters
+        ----------
+        survey : str
+            The survey to which the passband belongs: eg, "LSST".
+        filter_name : str
+            The filter_name of the passband: eg, "u".
+        bandpass : sncosmo.Bandpass
+            The bandpass object from which to create the Passband object.
+        """
+        table = np.column_stack([bandpass.wave, bandpass.trans])
+        return Passband(
+            table,
+            survey,
+            filter_name,
+            trim_quantile=None,  # Trimming is done in sncosmo
+            units="A",  # All sncosmo bandpasses are in Angstroms
+        )
+
+    @staticmethod
+    def load_transmission_table(table_path: Union[str, Path], **kwargs) -> np.ndarray:
+        """Load a transmission table from a file.
+
         Table must have 2 columns: wavelengths and transmissions; wavelengths must be
         strictly increasing.
 
@@ -626,12 +682,8 @@ class Passband:
         table_path : str or Path
             The path to the transmission table file. If no file exists at this location, the
             file will be downloaded from table_url.
-        table_url : str, optional
-            The URL to download the transmission table file. If None, the table URL will be set to
-            a default URL based on the survey and filter_name. Default is None.
-        force_download : bool, optional
-            If True, the transmission table will be downloaded even if it already exists locally.
-            Default is False.
+        **kwargs : dict
+            Additional keyword arguments to pass to the reader method.
 
         Returns
         -------
@@ -640,22 +692,31 @@ class Passband:
         """
         logger.info(f"Loading passband from file: {table_path}")
 
-        table_path.parent.mkdir(parents=True, exist_ok=True)
-        if force_download or not table_path.exists():
-            Passband.download_transmission_table(table_path, table_url)
+        table_path = Path(table_path)
+        if not table_path.exists():
+            raise FileNotFoundError(f"Transmission table not found at {table_path}")
 
-        # Load the table file
-        try:
-            loaded_table = np.loadtxt(table_path)
-        except OSError as e:
-            raise OSError(f"Error reading transmission table from file: {e}") from e
+        # Add default delimiter if not provided
+        if (table_path.suffix == ".csv" or table_path.suffix == ".ecsv") and "delimiter" not in kwargs:
+            kwargs["delimiter"] = ","
+
+        # Load the table.
+        loaded_table = np.loadtxt(table_path, **kwargs)
 
         # Check that the table has the correct shape
         if loaded_table.size == 0 or loaded_table.shape[1] != 2:
             raise ValueError("Transmission table must have exactly 2 columns.")
-        # Check that wavelengths are strictly increasing
-        if not np.all(np.diff(loaded_table[:, 0]) > 0):
-            raise ValueError("Wavelengths in transmission table must be strictly increasing.")
+
+        # Check that wavelengths are strictly increasing. If there are duplicates then
+        # we average the values.
+        diffs = np.diff(loaded_table[:, 0])
+        if np.any(diffs < 0.0):
+            raise ValueError("Wavelengths in transmission table must be increasing.")
+        if np.any(diffs == 0.0):
+            logger.warning("Duplicate wavelengths found in transmission table; averaging values.")
+            dup_inds = np.where(diffs == 0.0)
+            loaded_table[dup_inds, 1] = 0.5 * (loaded_table[dup_inds, 1] + loaded_table[dup_inds + 1, 1])
+            loaded_table = np.delete(loaded_table, dup_inds + 1, axis=0)
 
         return loaded_table
 
@@ -701,7 +762,9 @@ class Passband:
         return True
 
     def process_transmission_table(
-        self, delta_wave: Optional[float] = 5.0, trim_quantile: Optional[float] = 1e-3
+        self,
+        delta_wave: Optional[float] = 5.0,
+        trim_quantile: Optional[float] = 1e-3,
     ):
         """Process the transmission table.
 
@@ -941,27 +1004,3 @@ class Passband:
         ax.set_xlabel(r"Wavelength, $\AA$")
         ax.set_ylabel("Transmission Value")
         ax.set_ylim(0, None)
-
-
-# --- Helper Functions ----------------------------------------------------
-
-
-def _get_passband_url(survey: str, filter: str) -> Union[str, None]:
-    """Get the URL to download passband information.
-
-    Parameters
-    ----------
-    survey : str,
-        The passband's survey.
-    filter : str,
-        The passband's filter.
-
-    Returns
-    -------
-    url : str or None
-        Returns a string with the URL if the survey's data location is known.
-        Otherwise returns None.
-    """
-    if survey == "LSST":
-        return f"https://github.com/lsst/throughputs/blob/main/baseline/total_{filter}.dat?raw=true"
-    return None

--- a/src/tdastro/astro_utils/passbands.py
+++ b/src/tdastro/astro_utils/passbands.py
@@ -560,8 +560,14 @@ class Passband:
         # Perform validation of the transmission table.
         if table_values.shape[1] != 2:
             raise ValueError("Passband requires an input table with exactly two columns.")
-        if np.any(np.diff(table_values[:, 0]) <= 0):
+        diffs = np.diff(table_values[:, 0])
+        if np.any(diffs < 0.0):
             raise ValueError("Wavelengths in transmission table must be strictly increasing.")
+        if np.any(diffs == 0.0):
+            logger.warning("Duplicate wavelengths found in transmission table; averaging values.")
+            dup_inds = np.where(diffs == 0.0)
+            table_values[dup_inds, 1] = 0.5 * (table_values[dup_inds, 1] + table_values[dup_inds + 1, 1])
+            table_values = np.delete(table_values, dup_inds + 1, axis=0)
         self._loaded_table = np.copy(table_values)
 
         # Preprocess the passband.

--- a/src/tdastro/astro_utils/passbands.py
+++ b/src/tdastro/astro_utils/passbands.py
@@ -659,7 +659,7 @@ class Passband:
             if not success:
                 raise RuntimeError(f"Failed to download passband table from {table_url}.")
 
-        # Load the table and create the passband./
+        # Load the table and create the passband.
         loaded_table = Passband.load_transmission_table(table_path)
         return Passband(
             loaded_table,

--- a/src/tdastro/astro_utils/passbands.py
+++ b/src/tdastro/astro_utils/passbands.py
@@ -391,6 +391,24 @@ class PassbandGroup:
         filter_name_mask = np.isin(filters, list(self._filter_to_name.keys()))
         return full_name_mask | filter_name_mask
 
+    def process_transmission_tables(
+        self, delta_wave: Optional[float] = 5.0, trim_quantile: Optional[float] = 1e-3
+    ):
+        """Process the transmission tables for all passbands in the group; recalculate group's wave attribute.
+
+        Parameters
+        ----------
+        delta_wave : float or None, optional
+            The grid step of the wave grid. Default is 5.0.
+        trim_quantile : float or None, optional
+            The quantile to trim the transmission table by. For example, if trim_quantile is 1e-3, the
+            transmission table will be trimmed to include only the central 99.8% of rows.
+        """
+        for passband in self.passbands.values():
+            passband.process_transmission_table(delta_wave, trim_quantile)
+
+        self._update_internal_data()
+
     def fluxes_to_bandflux(self, flux_density_matrix: np.ndarray, filter: str) -> np.ndarray:
         """Calculate bandfluxes for a single passband in the group.
 

--- a/tests/tdastro/astro_utils/test_passband_groups.py
+++ b/tests/tdastro/astro_utils/test_passband_groups.py
@@ -10,9 +10,8 @@ from tdastro.sources.spline_model import SplineModel
 def create_lsst_passband_group(passbands_dir, delta_wave=5.0, trim_quantile=None):
     """Helper function to create a PassbandGroup object for LSST passbands, using transmission tables
     included in the test data directory."""
-    table_dir = passbands_dir / "LSST"
     return PassbandGroup(
-        preset="LSST", table_dir=table_dir, delta_wave=delta_wave, trim_quantile=trim_quantile
+        preset="LSST", table_dir=passbands_dir, delta_wave=delta_wave, trim_quantile=trim_quantile
     )
 
 

--- a/tests/tdastro/astro_utils/test_passband_groups.py
+++ b/tests/tdastro/astro_utils/test_passband_groups.py
@@ -55,11 +55,11 @@ def test_passband_group_access(tmp_path):
     """Test that we can create a passband group and access the individual passbands."""
     table_vals = np.array([[100, 0.5], [200, 0.75], [300, 0.25]])
     pb_list = [
-        Passband("survey1", "a", table_values=table_vals, trim_quantile=None),
-        Passband("survey1", "b", table_values=table_vals, trim_quantile=None),
-        Passband("survey1", "c", table_values=table_vals, trim_quantile=None),
-        Passband("survey2", "c", table_values=table_vals, trim_quantile=None),
-        Passband("survey2", "d", table_values=table_vals, trim_quantile=None),
+        Passband(table_vals, "survey1", "a", trim_quantile=None),
+        Passband(table_vals, "survey1", "b", trim_quantile=None),
+        Passband(table_vals, "survey1", "c", trim_quantile=None),
+        Passband(table_vals, "survey2", "c", trim_quantile=None),
+        Passband(table_vals, "survey2", "d", trim_quantile=None),
     ]
 
     pb_group = PassbandGroup(given_passbands=pb_list)
@@ -209,21 +209,21 @@ def test_passband_group_from_list(tmp_path):
     """Test that we can create a PassbandGroup from a pre-specified list."""
     pb_list = [
         Passband(
+            np.array([[100, 0.5], [200, 0.75], [300, 0.25]]),
             "my_survey",
             "a",
-            table_values=np.array([[100, 0.5], [200, 0.75], [300, 0.25]]),
             trim_quantile=None,
         ),
         Passband(
+            np.array([[250, 0.25], [300, 0.5], [350, 0.75]]),
             "my_survey",
             "b",
-            table_values=np.array([[250, 0.25], [300, 0.5], [350, 0.75]]),
             trim_quantile=None,
         ),
         Passband(
+            np.array([[400, 0.75], [500, 0.25], [600, 0.5]]),
             "my_survey",
             "c",
-            table_values=np.array([[400, 0.75], [500, 0.25], [600, 0.5]]),
             trim_quantile=None,
         ),
     ]
@@ -243,27 +243,27 @@ def test_passband_load_subset_passbands(tmp_path):
     """Test that we can load a subset of filters."""
     pb_list = [
         Passband(
+            np.array([[100, 0.5], [200, 0.75], [300, 0.25]]),
             "my_survey",
             "a",
-            table_values=np.array([[100, 0.5], [200, 0.75], [300, 0.25]]),
             trim_quantile=None,
         ),
         Passband(
+            np.array([[250, 0.25], [300, 0.5], [350, 0.75]]),
             "my_survey",
             "b",
-            table_values=np.array([[250, 0.25], [300, 0.5], [350, 0.75]]),
             trim_quantile=None,
         ),
         Passband(
+            np.array([[400, 0.75], [500, 0.25], [600, 0.5]]),
             "my_survey",
             "c",
-            table_values=np.array([[400, 0.75], [500, 0.25], [600, 0.5]]),
             trim_quantile=None,
         ),
         Passband(
+            np.array([[800, 0.75], [850, 0.25], [900, 0.5]]),
             "my_survey",
             "d",
-            table_values=np.array([[800, 0.75], [850, 0.25], [900, 0.5]]),
             trim_quantile=None,
         ),
     ]
@@ -286,15 +286,15 @@ def test_passband_unique_waves():
     """Test that if we create two passbands with very similar wavelengths, they get merged."""
     pb_list = [
         Passband(
+            np.array([[100, 0.5], [250, 0.25]]),
             "my_survey",
             "a",
-            table_values=np.array([[100, 0.5], [250, 0.25]]),
             trim_quantile=None,
         ),
         Passband(
+            np.array([[200.000001, 0.25], [300.000001, 0.5]]),
             "my_survey",
             "b",
-            table_values=np.array([[200.000001, 0.25], [300.000001, 0.5]]),
             trim_quantile=None,
         ),
     ]
@@ -307,15 +307,15 @@ def test_passband_unique_waves():
     # Larger gaps won't register.
     pb_list = [
         Passband(
+            np.array([[100, 0.5], [250, 0.25]]),
             "my_survey",
             "a",
-            table_values=np.array([[100, 0.5], [250, 0.25]]),
             trim_quantile=None,
         ),
         Passband(
+            np.array([[200.5, 0.25], [300.5, 0.5]]),
             "my_survey",
             "b",
-            table_values=np.array([[200.5, 0.25], [300.5, 0.5]]),
             trim_quantile=None,
         ),
     ]

--- a/tests/tdastro/astro_utils/test_passbands.py
+++ b/tests/tdastro/astro_utils/test_passbands.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 import numpy as np
 import pytest
+from sncosmo import get_bandpass
 from tdastro.astro_utils.passbands import Passband
 from tdastro.sources.spline_model import SplineModel
 
@@ -12,7 +13,7 @@ def create_lsst_passband(path, filter_name, **kwargs):
     """Helper function to create an LSST Passband object for testing."""
     survey = "LSST"
     table_path = f"{path}/{survey}/{filter_name}.dat"
-    return Passband(survey, filter_name, table_path=table_path, **kwargs)
+    return Passband.from_file(survey, filter_name, table_path=table_path, **kwargs)
 
 
 def create_toy_passband(path, transmission_table, filter_name="a", **kwargs):
@@ -27,7 +28,7 @@ def create_toy_passband(path, transmission_table, filter_name="a", **kwargs):
         f.write(transmission_table)
 
     # Create a Passband object
-    return Passband(survey, filter_name, table_path=table_path, **kwargs)
+    return Passband.from_file(survey, filter_name, table_path=table_path, **kwargs)
 
 
 def test_passband_str(passbands_dir, tmp_path):
@@ -44,18 +45,16 @@ def test_passband_str(passbands_dir, tmp_path):
 
 def test_passband_eq(passbands_dir, tmp_path):
     """Test the __str__ method of the Passband class."""
-    a_band = Passband("LSST", "a", table_values=np.array([[1000, 0.5], [1005, 0.6], [1010, 0.7]]))
-    b_band = Passband("LSST", "b", table_values=np.array([[1000, 0.5], [1005, 0.6], [1010, 0.7]]))
-    c_band = Passband("LSST", "c", table_values=np.array([[1000, 0.5], [1005, 0.7], [1010, 0.7]]))
-    d_band = Passband("LSST", "d", table_values=np.array([[1000, 0.5], [1005, 0.6], [1020, 0.7]]))
+    a_band = Passband(np.array([[1000, 0.5], [1005, 0.6], [1010, 0.7]]), "LSST", "a")
+    b_band = Passband(np.array([[1000, 0.5], [1005, 0.6], [1010, 0.7]]), "LSST", "b")
+    c_band = Passband(np.array([[1000, 0.5], [1005, 0.7], [1010, 0.7]]), "LSST", "c")
+    d_band = Passband(np.array([[1000, 0.5], [1005, 0.6], [1020, 0.7]]), "LSST", "d")
     assert a_band == b_band
     assert a_band != c_band
     assert a_band != d_band
 
     # Passbands with different units are not equal.
-    a2_band = Passband(
-        "LSST", "a", table_values=np.array([[1000, 0.5], [1005, 0.6], [1010, 0.7]]), units="nm"
-    )
+    a2_band = Passband(np.array([[1000, 0.5], [1005, 0.6], [1010, 0.7]]), "LSST", "a", units="nm")
     assert a_band != a2_band
 
 
@@ -67,7 +66,7 @@ def test_passband_manual_create(tmp_path):
 
     # Create a manual passband.
     transmission_table = np.array([[1000, 0.5], [1005, 0.6], [1010, 0.7]])
-    test_pb = Passband(survey="test", filter_name="u", table_values=transmission_table)
+    test_pb = Passband(transmission_table, survey="test", filter_name="u")
 
     assert test_pb.survey == "test"
     assert test_pb.filter_name == "u"
@@ -77,7 +76,7 @@ def test_passband_manual_create(tmp_path):
 
     # We can create an load a table in nm as well. It will auto-convert to Angstroms.
     transmission2 = np.array([[100, 0.5], [100.5, 0.6], [101, 0.7]])
-    test_pb2 = Passband(survey="test", filter_name="g", table_values=transmission2, units="nm")
+    test_pb2 = Passband(transmission2, survey="test", filter_name="g", units="nm")
     assert test_pb2.survey == "test"
     assert test_pb2.filter_name == "g"
     assert test_pb2.full_name == "test_g"
@@ -87,37 +86,25 @@ def test_passband_manual_create(tmp_path):
     # We raise an error if the data is not sorted.
     with pytest.raises(ValueError):
         _ = Passband(
+            np.array([[1000, 0.5], [900, 0.2], [1100, 0.7]]),
             survey="test",
             filter_name="u",
-            table_values=np.array([[1000, 0.5], [900, 0.2], [1100, 0.7]]),
         )
 
     # We raise an error if the data is not the right shape.
     with pytest.raises(ValueError):
         _ = Passband(
+            np.full((10, 3), 1.0),
             survey="test",
             filter_name="u",
-            table_values=np.full((10, 3), 1.0),
-        )
-
-    # We raise an error when no data is given or when we given a path AND table.
-    with pytest.raises(ValueError):
-        _ = Passband(survey="test", filter_name="u")
-
-    with pytest.raises(ValueError):
-        _ = Passband(
-            survey="test",
-            filter_name="u",
-            table_path="./",
-            table_values=transmission_table,
         )
 
     # We raise an error with an invalid unit.
     with pytest.raises(ValueError):
         _ = Passband(
+            transmission_table,
             survey="test",
             filter_name="u",
-            table_values=transmission_table,
             units="invalid",
         )
 
@@ -168,7 +155,7 @@ def test_passband_download_transmission_table(tmp_path):
     survey = "TEST"
     filter_name = "a"
     table_path = tmp_path / f"{survey}/{filter_name}.dat"
-    table_url = f"http://example.com/{survey}/{filter_name}.dat"
+    table_url = f"https://data.lsdb.io/{survey}/{filter_name}.dat"
     transmission_table = "1000 0.5\n1005 0.6\n1010 0.7\n"
 
     def mock_urlretrieve(url, known_hash, fname, path):
@@ -179,7 +166,7 @@ def test_passband_download_transmission_table(tmp_path):
 
     # Mock the urlretrieve portion of the download method
     with patch("pooch.retrieve", side_effect=mock_urlretrieve) as mocked_urlretrieve:
-        a_band = Passband(survey, filter_name, table_path=table_path, table_url=table_url)
+        a_band = Passband.from_file(survey, filter_name, table_path=table_path, table_url=table_url)
 
         # Check that the transmission table was downloaded
         mocked_urlretrieve.assert_called_once_with(
@@ -191,6 +178,35 @@ def test_passband_download_transmission_table(tmp_path):
 
         # Check that the transmission table was loaded correctly
         np.testing.assert_allclose(a_band._loaded_table, np.array([[1000, 0.5], [1005, 0.6], [1010, 0.7]]))
+
+
+def test_passband_from_file(passbands_dir, tmp_path):
+    """Test the from_file constructor of the Passband class."""
+    # Test a toy transmission table was loaded correctly
+    transmission_table = "1000 0.5\n1005 0.6\n1010 0.7\n"
+    a_band = create_toy_passband(tmp_path, transmission_table)
+    np.testing.assert_allclose(a_band._loaded_table, np.array([[1000, 0.5], [1005, 0.6], [1010, 0.7]]))
+
+    table_path = Path(tmp_path, "TOY", "a.dat")
+    a_band_2 = Passband.from_file("TOY", "a", table_path=table_path)
+    np.testing.assert_allclose(a_band_2._loaded_table, np.array([[1000, 0.5], [1005, 0.6], [1010, 0.7]]))
+
+    # We raise an error if the transmission table does not exist.
+    with pytest.raises(ValueError):
+        _ = Passband.from_file(survey="test", filter_name="u", table_path="./no_such_file.dat")
+
+
+def test_passband_from_sncosmo(passbands_dir):
+    """Test the from_sncosmo constructor of the Passband class."""
+    ztf_pb = get_bandpass("ztfg")
+    ztf_band = Passband.from_sncosmo("ZTF", "g", ztf_pb)
+    assert ztf_band.survey == "ZTF"
+    assert ztf_band.filter_name == "g"
+    assert ztf_band.full_name == "ZTF_g"
+    assert ztf_band.units == "A"
+    assert ztf_band._loaded_table is not None
+    assert np.allclose(ztf_band._loaded_table[:, 0], ztf_pb.wave)
+    assert np.allclose(ztf_band._loaded_table[:, 1], ztf_pb.trans)
 
 
 def test_process_transmission_table(passbands_dir, tmp_path):

--- a/tests/tdastro/astro_utils/test_passbands.py
+++ b/tests/tdastro/astro_utils/test_passbands.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 import numpy as np
 import pytest
-from sncosmo import get_bandpass
+from sncosmo import Bandpass
 from tdastro.astro_utils.passbands import Passband
 from tdastro.sources.spline_model import SplineModel
 
@@ -198,15 +198,18 @@ def test_passband_from_file(passbands_dir, tmp_path):
 
 def test_passband_from_sncosmo(passbands_dir):
     """Test the from_sncosmo constructor of the Passband class."""
-    ztf_pb = get_bandpass("ztfg")
-    ztf_band = Passband.from_sncosmo("ZTF", "g", ztf_pb)
+    sn_pb = Bandpass(
+        np.array([6000, 6005, 6010]),  # wavelengths (A)
+        np.array([0.5, 0.6, 0.7]),  # transmissions
+    )
+    ztf_band = Passband.from_sncosmo("ZTF", "g", sn_pb)
     assert ztf_band.survey == "ZTF"
     assert ztf_band.filter_name == "g"
     assert ztf_band.full_name == "ZTF_g"
     assert ztf_band.units == "A"
     assert ztf_band._loaded_table is not None
-    assert np.allclose(ztf_band._loaded_table[:, 0], ztf_pb.wave)
-    assert np.allclose(ztf_band._loaded_table[:, 1], ztf_pb.trans)
+    assert np.allclose(ztf_band._loaded_table[:, 0], sn_pb.wave)
+    assert np.allclose(ztf_band._loaded_table[:, 1], sn_pb.trans)
 
 
 def test_process_transmission_table(passbands_dir, tmp_path):


### PR DESCRIPTION
Adds support for ZTF passbands (and any other sncosmo passbands). Also refactors the code to:
- Create separate code paths for building a `Passband` from a file, a numpy array, or an `sncosmo.Bandpass` object.
- Add support for manually adding a passband.
- Change `_load_preset` to `add_preset` to allow a user to load passbands from multiple surveys.
Also adds some more tests.