### PR TITLE
Control randomness in test_snia

### DIFF
--- a/tests/tdastro/sources/test_snia.py
+++ b/tests/tdastro/sources/test_snia.py
@@ -1,8 +1,11 @@
+import numpy as np
 from tdastro.example_runs.simulate_snia import run_snia_end2end
 
 
 def test_snia_end2end(oversampled_observations, passbands_dir):
     """Test that the end to end run works."""
+    rng = np.random.default_rng(123)
+
     solid_angle = 0.0001
     res_list, passbands = run_snia_end2end(
         oversampled_observations,
@@ -10,6 +13,7 @@ def test_snia_end2end(oversampled_observations, passbands_dir):
         solid_angle=solid_angle,
         nsample=None,
         check_sncosmo=True,
+        rng_info=rng,
     )
     assert len(passbands) == 2
     assert len(res_list) == 4
@@ -21,6 +25,7 @@ def test_snia_end2end(oversampled_observations, passbands_dir):
         solid_angle=solid_angle,
         nsample=num_samples,
         check_sncosmo=True,
+        rng_info=rng,
     )
     assert len(res_list) == num_samples
     assert len(passbands) == 2


### PR DESCRIPTION
test_snia is occasionally failing due to randomness in the smoke tests. This uses a fixed seed for test so that we do not get occasional failures.