### PR TITLE
Provide basic extrapolation functions for sncosmo

### DIFF
--- a/src/tdastro/utils/wave_extrapolate.py
+++ b/src/tdastro/utils/wave_extrapolate.py
@@ -1,0 +1,204 @@
+"""Functions for extrapolating flux past the end of a model's range of valid
+wavelengths using flux = f(time, wavelengths).
+"""
+
+import numpy as np
+
+
+class WaveExtrapolationModel:
+    """The base class for the wavelength extrapolation methods."""
+
+    def __init__(self):
+        pass
+
+    def __call__(self, last_wave, last_flux, query_waves):
+        """Evaluate the extrapolation given the last valid points(s)
+        and a list of new query points.
+
+        Parameters
+        ----------
+        last_wave : float
+            The last valid wavelength (in AA).
+        last_flux : numpy.ndarray
+            A length T array of the last valid flux values at each time
+            at the last valid wavelength (in the model's units).
+        query_waves : numpy.ndarray
+            A length W array of the query wavelengths (in AA) at which to extrapolate.
+
+        Returns
+        -------
+        flux : numpy.ndarray
+            A T x W matrix of extrapolated values.
+        """
+        last_flux = np.asarray(last_flux)
+        num_times = last_flux.shape[0]
+
+        query_waves = np.asarray(query_waves)
+        num_waves = query_waves.shape[0]
+        return np.zeros((num_times, num_waves))
+
+
+class ConstantExtrapolation(WaveExtrapolationModel):
+    """Extrapolate using a constant value.
+
+    Attributes
+    ----------
+    value : float
+        The value (in the model's flux units) to use for the extrapolation.
+    """
+
+    def __init__(self, value=0.0):
+        super().__init__()
+
+        if value < 0:
+            raise ValueError("Extrapolation value must be positive.")
+        self.value = value
+
+    def __call__(self, last_wave, last_flux, query_waves):
+        """Evaluate the extrapolation given the last valid points(s)
+        and a list of new query points.
+
+        Parameters
+        ----------
+        last_wave : float
+            The last valid wavelength (in AA).
+        last_flux : numpy.ndarray
+            A length T array of the last valid flux values at each time
+            at the last valid wavelength (in the model's units).
+        query_waves : numpy.ndarray
+            A length W array of the query wavelengths (in AA) at which to extrapolate.
+
+        Returns
+        -------
+        flux : numpy.ndarray
+            A T x W matrix of extrapolated values.
+        """
+        last_flux = np.asarray(last_flux)
+        num_times = last_flux.shape[0]
+
+        query_waves = np.asarray(query_waves)
+        num_waves = query_waves.shape[0]
+        return np.full((num_times, num_waves), self.value)
+
+
+class LastValueExtrapolation(WaveExtrapolationModel):
+    """Extrapolate using the last valid value."""
+
+    def __init__(self):
+        super().__init__()
+
+    def __call__(self, last_wave, last_flux, query_waves):
+        """Evaluate the extrapolation given the last valid points(s)
+        and a list of new query points.
+
+        Parameters
+        ----------
+        last_wave : float
+            The last valid wavelength (in AA).
+        last_flux : numpy.ndarray
+            A length T array of the last valid flux values at each time
+            at the last valid wavelength (in the model's units).
+        query_waves : numpy.ndarray
+            A length W array of the query wavelengths (in AA) at which to extrapolate.
+
+        Returns
+        -------
+        flux : numpy.ndarray
+            A T x W matrix of extrapolated values.
+        """
+        last_flux = np.asarray(last_flux)
+        query_waves = np.asarray(query_waves)
+        num_waves = query_waves.shape[0]
+
+        return np.tile(last_flux[:, np.newaxis], (1, num_waves))
+
+
+class LinearDecay(WaveExtrapolationModel):
+    """Linear decay of the flux using the last valid point(s) down to zero.
+
+    Attributes
+    ----------
+    decay_width : float
+        The width of the decay region in Angstroms. The flux is
+        linearly decreased to zero over this range.
+    """
+
+    def __init__(self, decay_width=100.0):
+        super().__init__()
+
+        if decay_width <= 0:
+            raise ValueError("decay_width must be positive.")
+        self.decay_width = decay_width
+
+    def __call__(self, last_wave, last_flux, query_waves):
+        """Evaluate the extrapolation given the last valid points(s)
+        and a list of new query points.
+
+        Parameters
+        ----------
+        last_wave : float
+            The last valid wavelength (in AA).
+        last_flux : numpy.ndarray
+            A length T array of the last valid flux values at each time
+            at the last valid wavelength (in the model's units).
+        query_waves : numpy.ndarray
+            A length W array of the query wavelengths (in AA) at which to extrapolate.
+
+        Returns
+        -------
+        flux : numpy.ndarray
+            A T x W matrix of extrapolated values.
+        """
+        last_flux = np.asarray(last_flux)
+        query_waves = np.asarray(query_waves)
+        dist = np.abs(query_waves - last_wave)
+
+        multiplier = np.clip(1.0 - (dist / self.decay_width), 0.0, 1.0)
+        flux = last_flux[:, np.newaxis] * multiplier[np.newaxis, :]
+        return flux
+
+
+class ExponentialDecay(WaveExtrapolationModel):
+    """Exponential decay of the flux using the last valid point(s) down to zero.
+
+    f(t, λ) = f(t, λ_last) * exp(- rate * |λ - λ_last|)
+
+    Attributes
+    ----------
+    rate : float
+        The decay rate in the exponential function.
+    """
+
+    def __init__(self, rate):
+        super().__init__()
+
+        if rate < 0:
+            raise ValueError("Decay rate must be zero or positive.")
+        self.rate = rate
+
+    def __call__(self, last_wave, last_flux, query_waves):
+        """Evaluate the extrapolation given the last valid points(s)
+        and a list of new query points.
+
+        Parameters
+        ----------
+        last_wave : float
+            The last valid wavelength (in AA).
+        last_flux : numpy.ndarray
+            A length T array of the last valid flux values at each time
+            at the last valid wavelength (in the model's units).
+        query_waves : numpy.ndarray
+            A length W array of the query wavelengths (in AA) at which to extrapolate.
+
+        Returns
+        -------
+        flux : numpy.ndarray
+            A T x W matrix of extrapolated values.
+        """
+        last_flux = np.asarray(last_flux)
+        query_waves = np.asarray(query_waves)
+        dist = np.abs(query_waves - last_wave)
+
+        multiplier = np.exp(-self.rate * dist)
+        flux = last_flux[:, np.newaxis] * multiplier[np.newaxis, :]
+        return flux

--- a/tests/tdastro/utils/test_wave_extrapolate.py
+++ b/tests/tdastro/utils/test_wave_extrapolate.py
@@ -1,0 +1,114 @@
+import numpy as np
+import pytest
+from tdastro.utils.wave_extrapolate import (
+    ConstantExtrapolation,
+    ExponentialDecay,
+    LastValueExtrapolation,
+    LinearDecay,
+    WaveExtrapolationModel,
+)
+
+
+def test_wave_extrapolation_model():
+    """Test the base class for the extrapolation methods."""
+    # Create an instance of the base class
+    extrapolator = WaveExtrapolationModel()
+
+    # Test that the __call__ method returns a zero matrix
+    last_wave = 1000.0
+    last_flux = np.array([100.0, 200.0, 300.0])
+    query_waves = np.array([1000.0, 1025.0, 1050.0, 1200.0])
+    result = extrapolator(last_wave, last_flux, query_waves)
+    expected_result = np.zeros((3, 4))
+    np.testing.assert_allclose(result, expected_result)
+
+
+def test_constant_extrapolation():
+    """Test that the constant extrapolation function works."""
+    # Create an instance of the ConstantExtrapolation class
+    extrapolator = ConstantExtrapolation(value=100.0)
+
+    # Test extrapolation past the last valid point.
+    last_wave = 1000.0
+    last_flux = np.array([100.0, 200.0, 300.0])
+    query_waves = np.array([1000.0, 1025.0, 1050.0, 1200.0])
+    expected_flux = np.full((3, 4), 100.0)
+    result = extrapolator(last_wave, last_flux, query_waves)
+    np.testing.assert_allclose(result, expected_flux)
+
+    # Test that we fail if the value is not positive
+    with pytest.raises(ValueError):
+        _ = ConstantExtrapolation(value=-1)
+
+
+def test_last_value_extrapolation():
+    """Test that the last value extrapolation function works."""
+    # Create an instance of the LastValueExtrapolation class
+    extrapolator = LastValueExtrapolation()
+
+    # Test extrapolation past the last valid point.
+    last_wave = 1000.0
+    last_flux = np.array([100.0, 200.0, 300.0])
+    query_waves = np.array([1000.0, 1025.0, 1050.0, 1200.0])
+    expected_flux = np.array(
+        [
+            [100.0, 100.0, 100.0, 100.0],
+            [200.0, 200.0, 200.0, 200.0],
+            [300.0, 300.0, 300.0, 300.0],
+        ]
+    )
+    result = extrapolator(last_wave, last_flux, query_waves)
+    np.testing.assert_allclose(result, expected_flux)
+
+
+def test_linear_decay_extrapolate():
+    """Test that the linear decay function works."""
+    decay_width = 100.0
+    extrapolator = LinearDecay(decay_width=decay_width)
+
+    # Test extrapolation past the last valid point.
+    last_wave = 1000.0
+    last_flux = np.array([100.0, 200.0, 300.0])
+    query_waves = np.array([1000.0, 1025.0, 1050.0, 1075.0, 1100.0, 1150.0])
+    expected_flux = np.array(
+        [
+            [100.0, 75.0, 50.0, 25.0, 0.0, 0.0],
+            [200.0, 150.0, 100.0, 50.0, 0.0, 0.0],
+            [300.0, 225.0, 150.0, 75.0, 0.0, 0.0],
+        ]
+    )
+    result = extrapolator(last_wave, last_flux, query_waves)
+    np.testing.assert_allclose(result, expected_flux)
+
+    # Test extrapolation before the first valid point.
+    query_waves = np.array([1000.0, 975.0, 950.0, 925.0, 900.0, 850.0])
+    result = extrapolator(last_wave, last_flux, query_waves)
+    np.testing.assert_allclose(result, expected_flux)
+
+    # Test that we fail if the decay width is not positive
+    with pytest.raises(ValueError):
+        _ = LinearDecay(decay_width=-1.0)
+
+
+def test_exponential_decay_extrapolate():
+    """Test that the exponential decay function works."""
+    extrapolator = ExponentialDecay(rate=0.1)
+
+    # Test extrapolation past the last valid point.
+    last_wave = 1000.0
+    last_flux = np.array([100.0, 200.0, 300.0])
+    query_waves = np.array([1000.0, 1025.0, 1050.0, 1075.0, 1100.0, 1150.0])
+
+    t0_flux = 100.0 * np.exp([-0.0, -2.5, -5.0, -7.5, -10.0, -15.0])
+    expected_flux = np.vstack((t0_flux, t0_flux * 2, t0_flux * 3))
+    result = extrapolator(last_wave, last_flux, query_waves)
+    np.testing.assert_allclose(result, expected_flux)
+
+    # Test extrapolation before the first valid point.
+    query_waves = np.array([1000.0, 975.0, 950.0, 925.0, 900.0, 850.0])
+    result = extrapolator(last_wave, last_flux, query_waves)
+    np.testing.assert_allclose(result, expected_flux)
+
+    # Test that we fail if the decay rate is not positive
+    with pytest.raises(ValueError):
+        _ = ExponentialDecay(rate=-0.1)


### PR DESCRIPTION
Allow custom extrapolation beyond the wavelength bounds for sncosmo models. Since we might want to support this with other model types, we add an wave extrapolation class that can be reused (instead of putting this all in the sncosmo model itself).