### PR TITLE
Fix problems with randomness in sncosmo models

### DIFF
--- a/src/tdastro/base_models.py
+++ b/src/tdastro/base_models.py
@@ -546,7 +546,7 @@ class ParameterizedNode:
         for name, setter in self.setters.items():
             # Check if we need to sample this parameter's dependency node.
             if setter.dependency is not None and setter.dependency != self:
-                setter.dependency._sample_helper(graph_state, seen_nodes, rng_info)
+                setter.dependency._sample_helper(graph_state, seen_nodes, rng_info=rng_info)
 
             # Set the result from the correct source.
             if setter.source_type == ParameterSource.CONSTANT:
@@ -617,7 +617,7 @@ class ParameterizedNode:
 
         # Resample the nodes. All information is stored in the returned results dictionary.
         seen_nodes = {}
-        self._sample_helper(results, seen_nodes, rng_info)
+        self._sample_helper(results, seen_nodes, rng_info=rng_info)
         return results
 
     def build_pytree(self, graph_state, partial=None):

--- a/src/tdastro/sources/physical_model.py
+++ b/src/tdastro/sources/physical_model.py
@@ -292,7 +292,7 @@ class PhysicalModel(ParameterizedNode):
             return results[0, :, :]
         return results
 
-    def sample_parameters(self, given_args=None, num_samples=1, rng_info=None, **kwargs):
+    def sample_parameters(self, given_args=None, num_samples=1, rng_info=None):
         """Sample the model's underlying parameters if they are provided by a function
         or ParameterizedModel.
 
@@ -329,8 +329,8 @@ class PhysicalModel(ParameterizedNode):
 
         seen_nodes = {}
         if self.background is not None:
-            self.background._sample_helper(graph_state, seen_nodes, rng_info, **kwargs)
-        self._sample_helper(graph_state, seen_nodes, rng_info, **kwargs)
+            self.background._sample_helper(graph_state, seen_nodes, rng_info=rng_info)
+        self._sample_helper(graph_state, seen_nodes, rng_info=rng_info)
 
         return graph_state
 

--- a/src/tdastro/sources/sncomso_models.py
+++ b/src/tdastro/sources/sncomso_models.py
@@ -115,7 +115,7 @@ class SncosmoWrapperModel(PhysicalModel, CiteClass):
                 self.source_param_names.append(key)
         self.source.set(**kwargs)
 
-    def _sample_helper(self, graph_state, seen_nodes, num_samples=1, rng_info=None):
+    def _sample_helper(self, graph_state, seen_nodes, rng_info=None):
         """Internal recursive function to sample the model's underlying parameters
         if they are provided by a function or ParameterizedNode.
 
@@ -141,7 +141,7 @@ class SncosmoWrapperModel(PhysicalModel, CiteClass):
         ------
         Raise a ValueError the sampling encounters a problem with the order of dependencies.
         """
-        super()._sample_helper(graph_state, seen_nodes, rng_info)
+        super()._sample_helper(graph_state, seen_nodes, rng_info=rng_info)
         self._update_sncosmo_model_parameters(graph_state)
 
     def mask_by_time(self, times, graph_state=None):


### PR DESCRIPTION
The `SncosmoWrapperModel` was not correctly passing along the random number generator because its version of `_sample_helper` had an extra (unused) argument and I was relying on ordering. This PR removes that argument and always passes the `rng_info` as an explicit keyword parameter.