### PR TITLE
Create a source model that mimics a lightcurve

### DIFF
--- a/docs/notebooks/lightcurve_source_demo.ipynb
+++ b/docs/notebooks/lightcurve_source_demo.ipynb
@@ -1,6 +1,20 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "id": "e5b7a501",
+   "metadata": {},
+   "source": [
+    "# LightcurveSource Demo\n",
+    "\n",
+    "The `LightcurveSource` model is designed to replicate given lightcurves in specific bands. It is specified as a separate lightcurve for each passband. The underlying model produces estimated SEDs at each time, so that all of TDAstro’s effects can be applied.\n",
+    "\n",
+    "In this notebook we provide an introductory demo to setting up and using the `LightcurveSource` model.\n",
+    "\n",
+    "## Setup"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "463f4ed7",
@@ -11,7 +25,8 @@
     "import numpy as np\n",
     "\n",
     "from tdastro.astro_utils.passbands import PassbandGroup\n",
-    "from tdastro.sources.lightcurve_source import LightcurveModel"
+    "from tdastro.consts import lsst_filter_plot_colors\n",
+    "from tdastro.sources.lightcurve_source import LightcurveSource"
    ]
   },
   {
@@ -45,9 +60,11 @@
    "id": "6b6db695",
    "metadata": {},
    "source": [
-    "Next we want to create light curves for this source in each of the bands. This is what we want the model to reproduce then we call get_band_fluxes().\n",
+    "## Creating the model\n",
     "\n",
-    "For simplicity of the demo, we create each curve as randomly parameterized sin waves."
+    "We create the model from lightcurves for each passbands of interest. This is what we want the model to reproduce then we call get_band_fluxes(). While these lightcurves do no need to be the same as in the `PassbandGroup` every lightcurve must have a corresponding entry in the `PassbandGroup`.\n",
+    "\n",
+    "For simplicity of the demo, we create each curve as a randomly parameterized sin wave.  Note that the times for all the lightcurves do not need to be the same."
    ]
   },
   {
@@ -68,7 +85,7 @@
     "    filter_flux = amp * np.sin(times + time_offset) + flux_offset\n",
     "    print(f\"Filter {filter}: {amp:.2f} * sin(t + {time_offset:.2f}) + {flux_offset:.2f}\")\n",
     "\n",
-    "    lightcurves[filter] = np.array([times, filter_flux]).T"
+    "    lightcurves[filter] = np.array([times + time_offset, filter_flux]).T"
    ]
   },
   {
@@ -79,20 +96,19 @@
    "outputs": [],
    "source": [
     "# Plot the lightcurves\n",
-    "filter_plot_colors = {\n",
-    "    \"LSST_u\": \"purple\",\n",
-    "    \"LSST_g\": \"blue\",\n",
-    "    \"LSST_r\": \"green\",\n",
-    "    \"LSST_i\": \"yellow\",\n",
-    "    \"LSST_z\": \"orange\",\n",
-    "    \"LSST_y\": \"red\",\n",
-    "}\n",
-    "\n",
     "figure = plt.figure()\n",
     "ax = figure.add_axes([0, 0, 1, 1])\n",
     "for filter, lightcurve in lightcurves.items():\n",
-    "    color = filter_plot_colors.get(filter, \"black\")\n",
+    "    color = lsst_filter_plot_colors.get(filter, \"black\")\n",
     "    ax.plot(lightcurve[:, 0], lightcurve[:, 1], color=color, label=filter)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "188eba77",
+   "metadata": {},
+   "source": [
+    "We then create the model from the dictionary of lightcurve information "
    ]
   },
   {
@@ -102,10 +118,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model = LightcurveModel(\n",
-    "    lightcurves,\n",
-    "    passband_group,\n",
-    ")"
+    "model = LightcurveSource(lightcurves, passband_group)"
    ]
   },
   {
@@ -142,6 +155,58 @@
    "outputs": [],
    "source": [
     "model.plot_sed_basis()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c21e6520",
+   "metadata": {},
+   "source": [
+    "## Generating Flux Densities\n",
+    "\n",
+    "We evaluate the `LightcurveSource` model the same way we evaltuate any `PhysicalModel` with functions such as `evaluate()`, `sample_parameters()`, and `get_band_fluxes()`. This model was specifically designed for the `get_band_fluxes()` function, so we explore that below.\n",
+    "\n",
+    "Let's model a sequence of observations in the g and r filters only."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9498659c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# The state is not used since we do not have any random parameters, but we need it for get_band_fluxes().\n",
+    "state = model.sample_parameters(num_samples=1)\n",
+    "\n",
+    "# Create query times over the middle of the range. Make 3/4 of them r and the rest g.\n",
+    "query_times = np.linspace(5, 15, 200)\n",
+    "query_filters = np.array([\"g\" if int(t) % 4 == 0 else \"r\" for t in query_times])\n",
+    "\n",
+    "# Get the fluxes for the query times and filters\n",
+    "flux = model.get_band_fluxes(passband_group, query_times, query_filters, state)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bf65595e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Plot the fluxes\n",
+    "figure = plt.figure()\n",
+    "ax = figure.add_axes([0, 0, 1, 1])\n",
+    "for filter in [\"g\", \"r\"]:\n",
+    "    mask = query_filters == filter\n",
+    "    color = lsst_filter_plot_colors.get(filter, \"black\")\n",
+    "    label = f\"Observation in {filter}\"\n",
+    "    ax.plot(query_times[mask], flux[mask], color=color, label=label, linewidth=0, marker=\".\")\n",
+    "\n",
+    "ax.set_xlabel(\"Time\")\n",
+    "ax.set_ylabel(\"Flux\")\n",
+    "ax.legend()\n",
+    "plt.show()"
    ]
   }
  ],

--- a/docs/notebooks/lightcurve_source_demo.ipynb
+++ b/docs/notebooks/lightcurve_source_demo.ipynb
@@ -1,0 +1,169 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "463f4ed7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "\n",
+    "from tdastro.astro_utils.passbands import PassbandGroup\n",
+    "from tdastro.sources.lightcurve_source import LightcurveModel"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d5098537",
+   "metadata": {},
+   "source": [
+    "We start be loading the passbands that we will use to define the model. In this case we use the passbands from the LSST preset."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "71aa0508",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "passband_group = PassbandGroup(preset=\"LSST\")\n",
+    "filters = passband_group.passbands.keys()\n",
+    "print(passband_group)\n",
+    "\n",
+    "wavelengths = passband_group.waves\n",
+    "min_wave, max_wave = passband_group.wave_bounds()\n",
+    "print(f\"Wavelengths range [{min_wave}, {max_wave}]\")\n",
+    "\n",
+    "passband_group.plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6b6db695",
+   "metadata": {},
+   "source": [
+    "Next we want to create light curves for this source in each of the bands. This is what we want the model to reproduce then we call get_band_fluxes().\n",
+    "\n",
+    "For simplicity of the demo, we create each curve as randomly parameterized sin waves."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "173d88fd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "num_times = 100\n",
+    "times = np.linspace(0, 20, num_times)\n",
+    "\n",
+    "lightcurves = {}\n",
+    "for filter in filters:\n",
+    "    amp = 5.0 * np.random.random() + 1.0\n",
+    "    flux_offset = np.random.random() * 25 + 10\n",
+    "    time_offset = np.random.random() * 10\n",
+    "    filter_flux = amp * np.sin(times + time_offset) + flux_offset\n",
+    "    print(f\"Filter {filter}: {amp:.2f} * sin(t + {time_offset:.2f}) + {flux_offset:.2f}\")\n",
+    "\n",
+    "    lightcurves[filter] = np.array([times, filter_flux]).T"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8bd002c7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Plot the lightcurves\n",
+    "filter_plot_colors = {\n",
+    "    \"LSST_u\": \"purple\",\n",
+    "    \"LSST_g\": \"blue\",\n",
+    "    \"LSST_r\": \"green\",\n",
+    "    \"LSST_i\": \"yellow\",\n",
+    "    \"LSST_z\": \"orange\",\n",
+    "    \"LSST_y\": \"red\",\n",
+    "}\n",
+    "\n",
+    "figure = plt.figure()\n",
+    "ax = figure.add_axes([0, 0, 1, 1])\n",
+    "for filter, lightcurve in lightcurves.items():\n",
+    "    color = filter_plot_colors.get(filter, \"black\")\n",
+    "    ax.plot(lightcurve[:, 0], lightcurve[:, 1], color=color, label=filter)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f81cfd42",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model = LightcurveModel(\n",
+    "    lightcurves,\n",
+    "    passband_group,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c2281f9e",
+   "metadata": {},
+   "source": [
+    "If we plot the underlying lightcurves we can see they matched the provided ones."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0c7e8516",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model.plot_lightcurves()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "91a6f52f",
+   "metadata": {},
+   "source": [
+    "We can also plot the SEDs for each filter to see how the underlying model is computing the total SED. Each passband's SED basis is multiplied by the corresponding lightcurve's values over time to give its contributions to the overall SED.  Note that, in order to avoid overcounting the contributions of some wavelengths, the SED basis functions only contain wavelengths where the filters do not overlap."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dcdf9745",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model.plot_sed_basis()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "tdastro",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/tdastro/astro_utils/passbands.py
+++ b/src/tdastro/astro_utils/passbands.py
@@ -10,21 +10,10 @@ from citation_compass import cite_function
 from sncosmo import Bandpass, get_bandpass
 
 from tdastro import _TDASTRO_BASE_DATA_DIR
+from tdastro.consts import lsst_filter_plot_colors
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(__name__)
-
-
-# Set default colors for plotting to match:
-# https://community.lsst.org/t/lsst-filter-profiles/1463
-_lsst_filter_plot_colors = {
-    "u": "purple",
-    "g": "blue",
-    "r": "green",
-    "i": "yellow",
-    "z": "orange",
-    "y": "red",
-}
 
 
 class PassbandGroup:
@@ -1019,7 +1008,7 @@ class Passband:
         # If the color is provided, we use that. Otherwise we try
         # the LSST filter colors (or default to black).
         if color is None:
-            color = _lsst_filter_plot_colors.get(self.filter_name, "black")
+            color = lsst_filter_plot_colors.get(self.filter_name, "black")
 
         ax.plot(
             self.processed_transmission_table[:, 0],  # X values are the wavelength

--- a/src/tdastro/consts.py
+++ b/src/tdastro/consts.py
@@ -2,6 +2,8 @@ import numpy as np
 from astropy import constants
 from astropy import units as u
 
+# Physics Constants --------------------------------------
+
 # Mass of the sun in grams
 M_SUN_G = constants.M_sun.cgs.value
 
@@ -31,3 +33,24 @@ ANGSTROM_TO_CM = (1.0 * u.AA).to_value(u.cm)
 
 CGS_FNU_UNIT_TO_NJY = (1.0 * u.erg / u.second / u.cm**2 / u.Hz).to_value(u.nJy)
 """Conversion factor from erg/s/cm²/Hz to nJy, 1e32"""
+
+
+# Plotting constants ----------------------------------------
+
+# Set default colors for plotting to match. We provide values for
+# the filters with and without the "LSST_" prefix.
+# https://community.lsst.org/t/lsst-filter-profiles/1463
+lsst_filter_plot_colors = {
+    "u": "purple",
+    "g": "blue",
+    "r": "green",
+    "i": "yellow",
+    "z": "orange",
+    "y": "red",
+    "LSST_u": "purple",
+    "LSST_g": "blue",
+    "LSST_r": "green",
+    "LSST_i": "yellow",
+    "LSST_z": "orange",
+    "LSST_y": "red",
+}

--- a/src/tdastro/sources/lightcurve_source.py
+++ b/src/tdastro/sources/lightcurve_source.py
@@ -9,7 +9,7 @@ from tdastro.consts import lsst_filter_plot_colors
 from tdastro.sources.physical_model import PhysicalModel
 
 
-class LightcurveModel(PhysicalModel):
+class LightcurveSource(PhysicalModel):
     """A model that generates the SED of a source from lightcurves in given bands.
     The model estimates a box-shaped SED for each filter such that the resulting
     flux density is equal to the lightcurve's value after passing through
@@ -188,7 +188,7 @@ class LightcurveModel(PhysicalModel):
 
             # The contribution of this filter to the overall SED is the lightcurve's (interpolated)
             # value at each time multiplied by the SED values at each query wavelength.
-            sed_flux = np.outer(sed_waves, sed_time_mult)
+            sed_flux = np.outer(sed_time_mult, sed_waves)
             flux_density += sed_flux
 
         # Return the total flux density from all lightcurves.

--- a/src/tdastro/sources/lightcurve_source.py
+++ b/src/tdastro/sources/lightcurve_source.py
@@ -1,0 +1,262 @@
+"""A model that generates the SED of a source based on the lightcurves of fluxes
+in each band."""
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from tdastro.astro_utils.passbands import Passband, PassbandGroup
+from tdastro.consts import lsst_filter_plot_colors
+from tdastro.sources.physical_model import PhysicalModel
+
+
+class LightcurveModel(PhysicalModel):
+    """A model that generates the SED of a source from lightcurves in given bands.
+    The model estimates a box-shaped SED for each filter such that the resulting
+    flux density is equal to the lightcurve's value after passing through
+    the passband filter.
+
+    The set of passbands used to configure the model MUST be the same as used
+    to generate the SED (the wavelengths must match).
+
+    Parameterized values include:
+      * dec - The object's declination in degrees.
+      * ra - The object's right ascension in degrees.
+      * t0 - The t0 of the zero phase (if applicable), date.
+
+    Attributes
+    ----------
+    lightcurves : dict
+        A dictionary mapping filters to a 2d array representing the lightcurve
+        of the object. The first dimension is time and the second dimension
+        is the flux density in nJy.  An optional third dimension can be used to
+        represent the flux density error in nJy.
+    sed_values : dict
+        A dictionary mapping filters to the fake SED values for that passband.
+        These SED values are scaled by the lightcurve and added for the
+        final SED.
+    all_waves : numpy.ndarray
+        A 1d array of all of the wavelengths used by the passband group.
+
+    Parameters
+    ----------
+    lightcurves : dict
+        A dictionary mapping filters to a 2d array representing the lightcurve
+        of the object. The first dimension is time and the second dimension
+        is the flux density in nJy.  An optional third dimension can be used to
+        represent the flux density error in nJy.
+    passbands : Passband or PassbandGroup
+        The passband or passband group to use for defining the lightcurve.
+    """
+
+    def __init__(
+        self,
+        lightcurves,
+        passbands,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+
+        # Convert a single passband to a PassbandGroup.
+        if isinstance(passbands, Passband):
+            passbands = PassbandGroup(given_passbands=[passbands])
+
+        # Validate the lightcurves and confirm that we have the correct passband in the group.
+        for filter, data in lightcurves.items():
+            if filter not in passbands:
+                raise ValueError(f"Lightcurve {filter} does not match any passband in the group.")
+            if len(data.shape) != 2:
+                raise ValueError(f"Lightcurve {filter} must be a 2D array.")
+            if data.shape[1] != 2 and data.shape[1] != 3:
+                raise ValueError(f"Lightcurve {filter} must have either 2 or 3 columns.")
+        self.lightcurves = lightcurves
+
+        # Store the wavelengths information and lightcurves for each filter.
+        self.all_waves = passbands.waves
+        self.sed_values = self._create_sed_basis(list(lightcurves.keys()), passbands)
+
+        # Override some of the defaults of PhysicalModel. Never apply redshift and
+        # do not allow brackground models.
+        self.apply_redshift = False
+        if "background" in kwargs:
+            raise ValueError("Lightcurve models do not support background models.")
+        self.background = None
+
+    def _create_sed_basis(self, filters, passbands):
+        """Create the SED basis functions. For each passband this creates a box shaped SED
+        that does not overlap with any other passband. The height of the SED is normalized
+        such that the total flux density will be 1.0 after passing through the passband.
+
+        Parameters
+        ----------
+        filters : list
+            A list of filters to use for the model.
+        passbands : PassbandGroup
+            The passband group to use for defining the lightcurve.
+
+        Returns
+        -------
+        sed_values : dict
+            A dictionary mapping the filter names to the SED values over all wavelengths.
+        """
+        # Mark which wavelengths are used by each passband.
+        filter_uses_wave = np.zeros((len(filters), len(passbands.waves)))
+        for idx, filter in enumerate(filters):
+            # Get all of the wavelengths that have a non-negligible transmission value
+            # for this filter and find their indices in the passband group.
+            is_significant = passbands[filter].processed_transmission_table[:, 1] > 0.001
+            significant_waves = passbands[filter].waves[is_significant]
+            indices = np.searchsorted(passbands.waves, significant_waves)
+
+            # Mark all non-negligible wavelengths as used by this filter.
+            filter_uses_wave[idx, indices] = 1.0
+
+        # Find which wavelenfths are used by multiple filters.
+        filter_counts = np.sum(filter_uses_wave, axis=0)
+
+        # Create the sed values for each wavelength.
+        sed_values = {}
+        for idx, filter in enumerate(filters):
+            # Get the wavelengths that are used by ONLY this filter.
+            valid_waves = (filter_uses_wave[idx, :] == 1) & (filter_counts == 1)
+            if np.sum(valid_waves) == 0:
+                raise ValueError(
+                    f"Passband {filter} has no valid wavelengths where it: a) has a non-negligible "
+                    "transmission value (>0.001) and b) does not overlap with another passband."
+                )
+
+            # Compute how much flux is passed through these wavelengths of this filter
+            # and use this to normalize the sed values.
+            filter_sed = np.zeros((1, len(passbands.waves)))
+            filter_sed[0, valid_waves] = 1.0
+
+            total_flux = passbands.fluxes_to_bandflux(filter_sed, filter)
+            if total_flux[0] <= 0:
+                raise ValueError(f"Total flux for filter {filter} is {total_flux[0]}.")
+            sed_values[filter] = filter_sed[0, :] / total_flux[0]
+
+        return sed_values
+
+    def set_apply_redshift(self, apply_redshift):
+        """Toggles the apply_redshift setting.
+
+        Parameters
+        ----------
+        apply_redshift : bool
+            The new value for apply_redshift.
+        """
+        raise NotImplementedError("Lightcurve models do not support apply_redshift.")
+
+    def compute_flux(self, times, wavelengths, graph_state):
+        """Draw effect-free rest frame flux densities.
+        The rest-frame flux is defined as F_nu = L_nu / 4*pi*D_L**2,
+        where D_L is the luminosity distance.
+
+        Parameters
+        ----------
+        times : numpy.ndarray
+            A length T array of rest frame timestamps in MJD.
+        wavelengths : numpy.ndarray, optional
+            A length N array of rest frame wavelengths (in angstroms).
+        graph_state : GraphState
+            An object mapping graph parameters to their values.
+
+        Returns
+        -------
+        flux_density : numpy.ndarray
+            A length T x N matrix of rest frame SED values (in nJy).
+        """
+        flux_density = np.zeros((len(times), len(wavelengths)))
+
+        for filter, lightcurve in self.lightcurves.items():
+            # Compute the SED values for the wavelengths we are actually sampling.
+            sed_waves = np.interp(
+                wavelengths,  # The query wavelengths
+                self.all_waves,  # All of the passband group's wavelengths
+                self.sed_values[filter],  # The SED values at each of the passband group's wavelengths
+                left=0.0,  # Do not extrapolate in wavelength
+                right=0.0,  # Do not extrapolate in wavelength
+            )
+
+            # Compute the multipliers for the SEDs at different time steps along this lightcurve.
+            sed_time_mult = np.interp(
+                times,  # The query times
+                lightcurve[:, 0],  # The lightcurve times for this passband filter
+                lightcurve[:, 1],  # The lightcurve flux densities for this passband filter
+                left=0.0,  # Do not extrapolate in time
+                right=0.0,  # Do not extrapolate in time
+            )
+
+            # The contribution of this filter to the overall SED is the lightcurve's (interpolated)
+            # value at each time multiplied by the SED values at each query wavelength.
+            sed_flux = np.outer(sed_waves, sed_time_mult)
+            flux_density += sed_flux
+
+        # Return the total flux density from all lightcurves.
+        return flux_density
+
+    def plot_sed_basis(self, ax=None, figure=None):
+        """Plot the basis functions for the SED.  This is a debugging
+        function to help the user understand the SEDs produced by this
+        model.
+
+        Parameters
+        ----------
+        ax : matplotlib.pyplot.Axes or None, optional
+            Axes, None by default.
+        figure : matplotlib.pyplot.Figure or None
+            Figure, None by default.
+        """
+        if ax is None:
+            if figure is None:
+                figure = plt.figure()
+            ax = figure.add_axes([0, 0, 1, 1])
+
+        # Plot each passband.
+        for filter_name, filter_curve in self.sed_values.items():
+            color = lsst_filter_plot_colors.get(filter_name, "black")
+            ax.plot(self.all_waves, filter_curve, color=color, label=filter_name)
+
+        # Set the x and y axis labels.
+        ax.set_xlabel("Wavelength (Angstroms)")
+        ax.set_ylabel("SED (nJy)")
+        ax.set_title("SED Basis Functions")
+        ax.legend()
+
+    def plot_lightcurves(self, times=None, ax=None, figure=None):
+        """Plot the underlying lightcurves. This is a debugging
+        function to help the user understand the SEDs produced by this
+        model.
+
+        Parameters
+        ----------
+        times : numpy.ndarray or None, optional
+            An array of timestamps at which to plot the lightcurves.
+            If None, the function uses the timestamps from each lightcurves.
+        ax : matplotlib.pyplot.Axes or None, optional
+            Axes, None by default.
+        figure : matplotlib.pyplot.Figure or None
+            Figure, None by default.
+        """
+        if ax is None:
+            if figure is None:
+                figure = plt.figure()
+            ax = figure.add_axes([0, 0, 1, 1])
+
+        # Plot each passband.
+        for filter_name, filter_curve in self.lightcurves.items():
+            # Check if we need to use the query times.
+            if times is None:
+                plot_times = filter_curve[:, 0]
+                plot_values = filter_curve[:, 1]
+            else:
+                plot_times = times
+                plot_values = np.interp(times, filter_curve[:, 0], filter_curve[:, 1], left=0.0, right=0.0)
+
+            color = lsst_filter_plot_colors.get(filter_name, "black")
+            ax.plot(plot_times, plot_values, color=color, label=filter_name)
+
+        # Set the x and y axis labels.
+        ax.set_xlabel("Time (days)")
+        ax.set_ylabel("Filter value (nJy)")
+        ax.set_title("Lightcurve Source Underlying Lightcurves")
+        ax.legend()

--- a/tests/tdastro/sources/test_lightcurve_source.py
+++ b/tests/tdastro/sources/test_lightcurve_source.py
@@ -1,0 +1,134 @@
+import numpy as np
+import pytest
+from tdastro.astro_utils.passbands import Passband, PassbandGroup
+from tdastro.sources.lightcurve_source import LightcurveSource
+
+
+def _create_toy_passbands() -> PassbandGroup:
+    """Create a toy passband group with three passbands where the first passband
+    has no overlap while the second two overlap each other for half the range.
+    """
+    a_band = Passband(np.array([[400, 0.5], [500, 0.5], [600, 0.5]]), "LSST", "u")
+    b_band = Passband(np.array([[800, 0.8], [900, 0.8], [1000, 0.8]]), "LSST", "g")
+    c_band = Passband(np.array([[900, 0.6], [1000, 0.6], [1100, 0.6]]), "LSST", "r")
+    return PassbandGroup(given_passbands=[a_band, b_band, c_band])
+
+
+def _create_toy_lightcurves() -> dict:
+    """Create toy lightcurves where the first two are constant and the third
+    is linearly increasing.  Each lightcurve covers a slightly different
+    time range.
+    """
+    times = np.linspace(1, 11, 100)
+    lightcurves = {
+        "u": np.array([times - 0.2, 2.0 * np.ones_like(times)]).T,
+        "g": np.array([times - 0.1, 3.0 * np.ones_like(times)]).T,
+        "r": np.array([times, 0.1 * times + 1.0]).T,
+    }
+    return lightcurves
+
+
+def test_create_lightcurve_source() -> None:
+    """Test that we can create a simple LightcurveSource object."""
+    pb_group = _create_toy_passbands()
+    lightcurves = _create_toy_lightcurves()
+    lc_source = LightcurveSource(lightcurves, pb_group)
+
+    # Check the internal structure of the LightCurveSource.
+    assert len(lc_source.lightcurves) == 3
+    assert len(lc_source.sed_values) == 3
+    assert np.allclose(lc_source.all_waves, pb_group.waves)
+
+    filters = list(lc_source.lightcurves.keys())
+    assert filters == ["u", "g", "r"]
+
+    # Check that no two SED basis functions overlap.
+    for f1 in filters:
+        for f2 in filters:
+            if f1 != f2:
+                assert np.count_nonzero(lc_source.sed_values[f1] * lc_source.sed_values[f2]) == 0
+
+    # A call to get_band_fluxes should return the desired lightcurves.  We only use two of the passbands.
+    graph_state = lc_source.sample_parameters(num_samples=1)  # dummy. unused.
+    query_times = np.array([0.0, 0.5, 1.0, 2.0, 3.0, 4.0, 20.0, 21.0])
+    query_filters = np.array(["u", "r", "u", "r", "u", "r", "u", "r"])
+    fluxes = lc_source.get_band_fluxes(pb_group, query_times, query_filters, graph_state)
+    assert len(fluxes) == len(query_times)
+
+    # Timesteps 0.0, 0.5, 20.0, and 21.0 fall outside the range of the model and are set to 0.0.
+    # Timesteps 1.0 and 3.0 are from the y band which is constant at 2.
+    # Timesteps 2.0 and 4.0 are from the r band which is linearly increasing with time.
+    assert np.allclose(fluxes, [0.0, 0.0, 2.0, 1.2, 2.0, 1.4, 0.0, 0.0])
+
+
+def test_lightcurve_source_nonoverlap() -> None:
+    """Test that we can query the LightcurveSource with wavelengths that
+    do not overlap the lightcurves.
+    """
+    pb_group = _create_toy_passbands()
+    lightcurves = _create_toy_lightcurves()
+    del lightcurves["u"]  # Remove the u band lightcurve.
+
+    lc_source = LightcurveSource(lightcurves, pb_group)
+    assert len(lc_source.lightcurves) == 2
+    assert len(lc_source.sed_values) == 2
+    assert np.allclose(lc_source.all_waves, pb_group.waves)
+
+    filters = list(lc_source.lightcurves.keys())
+    assert filters == ["g", "r"]
+
+    # A call to get_band_fluxes should return the desired lightcurves.  We query
+    # u and g bands. Since u is not present, we should get zeros at those times.
+    graph_state = lc_source.sample_parameters(num_samples=1)  # dummy. unused.
+    query_times = np.array([0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+    query_filters = np.array(["g", "u", "g", "u", "g", "u", "g"])
+    fluxes = lc_source.get_band_fluxes(pb_group, query_times, query_filters, graph_state)
+    assert len(fluxes) == len(query_times)
+
+    assert np.allclose(fluxes, [0.0, 0.0, 3.0, 0.0, 3.0, 0.0, 3.0])
+
+
+def test_create_lightcurve_source_fail() -> None:
+    """Test fail cases for creating the LightCurveSource object."""
+    a_band = Passband(np.array([[400, 0.5], [500, 0.5], [600, 0.5]]), "LSST", "u")
+    b_band = Passband(np.array([[800, 0.8], [900, 0.8], [1000, 0.8]]), "LSST", "g")
+    c_band = Passband(np.array([[900, 0.6], [1000, 0.6], [1100, 0.6]]), "LSST", "r")
+    pb_group = PassbandGroup(given_passbands=[a_band, b_band, c_band])
+
+    times = np.linspace(0, 10, 100)
+    lightcurves = {
+        "u": np.array([times, 2.0 * np.ones_like(times)]).T,
+        "g": np.array([times, 3.0 * np.ones_like(times)]).T,
+        "r": np.array([times, 4.0 * np.ones_like(times)]).T,
+        "i": np.array([times, 0.1 * times + 1.0]).T,
+    }
+
+    # Fail on mismatched passbands.
+    with pytest.raises(ValueError):
+        _ = LightcurveSource(lightcurves, pb_group)
+
+    # Remove the offending passband and try again.
+    del lightcurves["i"]
+    _ = LightcurveSource(lightcurves, pb_group)
+
+    # Make one of the lightcurves the wrong shape.
+    lightcurves["u"] = times.T
+    with pytest.raises(ValueError):
+        _ = LightcurveSource(lightcurves, pb_group)
+    lightcurves["u"] = np.array([times, 2.0 * np.ones_like(times)]).T
+
+    # We fail if two passbands overlap other passbands completely.
+    d_band = Passband(np.array([[850, 0.6], [1050, 0.6]]), "LSST", "i")
+    pb_group = PassbandGroup(given_passbands=[a_band, b_band, c_band, d_band])
+    lightcurves["i"] = np.array([times, 0.1 * times + 1.0]).T
+    with pytest.raises(ValueError):
+        _ = LightcurveSource(lightcurves, pb_group)
+
+
+def test_lightcurve_plot() -> None:
+    """Test that the plotting functions do not crash."""
+    pb_group = _create_toy_passbands()
+    lightcurves = _create_toy_lightcurves()
+    lc_source = LightcurveSource(lightcurves, pb_group)
+    lc_source.plot_lightcurves()
+    lc_source.plot_sed_basis()


### PR DESCRIPTION
closes #282 

Creates a new `LightcurveSource` that converts per-band lightcurves into an SED model. Operations are done at the SED level, which is more expensive, but allows TDAstro to use all the effect infrastructure as-is.