### PR TITLE
Upgrade to numpy 2.0

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -19,6 +19,6 @@ project_license: MIT
 project_name: tdastro
 project_organization: lincc-frameworks
 python_versions:
-- '3.9'
 - '3.10'
 - '3.11'
+- '3.12'

--- a/.github/workflows/asv-main.yml
+++ b/.github/workflows/asv-main.yml
@@ -8,7 +8,7 @@ on:
     branches: [ main ]
 
 env:
-  PYTHON_VERSION: "3.10"
+  PYTHON_VERSION: "3.11"
   ASV_VERSION: "0.6.4"
   WORKING_DIR: ${{github.workspace}}/benchmarks
 

--- a/.github/workflows/asv-nightly.yml
+++ b/.github/workflows/asv-nightly.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
   
 env:
-  PYTHON_VERSION: "3.10"
+  PYTHON_VERSION: "3.11"
   ASV_VERSION: "0.6.4"
   WORKING_DIR: ${{github.workspace}}/benchmarks
   NIGHTLY_HASH_FILE: nightly-hash

--- a/.github/workflows/asv-pr.yml
+++ b/.github/workflows/asv-pr.yml
@@ -15,7 +15,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  PYTHON_VERSION: "3.10"
+  PYTHON_VERSION: "3.11"
   ASV_VERSION: "0.6.4"
   WORKING_DIR: ${{github.workspace}}/benchmarks
   ARTIFACTS_DIR: ${{github.workspace}}/artifacts

--- a/.github/workflows/build-documentation.yml
+++ b/.github/workflows/build-documentation.yml
@@ -21,10 +21,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.10
+    - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
+        python-version: '3.11'
     - name: Install dependencies
       run: |
         sudo apt-get update

--- a/.github/workflows/pre-commit-ci.yml
+++ b/.github/workflows/pre-commit-ci.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
+        python-version: '3.11'
     - name: Install dependencies
       run: |
         sudo apt-get update

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
+        python-version: '3.11'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.10', '3.11', '3.12']
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/testing-and-coverage.yml
+++ b/.github/workflows/testing-and-coverage.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.10', '3.11', '3.12']
 
     steps:
     - uses: actions/checkout@v4

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.10"
+    python: "3.11"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -36,7 +36,7 @@
     // The Pythons you'd like to test against. If not provided, defaults
     // to the current version of Python used to run `asv`.
     "pythons": [
-        "3.10"
+        "3.11"
     ],
     // The matrix of dependencies to test. Each key is the name of a
     // package (in PyPI) and the values are version numbers.  An empty

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,7 +20,8 @@ time-domain simulation software with realistic effects and survey strategies.
    :align: center
    :alt: TDAstro simulation components
 
-   TDAstro simulation components
+   >> conda create env -n <env_name> python=3.11
+   >> conda activate <env_name>
 
 The main simulation components in TDAstro include:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,8 +20,6 @@ time-domain simulation software with realistic effects and survey strategies.
    :align: center
    :alt: TDAstro simulation components
 
-   >> conda create env -n <env_name> python=3.11
-   >> conda activate <env_name>
 
 The main simulation components in TDAstro include:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,11 +21,12 @@ dependencies = [
     "cdshealpix",
     "citation-compass>=0.0.3",
     "dust_extinction",
+    "extinction>=0.4.7",  # Needed by sncosmo
     "healsparse",
     "jax",
     "matplotlib",
     "nested-pandas",
-    "numpy",
+    "numpy>2.0",
     "pandas",
     "pooch",
     "pzflow",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
     "Programming Language :: Python",
 ]
 dynamic = ["version"]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "astropy",
     "cdshealpix",
@@ -67,7 +67,7 @@ testpaths = [
 
 [tool.black]
 line-length = 110
-target-version = ["py39"]
+target-version = ["py310"]
 
 [tool.isort]
 profile = "black"
@@ -75,7 +75,7 @@ line_length = 110
 
 [tool.ruff]
 line-length = 110
-target-version = "py39"
+target-version = "py310"
 
 [tool.ruff.lint]
 select = [

--- a/src/tdastro/opsim/opsim.py
+++ b/src/tdastro/opsim/opsim.py
@@ -489,7 +489,7 @@ class OpSim:
         nside_coverage = 64
 
         view_maps = []
-        for ra, dec in zip(self.table[self.colmap["ra"]], self.table[self.colmap["dec"]]):
+        for ra, dec in zip(self.table[self.colmap["ra"]], self.table[self.colmap["dec"]], strict=False):
             circ = hsp.Circle(ra=ra, dec=dec, radius=radius, value=True)
 
             # Generating a map to union is more expensive than `cov_map |= circ`

--- a/tests/tdastro/astro_utils/test_passbands.py
+++ b/tests/tdastro/astro_utils/test_passbands.py
@@ -358,8 +358,8 @@ def test_trim_transmission_table(passbands_dir, tmp_path):
     table = c_band._trim_transmission_by_quantile(c_band._loaded_table, trim_quantile=0.05)
     assert len(table) < len(c_band._loaded_table)
 
-    original_area = np.trapz(c_band._loaded_table[:, 1], x=c_band._loaded_table[:, 0])
-    trimmed_area = np.trapz(table[:, 1], x=table[:, 0])
+    original_area = np.trapezoid(c_band._loaded_table[:, 1], x=c_band._loaded_table[:, 0])
+    trimmed_area = np.trapezoid(table[:, 1], x=table[:, 0])
     assert trimmed_area >= (original_area * 0.9)
 
     # Test 4: LSST transmission table
@@ -367,8 +367,8 @@ def test_trim_transmission_table(passbands_dir, tmp_path):
     table = LSST_z._trim_transmission_by_quantile(LSST_z._loaded_table, trim_quantile=0.05)
     assert len(table) < len(LSST_z._loaded_table)
 
-    original_area = np.trapz(LSST_z._loaded_table[:, 1], x=LSST_z._loaded_table[:, 0])
-    trimmed_area = np.trapz(table[:, 1], x=table[:, 0])
+    original_area = np.trapezoid(LSST_z._loaded_table[:, 1], x=LSST_z._loaded_table[:, 0])
+    trimmed_area = np.trapezoid(table[:, 1], x=table[:, 0])
     assert trimmed_area >= (original_area * 0.9)
 
 
@@ -417,7 +417,7 @@ def test_passband_fluxes_to_bandflux(passbands_dir, tmp_path):
             [1.0, 1.0, 1.0],
         ]
     )
-    expected_in_band_flux = np.trapz(flux * a_band.processed_transmission_table[:, 1], x=a_band.waves)
+    expected_in_band_flux = np.trapezoid(flux * a_band.processed_transmission_table[:, 1], x=a_band.waves)
     in_band_flux = a_band.fluxes_to_bandflux(flux)
     np.testing.assert_allclose(in_band_flux, expected_in_band_flux)
 
@@ -435,7 +435,7 @@ def test_passband_fluxes_to_bandflux(passbands_dir, tmp_path):
         ]
     )
     in_band_flux = a_band.fluxes_to_bandflux(flux)
-    expected_in_band_flux = np.trapz(
+    expected_in_band_flux = np.trapezoid(
         flux * a_band.processed_transmission_table[:, 1], x=a_band.processed_transmission_table[:, 0]
     )
     np.testing.assert_allclose(in_band_flux, expected_in_band_flux)

--- a/tests/tdastro/astro_utils/test_passbands.py
+++ b/tests/tdastro/astro_utils/test_passbands.py
@@ -350,7 +350,10 @@ def test_trim_transmission_table(passbands_dir, tmp_path):
     transmissions = rng.normal(0.5, 0.1, 1000)
     wavelengths = np.arange(100, 1100, 1)
     transmission_table = "\n".join(
-        [f"{wavelength} {transmission}" for wavelength, transmission in zip(wavelengths, transmissions)]
+        [
+            f"{wavelength} {transmission}"
+            for wavelength, transmission in zip(wavelengths, transmissions, strict=False)
+        ]
     )
     c_band = create_toy_passband(tmp_path, transmission_table, filter_name="c")
 


### PR DESCRIPTION
Upgrade TDAstro to use numpy>2.0. This requires using >= 0.4.7 of the extinction package.

Also:
- changes `trapz` to `trapezoid` since `trapz` was recently deprecated in numpy.
- changes the test matrix to drop Python 3.9 and use Python 3.12