### PR TITLE
Replace PhysicalModel's background with MultiSourceModel

### DIFF
--- a/docs/notebooks/sampling.ipynb
+++ b/docs/notebooks/sampling.ipynb
@@ -446,6 +446,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "While we use a `BasicMathNode` to compute the combined brightness to illustrate chaining above, we would often prefer to use a `MultiSourceModel` to represent a combination of fluxes."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Conclusion\n",
     "\n",
     "TDAstro provides significant flexibility in how parameters can be defined, allowing a users to create complex statistical models. The specification is meant to be familiar to users of Python by using direct assignment (`argument=object`) for functions and the `.` notation (`argument=object.parameter`) for references parameters. Internally TDAstro manages the various references so that each new sample regenerates the instances of the all the parameters in the model in a statistically consistent way.\n",

--- a/docs/notebooks/technical_overview.ipynb
+++ b/docs/notebooks/technical_overview.ipynb
@@ -360,6 +360,98 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "The state is used within the `evaluate()` function to generate the flux densities."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "time = np.arange(0, 10, 0.1)\n",
+    "waves = np.array([1000.0, 2000.0])\n",
+    "fluxes = source.evaluate(time, waves, state)\n",
+    "print(f\"Generated {fluxes.shape} fluxes (samples x times x wavelengths).\")\n",
+    "\n",
+    "# Plot the the flux for sample=0 and wavelength=1000.0.\n",
+    "plt.plot(time, fluxes[0, :, 0], \"k-\")\n",
+    "plt.xlabel(\"Time (days)\")\n",
+    "plt.ylabel(\"Flux (nJy)\")\n",
+    "plt.title(\"Flux for sample=0 and wavelength=1000.0\")\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## MultiSourceModels\n",
+    "\n",
+    "We expect that many users will want to simulate fluxes produced by a combination of objects, such as a supernova and its host galaxy.  TDAstro provides the `MultiSourceModel` for computing such combinations. The flux produced by the model is the (weighted) sum of fluxes from the individual sources.\n",
+    "\n",
+    "Each source in the `MultiSourceModel` separately applies rest frame effects to its component flux. This allows users to model unresolved objects at different distances (with different redshifts or dust extinctions).  All observer frame effects are applied to the summed fluxes for consistency."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from tdastro.sources.basic_sources import SinWaveSource\n",
+    "from tdastro.sources.multi_source_model import MultiSourceModel\n",
+    "\n",
+    "# We model the host as a galaxy with a random brightness and position.\n",
+    "host = StaticSource(\n",
+    "    brightness=NumpyRandomFunc(\"normal\", loc=10.0, scale=1.0),\n",
+    "    ra=NumpyRandomFunc(\"uniform\", low=10.0, high=15.0),\n",
+    "    dec=NumpyRandomFunc(\"uniform\", low=-10.0, high=10.0),\n",
+    "    node_label=\"host\",\n",
+    ")\n",
+    "\n",
+    "# We model the source as a sine wave with a given frequency and amplitude.\n",
+    "source = SinWaveSource(\n",
+    "    brightness=1.0,\n",
+    "    frequency=0.5,\n",
+    "    ra=NumpyRandomFunc(\"normal\", loc=host.ra, scale=0.1),\n",
+    "    dec=NumpyRandomFunc(\"normal\", loc=host.dec, scale=0.1),\n",
+    "    t0=0.0,\n",
+    "    node_label=\"sin_wave_source\",\n",
+    ")\n",
+    "\n",
+    "# We combine the host and source into a multi-source model and sample it.\n",
+    "combined = MultiSourceModel(\n",
+    "    sources=[host, source],\n",
+    "    node_label=\"combined_model\",\n",
+    ")\n",
+    "state = combined.sample_parameters(num_samples=1)\n",
+    "print(state)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Evaluate and generate the fluxes from the combined model for a\n",
+    "# single wavelength parameter sample.\n",
+    "time = np.arange(0, 10, 0.1)\n",
+    "fluxes = combined.evaluate(time, np.array([1000.0]), state)\n",
+    "\n",
+    "# Plot the the flux for sample=0 and wavelength=1000.0.\n",
+    "plt.plot(time, fluxes[:, 0], \"k-\")\n",
+    "plt.xlabel(\"Time (days)\")\n",
+    "plt.ylabel(\"Flux (nJy)\")\n",
+    "plt.title(\"Flux for combined model\")\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## pzflow\n",
     "\n",
     "We can use the `pzflow` package to generate data from joint distributions that have been learned from real data. Sampling with `pzflow` creates Pandas tables of values. We can access each column using the same `.` notation as above, allowing us to use a consistent set of values from multiple variables.\n",
@@ -412,7 +504,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "tdenv",
+   "display_name": "tdastro",
    "language": "python",
    "name": "python3"
   },
@@ -426,7 +518,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.16"
+   "version": "3.10.4"
   }
  },
  "nbformat": 4,

--- a/src/tdastro/effects/basic_effects.py
+++ b/src/tdastro/effects/basic_effects.py
@@ -1,0 +1,60 @@
+"""A collection of toy effect models that are primarily used for testing."""
+
+from tdastro.effects.effect_model import EffectModel
+
+
+class ConstantDimming(EffectModel):
+    """An effect that dims by a constant amount. Primarily used for testing.
+
+    Attributes
+    ----------
+    flux_fraction : parameter
+        The fraction of flux that is passed through.
+    rest_frame : bool
+        Whether the effect is applied in the rest frame of the observation (True)
+        or in the observed frame (False).
+    """
+
+    def __init__(self, flux_fraction, rest_frame=True, **kwargs):
+        super().__init__(**kwargs)
+        self.add_effect_parameter("flux_fraction", flux_fraction)
+
+        # Override the default rest_frame parameter.
+        self.rest_frame = rest_frame
+
+    def apply(
+        self,
+        flux_density,
+        times=None,
+        wavelengths=None,
+        flux_fraction=None,
+        rng_info=None,
+        **kwargs,
+    ):
+        """Apply the effect to observations (flux_density values).
+
+        Parameters
+        ----------
+        flux_density : numpy.ndarray
+            A length T X N matrix of flux density values (in nJy).
+        times : numpy.ndarray, optional
+            A length T array of times (in MJD). Not used for this effect.
+        wavelengths : numpy.ndarray, optional
+            A length N array of wavelengths (in angstroms). Not used for this effect.
+        flux_fraction : float, optional
+            The fraction of flux that is passed through. Raises an error if None is provided.
+        rng_info : numpy.random._generator.Generator, optional
+            A given numpy random number generator to use for this computation. If not
+            provided, the function uses the node's random number generator.
+        **kwargs : `dict`, optional
+           Any additional keyword arguments. This includes all of the
+           parameters needed to apply the effect.
+
+        Returns
+        -------
+        flux_density : numpy.ndarray
+            A length T x N matrix of flux densities after the effect is applied (in nJy).
+        """
+        if flux_fraction is None:
+            raise ValueError("flux_fraction must be provided")
+        return flux_density * flux_fraction

--- a/src/tdastro/sources/multi_source_model.py
+++ b/src/tdastro/sources/multi_source_model.py
@@ -16,6 +16,9 @@ class MultiSourceModel(PhysicalModel):
     for each source (for unresolved sources).  The observer frame effects are applied
     to the weighted sum of the sources.
 
+    Note: Each source may have its own sampled (RA, dec) position, which are not
+    required to align.
+
     Attributes
     ----------
     sources : list

--- a/src/tdastro/sources/multi_source_model.py
+++ b/src/tdastro/sources/multi_source_model.py
@@ -1,0 +1,200 @@
+"""The MultiSourceModel provides a wrapper to combine multiple
+PhysicalModels into a single model.
+"""
+
+import numpy as np
+
+from tdastro.graph_state import GraphState
+from tdastro.sources.physical_model import PhysicalModel
+
+
+class MultiSourceModel(PhysicalModel):
+    """A MultiSourceModel computes the flux from multiple overlapping objects,
+    including (host, source pairs) or unresolved sources.
+
+    All rest frame effects are applied to each source, allowing different redshifts
+    for each source (for unresolved sources).  The observer frame effects are applied
+    to the weighted sum of the sources.
+
+    Attributes
+    ----------
+    sources : list
+        A list of PhysicalModel objects to use in the flux calculation.
+    weights : numpy.ndarray, optional
+        A length N array of weights to apply to each source. If None, all sources
+        will be weighted equally.
+
+    Parameters
+    ----------
+    sources : list
+        A list of PhysicalModel objects to use in the flux calculation.
+    weights : numpy.ndarray, optional
+        A length N array of weights to apply to each source. If None, all sources
+        will be weighted equally.
+    **kwargs : dict, optional
+        Any additional keyword arguments.
+    """
+
+    def __init__(
+        self,
+        sources,
+        weights=None,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+
+        # Check that all sources are PhysicalModel objects and they do not contain
+        # observer frame effects.
+        for source in sources:
+            if not isinstance(source, PhysicalModel):
+                raise ValueError("All sources must be PhysicalModel objects.")
+            if len(source.obs_frame_effects) > 0:
+                raise ValueError("The MultiSourceModel cannot contain sources with observer frame effects.")
+        self.sources = sources
+
+        if weights is None:
+            self.weights = np.full(len(sources), 1.0)
+        elif len(weights) != len(sources):
+            raise ValueError("Length of weights must match length of sources.")
+        else:
+            self.weights = weights
+
+    def set_graph_positions(self, seen_nodes=None):
+        """Force an update of the graph structure (numbering of each node).
+
+        Parameters
+        ----------
+        seen_nodes : set, optional
+            A set of nodes that have already been processed to prevent infinite loops.
+            Caller should not set.
+        """
+        if seen_nodes is None:
+            seen_nodes = set()
+
+        # Set the graph positions for this node and each source.
+        super().set_graph_positions(seen_nodes=seen_nodes)
+        for source in self.sources:
+            source.set_graph_positions(seen_nodes=seen_nodes)
+
+    def set_apply_redshift(self, apply_redshift):
+        """Toggles the apply_redshift setting.
+
+        Parameters
+        ----------
+        apply_redshift : bool
+            The new value for apply_redshift.
+        """
+        for source in self.sources:
+            source.set_apply_redshift(apply_redshift)
+
+    def add_effect(self, effect):
+        """Add an effect to the model.  Rest frame effects are applied to each source
+        and observer frame effects are stored in this model.
+
+        Parameters
+        ----------
+        effect : Effect
+            The effect to add to the model.
+        """
+        if effect.rest_frame:
+            # The rest frame effects are applied to each source.
+            for source in self.sources:
+                source.add_effect(effect)
+        else:
+            # Add observer frame effects to this model.
+            # Add any effect parameters that are not already in the model.
+            for param_name, setter in effect.parameters.items():
+                if param_name not in self.setters:
+                    self.add_parameter(param_name, setter, allow_gradient=False)
+            self.obs_frame_effects.append(effect)
+
+    def sample_parameters(self, given_args=None, num_samples=1, rng_info=None):
+        """Sample the model's underlying parameters if they are provided by a function
+        or ParameterizedModel.
+
+        Parameters
+        ----------
+        given_args : dict, optional
+            A dictionary representing the given arguments for this sample run.
+            This can be used as the JAX PyTree for differentiation.
+        num_samples : int
+            A count of the number of samples to compute.
+            Default: 1
+        rng_info : numpy.random._generator.Generator, optional
+            A given numpy random number generator to use for this computation. If not
+            provided, the function uses the node's random number generator.
+        **kwargs : dict, optional
+            All the keyword arguments, including the values needed to sample
+            parameters.
+
+        Returns
+        -------
+        graph_state : GraphState
+            An object mapping graph parameters to their values.
+        """
+        # If the graph has not been sampled ever, update the node positions for
+        # every node (model, background, effects).
+        if self.node_pos is None:
+            self.set_graph_positions()
+
+        # We use the same seen_nodes for all sampling calls so each node
+        # is sampled at most one time regardless of link structure.
+        graph_state = GraphState(num_samples)
+        if given_args is not None:
+            graph_state.update(given_args, all_fixed=True)
+
+        seen_nodes = {}
+        for source in self.sources:
+            source._sample_helper(graph_state, seen_nodes, rng_info=rng_info)
+        self._sample_helper(graph_state, seen_nodes, rng_info=rng_info)
+
+        return graph_state
+
+    def _evaluate_single(self, times, wavelengths, state, rng_info=None, **kwargs):
+        """Evaluate the model and apply the effects for a single, given graph state.
+        This function applies redshift, computes the flux density for the object,
+        applies rest frames effects, performs the redshift correction (if needed),
+        and applies the observer frame effects.
+
+        Parameters
+        ----------
+        times : numpy.ndarray
+            A length T array of observer frame timestamps in MJD.
+        wavelengths : numpy.ndarray
+            A length N array of wavelengths (in angstroms).
+        state : GraphState
+            An object mapping graph parameters to their values with num_samples=1.
+        rng_info : numpy.random._generator.Generator, optional
+            A given numpy random number generator to use for this computation. If not
+            provided, the function uses the node's random number generator.
+        **kwargs : dict, optional
+            All the other keyword arguments.
+
+        Returns
+        -------
+        flux_density : numpy.ndarray
+            A length T x N matrix of SED values (in nJy).
+        """
+        # Compute the weighted sum of contributions from each source.
+        flux_density = np.zeros((len(times), len(wavelengths)))
+        for source, weight in zip(self.sources, self.weights, strict=False):
+            flux_density += weight * source._evaluate_single(
+                times,
+                wavelengths,
+                state,
+                rng_info=rng_info,
+                **kwargs,
+            )
+
+        # Apply the observer frame effects on the weighted sum of sources.
+        params = self.get_local_params(state)
+        for effect in self.obs_frame_effects:
+            flux_density = effect.apply(
+                flux_density,
+                times=times,
+                wavelengths=wavelengths,
+                rng_info=rng_info,
+                **params,
+            )
+
+        return flux_density

--- a/src/tdastro/sources/physical_model.py
+++ b/src/tdastro/sources/physical_model.py
@@ -17,10 +17,6 @@ class PhysicalModel(ParameterizedNode):
     a setter function to change them) and settable model parameters that can be passed functions
     or constants and are stored in the graph's (external) graph_state dictionary.
 
-    Physical models can also have special background pointers that link to another PhysicalModel
-    producing flux density. We can chain these to have a supernova in front of a star in front
-    of a static background.
-
     Physical models also support adding and applying a variety of effects, such as redshift.
 
     Parameterized values include:
@@ -32,8 +28,6 @@ class PhysicalModel(ParameterizedNode):
 
     Attributes
     ----------
-    background : PhysicalModel
-        A source of background flux such as a host galaxy.
     apply_redshift : bool
         Indicates whether to apply the redshift.
     rest_frame_effects : list of EffectModel
@@ -55,8 +49,6 @@ class PhysicalModel(ParameterizedNode):
         The object's luminosity distance (in pc). If no value is provided and
         a cosmology parameter is given, the model will try to derive from
         the redshift and the cosmology.
-    background : PhysicalModel
-        A source of background flux such as a host galaxy.
     seed : int, optional
         The seed for a random number generator.
     **kwargs : dict, optional
@@ -70,7 +62,6 @@ class PhysicalModel(ParameterizedNode):
         redshift=None,
         t0=None,
         distance=None,
-        background=None,
         seed=None,
         **kwargs,
     ):
@@ -92,9 +83,6 @@ class PhysicalModel(ParameterizedNode):
         else:
             self.add_parameter("distance", None, allow_gradient=False)
 
-        # Background is an object not a sampled parameter
-        self.background = background
-
         # Initialize the effect settings to their default values.
         self.apply_redshift = redshift is not None
 
@@ -107,23 +95,6 @@ class PhysicalModel(ParameterizedNode):
         if seed is None:
             seed = int.from_bytes(urandom(4), "big")
         self._rng = np.random.default_rng(seed=seed)
-
-    def set_graph_positions(self, seen_nodes=None):
-        """Force an update of the graph structure (numbering of each node).
-
-        Parameters
-        ----------
-        seen_nodes : set, optional
-            A set of nodes that have already been processed to prevent infinite loops.
-            Caller should not set.
-        """
-        if seen_nodes is None:
-            seen_nodes = set()
-
-        # Set the graph positions for each node, its background, and all of its effects.
-        super().set_graph_positions(seen_nodes=seen_nodes)
-        if self.background is not None:
-            self.background.set_graph_positions(seen_nodes=seen_nodes)
 
     def set_apply_redshift(self, apply_redshift):
         """Toggles the apply_redshift setting.
@@ -194,6 +165,77 @@ class PhysicalModel(ParameterizedNode):
         """
         raise NotImplementedError()
 
+    def _evaluate_single(self, times, wavelengths, state, rng_info=None, **kwargs):
+        """Evaluate the model and apply the effects for a single, given graph state.
+        This function applies redshift, computes the flux density for the object,
+        applies rest frames effects, performs the redshift correction (if needed),
+        and applies the observer frame effects.
+
+        Parameters
+        ----------
+        times : numpy.ndarray
+            A length T array of observer frame timestamps in MJD.
+        wavelengths : numpy.ndarray
+            A length N array of wavelengths (in angstroms).
+        state : GraphState
+            An object mapping graph parameters to their values with num_samples=1.
+        rng_info : numpy.random._generator.Generator, optional
+            A given numpy random number generator to use for this computation. If not
+            provided, the function uses the node's random number generator.
+        **kwargs : dict, optional
+            All the other keyword arguments.
+
+        Returns
+        -------
+        flux_density : numpy.ndarray
+            A length T x N matrix of SED values (in nJy).
+        """
+        if state is None or state.num_samples != 1:
+            raise ValueError("A GraphState with num_samples=1 required.")
+        params = self.get_local_params(state)
+
+        # Pre-effects are adjustments done to times and/or wavelengths, before flux density
+        # computation. We skip if redshift is 0.0 since there is nothing to do.
+        if self.apply_redshift and params["redshift"] != 0.0:
+            if params.get("redshift", None) is None:
+                raise ValueError("The 'redshift' parameter is required for redshifted models.")
+            if params.get("t0", None) is None:
+                raise ValueError("The 't0' parameter is required for redshifted models.")
+            rest_times, rest_wavelengths = obs_to_rest_times_waves(
+                times, wavelengths, params["redshift"], params["t0"]
+            )
+        else:
+            rest_times = times
+            rest_wavelengths = wavelengths
+
+        # Compute the flux density for the object and apply any rest frame effects.
+        flux_density = self.compute_flux(rest_times, rest_wavelengths, state, **kwargs)
+        for effect in self.rest_frame_effects:
+            flux_density = effect.apply(
+                flux_density,
+                times=rest_times,
+                wavelengths=rest_wavelengths,
+                rng_info=rng_info,
+                **params,
+            )
+
+        # Post-effects are adjustments done to the flux density after computation.
+        if self.apply_redshift and params["redshift"] != 0.0:
+            # We have alread checked that redshift is not None.
+            flux_density = rest_to_obs_flux(flux_density, params["redshift"])
+
+        # Apply observer frame effects.
+        for effect in self.obs_frame_effects:
+            flux_density = effect.apply(
+                flux_density,
+                times=times,
+                wavelengths=wavelengths,
+                rng_info=rng_info,
+                **params,
+            )
+
+        return flux_density
+
     def evaluate(self, times, wavelengths, graph_state=None, given_args=None, rng_info=None, **kwargs):
         """Draw observations for this object and apply the noise.
 
@@ -201,7 +243,7 @@ class PhysicalModel(ParameterizedNode):
         ----------
         times : numpy.ndarray
             A length T array of observer frame timestamps in MJD.
-        wavelengths : numpy.ndarray, optional
+        wavelengths : numpy.ndarray
             A length N array of wavelengths (in angstroms).
         graph_state : GraphState, optional
             An object mapping graph parameters to their values.
@@ -233,60 +275,14 @@ class PhysicalModel(ParameterizedNode):
 
         results = np.empty((graph_state.num_samples, len(times), len(wavelengths)))
         for sample_num, state in enumerate(graph_state):
-            params = self.get_local_params(state)
-
-            # Pre-effects are adjustments done to times and/or wavelengths, before flux density
-            # computation. We skip if redshift is 0.0 since there is nothing to do.
-            if self.apply_redshift and params["redshift"] != 0.0:
-                if params.get("redshift", None) is None:
-                    raise ValueError("The 'redshift' parameter is required for redshifted models.")
-                if params.get("t0", None) is None:
-                    raise ValueError("The 't0' parameter is required for redshifted models.")
-                rest_times, rest_wavelengths = obs_to_rest_times_waves(
-                    times, wavelengths, params["redshift"], params["t0"]
-                )
-            else:
-                rest_times = times
-                rest_wavelengths = wavelengths
-
-            # Compute the flux density for the current object, add in anything behind
-            # the object, such as a host galaxy, and then apply rest frame effects.
-            flux_density = self.compute_flux(rest_times, rest_wavelengths, state, **kwargs)
-            if self.background is not None:
-                flux_density += self.background.compute_flux(
-                    rest_times,
-                    rest_wavelengths,
-                    state,
-                    ra=params["ra"],
-                    dec=params["dec"],
-                    **kwargs,
-                )
-            for effect in self.rest_frame_effects:
-                flux_density = effect.apply(
-                    flux_density,
-                    times=rest_times,
-                    wavelengths=rest_wavelengths,
-                    rng_info=rng_info,
-                    **params,
-                )
-
-            # Post-effects are adjustments done to the flux density after computation.
-            if self.apply_redshift and params["redshift"] != 0.0:
-                # We have alread checked that redshift is not None.
-                flux_density = rest_to_obs_flux(flux_density, params["redshift"])
-
-            # Apply observer frame effects (in the observer's frame).
-            for effect in self.obs_frame_effects:
-                flux_density = effect.apply(
-                    flux_density,
-                    times=times,
-                    wavelengths=wavelengths,
-                    rng_info=rng_info,
-                    **params,
-                )
-
-            # Save the result.
-            results[sample_num, :, :] = flux_density
+            # Compute the flux (applying all effects) and save the result.
+            results[sample_num, :, :] = self._evaluate_single(
+                times,
+                wavelengths,
+                state,
+                rng_info=rng_info,
+                **kwargs,
+            )
 
         if graph_state.num_samples == 1:
             return results[0, :, :]
@@ -321,15 +317,13 @@ class PhysicalModel(ParameterizedNode):
         if self.node_pos is None:
             self.set_graph_positions()
 
-        # We use the same seen_nodes for all sampling calls so each node
-        # is sampled at most one time regardless of link structure.
         graph_state = GraphState(num_samples)
         if given_args is not None:
             graph_state.update(given_args, all_fixed=True)
 
+        # We use the same seen_nodes for all sampling calls so each node
+        # is sampled at most one time regardless of link structure.
         seen_nodes = {}
-        if self.background is not None:
-            self.background._sample_helper(graph_state, seen_nodes, rng_info=rng_info)
         self._sample_helper(graph_state, seen_nodes, rng_info=rng_info)
 
         return graph_state

--- a/src/tdastro/sources/physical_model.py
+++ b/src/tdastro/sources/physical_model.py
@@ -128,23 +128,6 @@ class PhysicalModel(ParameterizedNode):
         """
         return None
 
-    def set_graph_positions(self, seen_nodes=None):
-        """Force an update of the graph structure (numbering of each node).
-
-        Parameters
-        ----------
-        seen_nodes : set, optional
-            A set of nodes that have already been processed to prevent infinite loops.
-            Caller should not set.
-        """
-        if seen_nodes is None:
-            seen_nodes = set()
-
-        # Set the graph positions for each node, its background, and all of its effects.
-        super().set_graph_positions(seen_nodes=seen_nodes)
-        if self.background is not None:
-            self.background.set_graph_positions(seen_nodes=seen_nodes)
-
     def set_apply_redshift(self, apply_redshift):
         """Toggles the apply_redshift setting.
 

--- a/tests/tdastro/effects/test_basic_effects.py
+++ b/tests/tdastro/effects/test_basic_effects.py
@@ -1,0 +1,50 @@
+import numpy as np
+import pytest
+from tdastro.effects.basic_effects import ConstantDimming
+from tdastro.sources.basic_sources import StaticSource
+
+
+def test_constant_dimming() -> None:
+    """Test that we can sample and create a ConstantDimming."""
+    values = np.full((5, 3), 100.0)
+
+    # We can apply the noise.
+    effect = ConstantDimming(flux_fraction=0.1)
+    values = effect.apply(values, flux_fraction=0.1)
+    assert np.all(values == 10.0)
+
+    # We fail if we do not pass in the expected parameters.
+    with pytest.raises(ValueError):
+        _ = effect.apply(values)
+
+
+def test_static_source_constant_dimming() -> None:
+    """Test that we can sample and create a StaticSource object with constant dimming."""
+    model = StaticSource(brightness=10.0, node_label="my_static_source")
+    assert len(model.rest_frame_effects) == 0
+    assert len(model.obs_frame_effects) == 0
+
+    # We can add the white noise effect.  By default it is a rest frame effect.
+    effect = ConstantDimming(flux_fraction=0.1)
+    model.add_effect(effect)
+    assert len(model.rest_frame_effects) == 1
+    assert len(model.obs_frame_effects) == 0
+
+    state = model.sample_parameters()
+    times = np.array([1, 2, 3, 4, 5, 10])
+    wavelengths = np.array([100.0, 200.0, 300.0])
+    values = model.evaluate(times, wavelengths, state)
+    assert values.shape == (6, 3)
+    assert np.all(values == 1.0)
+
+    # We can add the white noise effect as a observer frame effect instead.
+    model2 = StaticSource(brightness=10.0, node_label="my_static_source")
+    effect2 = ConstantDimming(flux_fraction=0.5, rest_frame=False)
+    model2.add_effect(effect2)
+    assert len(model2.rest_frame_effects) == 0
+    assert len(model2.obs_frame_effects) == 1
+
+    state2 = model2.sample_parameters()
+    values2 = model2.evaluate(times, wavelengths, state2)
+    assert values2.shape == (6, 3)
+    assert np.all(values2 == 5.0)

--- a/tests/tdastro/sources/test_galaxy_models.py
+++ b/tests/tdastro/sources/test_galaxy_models.py
@@ -2,6 +2,7 @@ import numpy as np
 from tdastro.math_nodes.np_random import NumpyRandomFunc
 from tdastro.sources.basic_sources import StaticSource
 from tdastro.sources.galaxy_models import GaussianGalaxy
+from tdastro.sources.multi_source_model import MultiSourceModel
 
 
 def test_gaussian_galaxy() -> None:
@@ -12,18 +13,22 @@ def test_gaussian_galaxy() -> None:
         dec=NumpyRandomFunc("uniform", low=-90.0, high=90.0),
         brightness=10.0,
         radius=1.0 / 3600.0,
+        node_name="host",
     )
 
     # We define the position of the source using Gaussian noise from the center of the host galaxy.
     source = StaticSource(
         ra=NumpyRandomFunc("normal", loc=host.ra, scale=host.galaxy_radius_std),
         dec=NumpyRandomFunc("normal", loc=host.dec, scale=host.galaxy_radius_std),
-        background=host,
         brightness=100.0,
+        node_name="source",
     )
 
+    # Create a combined source / host model.
+    combined_source = MultiSourceModel(sources=[host, source], ra=source.ra, dec=source.dec)
+
     # Both RA and dec should be "close" to (but not exactly at) the center of the galaxy.
-    state = source.sample_parameters()
+    state = combined_source.sample_parameters()
     host_ra = host.get_param(state, "ra")
     host_dec = host.get_param(state, "dec")
     source_ra_offset = source.get_param(state, "ra") - host_ra
@@ -36,14 +41,14 @@ def test_gaussian_galaxy() -> None:
     wavelengths = np.array([100.0, 200.0, 300.0])
 
     # All the measured fluxes should have some contribution from the background object.
-    values = source.evaluate(times, wavelengths)
+    values = combined_source.evaluate(times, wavelengths)
     assert values.shape == (6, 3)
     assert np.all(values > 100.0)
     assert np.all(values <= 110.0)
 
     # Check that if we resample the source it will propagate and correctly resample the host.
     # the host's (RA, dec) should change and the source's should still be close.
-    state2 = source.sample_parameters()
+    state2 = combined_source.sample_parameters()
     assert host_ra != host.get_param(state2, "ra")
     assert host_dec != host.get_param(state2, "dec")
 

--- a/tests/tdastro/sources/test_multi_source_models.py
+++ b/tests/tdastro/sources/test_multi_source_models.py
@@ -1,0 +1,190 @@
+import numpy as np
+import pytest
+from tdastro.effects.basic_effects import ConstantDimming
+from tdastro.math_nodes.np_random import NumpyRandomFunc
+from tdastro.sources.basic_sources import StaticSource, StepSource
+from tdastro.sources.multi_source_model import MultiSourceModel
+
+
+def test_multi_source_node() -> None:
+    """Test that we can create and evaluate a MultiSourceModel."""
+    source1 = StaticSource(brightness=10.0, node_label="my_static_source")
+    source2 = StepSource(brightness=15.0, t0=1.0, t1=2.0, node_label="my_step_source")
+    model = MultiSourceModel([source1, source2], node_label="my_multi_source")
+
+    state = model.sample_parameters()
+    assert state["my_static_source"]["brightness"] == 10.0
+    assert state["my_step_source"]["brightness"] == 15.0
+
+    times = np.array([0.0, 1.5, 3.0])
+    wavelengths = np.array([1000.0, 2000.0])
+
+    values = model.evaluate(times, wavelengths, state)
+    assert values.shape == (3, 2)
+    assert np.allclose(values, [[10.0, 10.0], [25.0, 25.0], [10.0, 10.0]])
+
+
+def test_multi_source_node_resample() -> None:
+    """Test that we can correctly resample a MultiSourceModel."""
+    ra = NumpyRandomFunc("uniform", low=10.0, high=20.0)
+    dec = NumpyRandomFunc("uniform", low=-10.0, high=10.0)
+
+    # Source1 and Source2 share the same ra and dec for each sample, but have
+    # different brightness values.
+    source1 = StaticSource(
+        brightness=NumpyRandomFunc("uniform", low=10.0, high=20.0),
+        ra=ra,
+        dec=dec,
+        node_label="my_static_source",
+    )
+    source2 = StepSource(
+        brightness=NumpyRandomFunc("uniform", low=30.0, high=40.0),
+        ra=ra,
+        dec=dec,
+        t0=1.0,
+        t1=2.0,
+        node_label="my_step_source",
+    )
+    model = MultiSourceModel([source1, source2], node_label="my_multi_source")
+
+    num_samples = 1000
+    rng_info = np.random.default_rng(100)
+    state = model.sample_parameters(num_samples=num_samples, rng_info=rng_info)
+    assert len(np.unique(state["my_static_source"]["ra"])) > num_samples / 2
+    assert len(np.unique(state["my_static_source"]["dec"])) > num_samples / 2
+    assert np.allclose(state["my_static_source"]["ra"], state["my_static_source"]["ra"])
+    assert np.allclose(state["my_static_source"]["dec"], state["my_static_source"]["dec"])
+
+    brightness_diff = state["my_step_source"]["brightness"] - state["my_static_source"]["brightness"]
+    assert np.all(brightness_diff > 5.0)
+
+    # We can evaluate the combined model at all of the times.
+    times = np.array([0.0, 1.5, 3.0])
+    wavelengths = np.array([1000.0, 2000.0])
+
+    values = model.evaluate(times, wavelengths, state)
+    assert values.shape == (1000, 3, 2)
+
+    assert np.allclose(values[:, 0, 0], state["my_static_source"]["brightness"])
+    assert np.allclose(values[:, 0, 1], state["my_static_source"]["brightness"])
+    assert np.allclose(
+        values[:, 1, 0],
+        state["my_static_source"]["brightness"] + state["my_step_source"]["brightness"],
+    )
+    assert np.allclose(
+        values[:, 1, 1],
+        state["my_static_source"]["brightness"] + state["my_step_source"]["brightness"],
+    )
+    assert np.allclose(values[:, 2, 0], state["my_static_source"]["brightness"])
+    assert np.allclose(values[:, 2, 1], state["my_static_source"]["brightness"])
+
+
+def test_multi_source_node_redshift() -> None:
+    """Test that we handle redshifts separately for each source."""
+    source1 = StepSource(brightness=10.0, t0=1.0, t1=3.0, redshift=0.0, node_label="source1")
+    source2 = StepSource(brightness=10.0, t0=2.0, t1=4.0, redshift=1.0, node_label="source2")
+    model = MultiSourceModel([source1, source2], node_label="my_multi_source")
+
+    state = model.sample_parameters()
+    times = np.array([0.5, 1.5, 2.5, 3.5, 4.5])
+    wavelengths = np.array([1000.0, 2000.0])
+
+    # Compute the expected values:
+    # The redshift applied to source1 is a no-op for both time and brightness.
+    # The redshift applied to source2 shifts times to [1.25 1.75 2.25 2.75 3.25]
+    # and scales up the brightness by a factor of (1 + z) = 2.0.
+    contrib1 = np.array([[0.0, 0.0], [10.0, 10.0], [10.0, 10.0], [0.0, 0.0], [0.0, 0.0]])
+    contrib2 = np.array([[0.0, 0.0], [0.0, 0.0], [20.0, 20.0], [20.0, 20.0], [20.0, 20.0]])
+
+    values = model.evaluate(times, wavelengths, state)
+    assert values.shape == (5, 2)
+    assert np.allclose(values, contrib1 + contrib2)
+
+
+def test_multi_source_node_effects_rest_frame() -> None:
+    """Test that we handle rest frame effects separately for each source."""
+    source1 = StepSource(brightness=10.0, t0=1.0, t1=3.0, node_label="source1")
+    source2 = StepSource(brightness=10.0, t0=2.0, t1=4.0, node_label="source2")
+    source1.add_effect(ConstantDimming(flux_fraction=0.5, rest_frame=True))
+    source2.add_effect(ConstantDimming(flux_fraction=0.1, rest_frame=True))
+    model = MultiSourceModel([source1, source2], node_label="my_multi_source")
+
+    # We added the effect to each submodel's rest frame list.
+    assert len(source1.rest_frame_effects) == 1
+    assert len(source2.rest_frame_effects) == 1
+    assert len(source1.obs_frame_effects) == 0
+    assert len(source2.obs_frame_effects) == 0
+    assert len(model.rest_frame_effects) == 0
+    assert len(model.obs_frame_effects) == 0
+
+    state = model.sample_parameters()
+    times = np.array([0.5, 1.5, 2.5, 3.5, 4.5])
+    wavelengths = np.array([1000.0, 2000.0])
+    values = model.evaluate(times, wavelengths, state)
+    assert values.shape == (5, 2)
+
+    contrib1 = np.array([[0.0, 0.0], [5.0, 5.0], [5.0, 5.0], [0.0, 0.0], [0.0, 0.0]])
+    contrib2 = np.array([[0.0, 0.0], [0.0, 0.0], [1.0, 1.0], [1.0, 1.0], [0.0, 0.0]])
+    assert np.allclose(values, contrib1 + contrib2)
+
+
+def test_multi_source_node_effects_rest_frame_add() -> None:
+    """Test that we handle rest frame effects separately for each source."""
+    source1 = StepSource(brightness=10.0, t0=1.0, t1=3.0, node_label="source1")
+    source2 = StepSource(brightness=10.0, t0=2.0, t1=4.0, node_label="source2")
+    model = MultiSourceModel([source1, source2], node_label="my_multi_source")
+    model.add_effect(ConstantDimming(flux_fraction=0.5, rest_frame=True))
+
+    # We added the effect to each submodel's rest frame list.
+    assert len(source1.rest_frame_effects) == 1
+    assert len(source2.rest_frame_effects) == 1
+    assert len(source1.obs_frame_effects) == 0
+    assert len(source2.obs_frame_effects) == 0
+    assert len(model.rest_frame_effects) == 0
+    assert len(model.obs_frame_effects) == 0
+
+    state = model.sample_parameters()
+    times = np.array([0.5, 1.5, 2.5, 3.5, 4.5])
+    wavelengths = np.array([1000.0, 2000.0])
+    values = model.evaluate(times, wavelengths, state)
+    assert values.shape == (5, 2)
+
+    contrib1 = np.array([[0.0, 0.0], [5.0, 5.0], [5.0, 5.0], [0.0, 0.0], [0.0, 0.0]])
+    contrib2 = np.array([[0.0, 0.0], [0.0, 0.0], [5.0, 5.0], [5.0, 5.0], [0.0, 0.0]])
+    assert np.allclose(values, contrib1 + contrib2)
+
+
+def test_multi_source_node_effects_obs_frame() -> None:
+    """Test that we handle observer frame effects together."""
+    source1 = StepSource(brightness=10.0, t0=1.0, t1=3.0, node_label="source1")
+    source2 = StepSource(brightness=10.0, t0=2.0, t1=4.0, node_label="source2")
+    model = MultiSourceModel([source1, source2], node_label="my_multi_source")
+    model.add_effect(ConstantDimming(flux_fraction=0.5, rest_frame=False))
+
+    # We added the effect to the joint model's rest frame list.
+    assert len(source1.rest_frame_effects) == 0
+    assert len(source2.rest_frame_effects) == 0
+    assert len(source1.obs_frame_effects) == 0
+    assert len(source2.obs_frame_effects) == 0
+    assert len(model.rest_frame_effects) == 0
+    assert len(model.obs_frame_effects) == 1
+
+    state = model.sample_parameters()
+    times = np.array([0.5, 1.5, 2.5, 3.5, 4.5])
+    wavelengths = np.array([1000.0, 2000.0])
+    values = model.evaluate(times, wavelengths, state)
+    assert values.shape == (5, 2)
+
+    contrib1 = np.array([[0.0, 0.0], [5.0, 5.0], [5.0, 5.0], [0.0, 0.0], [0.0, 0.0]])
+    contrib2 = np.array([[0.0, 0.0], [0.0, 0.0], [5.0, 5.0], [5.0, 5.0], [0.0, 0.0]])
+    assert np.allclose(values, contrib1 + contrib2)
+
+
+def test_multi_source_node_effects_fail() -> None:
+    """Test that we fail if any source includes an observer frame effect."""
+    source1 = StepSource(brightness=10.0, t0=1.0, t1=3.0, node_label="source1")
+    source2 = StepSource(brightness=10.0, t0=2.0, t1=4.0, node_label="source2")
+    source2.add_effect(ConstantDimming(flux_fraction=0.5, rest_frame=False))
+
+    with pytest.raises(ValueError):
+        _ = MultiSourceModel([source1, source2], node_label="my_multi_source")


### PR DESCRIPTION
Closes #281 

Add a `MultiSourceModel` that computes the flux as the (weighted) sum from a list of individual sources. Remove `PhysicalModel`'s background attribute in favor of this (**warning: this will be a breaking change**). This provides more flexibility and also consistency in how the effects are applied.

For testing purposes we add a toy effect `ConstantDimming`.