### PR TITLE
Make extrapolation available to all models

### DIFF
--- a/src/tdastro/sources/basic_sources.py
+++ b/src/tdastro/sources/basic_sources.py
@@ -215,7 +215,7 @@ class LinearWavelengthSource(PhysicalModel):
 
         Returns
         -------
-        minwave : float or Nonw
+        minwave : float or None
             The minimum wavelength of the model (in angstroms) or None
             if the model does not have a defined minimum wavelength.
         """
@@ -226,7 +226,7 @@ class LinearWavelengthSource(PhysicalModel):
 
         Returns
         -------
-        maximum : float or Nonw
+        maximum : float or None
             The maximum wavelength of the model (in angstroms) or None
             if the model does not have a defined maximum wavelength.
         """

--- a/src/tdastro/sources/basic_sources.py
+++ b/src/tdastro/sources/basic_sources.py
@@ -166,6 +166,9 @@ class LinearWavelengthSource(PhysicalModel):
     """A source that emits flux as a linear function of wavelength
     (that is constant over time): f(t, w) = scale * w + base.
 
+    Includes optional minimum and maximum wavelength bounds to test
+    extrapolation.
+
     Parameterized values include:
       * linear_base - The base brightness in nJy.
       * linear_scale - The slope of the linear function in nJy/Angstrom.
@@ -175,20 +178,59 @@ class LinearWavelengthSource(PhysicalModel):
       * redshift - The object's redshift. [from PhysicalModel]
       * t0 - No effect for static model. [from PhysicalModel]
 
+    Attributes
+    ----------
+    min_wave : float or None
+        The minimum wavelength of the model (in angstroms). Or None if there
+        is no minimum wavelength.
+    max_wave : float or None
+        The maximum wavelength of the model (in angstroms). Or None if there
+        is no maximum wavelength.
+
     Parameters
     ----------
     linear_base : parameter
         The base brightness in nJy.
     linear_scale : parameter
         The slope of the linear function in nJy/Angstrom.
+    min_wave : float or None
+        The minimum wavelength of the model (in angstroms). Or None if there
+        is no minimum wavelength.
+    max_wave : float or None
+        The maximum wavelength of the model (in angstroms). Or None if there
+        is no maximum wavelength.
     **kwargs : dict, optional
         Any additional keyword arguments.
     """
 
-    def __init__(self, linear_base, linear_scale, **kwargs):
+    def __init__(self, linear_base, linear_scale, min_wave=None, max_wave=None, **kwargs):
         super().__init__(**kwargs)
         self.add_parameter("linear_base", linear_base, **kwargs)
         self.add_parameter("linear_scale", linear_scale, **kwargs)
+        self.min_wave = min_wave
+        self.max_wave = max_wave
+
+    def minwave(self):
+        """Get the minimum wavelength of the model.
+
+        Returns
+        -------
+        minwave : float or Nonw
+            The minimum wavelength of the model (in angstroms) or None
+            if the model does not have a defined minimum wavelength.
+        """
+        return self.min_wave
+
+    def maxwave(self):
+        """Get the maximum wavelength of the model.
+
+        Returns
+        -------
+        maximum : float or Nonw
+            The maximum wavelength of the model (in angstroms) or None
+            if the model does not have a defined maximum wavelength.
+        """
+        return self.max_wave
 
     def compute_flux(self, times, wavelengths, graph_state, **kwargs):
         """Draw effect-free observations for this object.

--- a/src/tdastro/sources/physical_model.py
+++ b/src/tdastro/sources/physical_model.py
@@ -40,6 +40,9 @@ class PhysicalModel(ParameterizedNode):
         A list of effects to apply in the rest frame.
     obs_frame_effects : list of EffectModel
         A list of effects to apply in the observer frame.
+    wave_extrapolation : WaveExtrapolationModel, optional
+        The extrapolation model to use for wavelengths that fall outside
+        the model's defined bounds.  If None then the model will use all zeros.
 
     Parameters
     ----------
@@ -57,6 +60,9 @@ class PhysicalModel(ParameterizedNode):
         the redshift and the cosmology.
     background : PhysicalModel
         A source of background flux such as a host galaxy.
+    wave_extrapolation : WaveExtrapolationModel, optional
+        The extrapolation model to use for wavelengths that fall outside
+        the model's defined bounds.  If None then the model will use all zeros.
     seed : int, optional
         The seed for a random number generator.
     **kwargs : dict, optional
@@ -71,6 +77,7 @@ class PhysicalModel(ParameterizedNode):
         t0=None,
         distance=None,
         background=None,
+        wave_extrapolation=None,
         seed=None,
         **kwargs,
     ):
@@ -102,11 +109,36 @@ class PhysicalModel(ParameterizedNode):
         self.rest_frame_effects = []
         self.obs_frame_effects = []
 
+        # Set the extrapolation for values outside the model's defined bounds.
+        self.wave_extrapolation = wave_extrapolation
+
         # Get a default random number generator for this object, using the
         # given seed if one is provided.
         if seed is None:
             seed = int.from_bytes(urandom(4), "big")
         self._rng = np.random.default_rng(seed=seed)
+
+    def minwave(self):
+        """Get the minimum wavelength of the model.
+
+        Returns
+        -------
+        minwave : float or Nonw
+            The minimum wavelength of the model (in angstroms) or None
+            if the model does not have a defined minimum wavelength.
+        """
+        return None
+
+    def maxwave(self):
+        """Get the maximum wavelength of the model.
+
+        Returns
+        -------
+        maximum : float or Nonw
+            The maximum wavelength of the model (in angstroms) or None
+            if the model does not have a defined maximum wavelength.
+        """
+        return None
 
     def set_graph_positions(self, seen_nodes=None):
         """Force an update of the graph structure (numbering of each node).
@@ -173,7 +205,7 @@ class PhysicalModel(ParameterizedNode):
         """
         return np.full(len(times), True)
 
-    def compute_flux(self, times, wavelengths, graph_state):
+    def compute_flux(self, times, wavelengths, graph_state, **kwargs):
         """Draw effect-free rest frame flux densities.
         The rest-frame flux is defined as F_nu = L_nu / 4*pi*D_L**2,
         where D_L is the luminosity distance.
@@ -186,6 +218,8 @@ class PhysicalModel(ParameterizedNode):
             A length N array of rest frame wavelengths (in angstroms).
         graph_state : GraphState
             An object mapping graph parameters to their values.
+        **kwargs : dict, optional
+            Any additional keyword arguments.
 
         Returns
         -------
@@ -193,6 +227,73 @@ class PhysicalModel(ParameterizedNode):
             A length T x N matrix of rest frame SED values (in nJy).
         """
         raise NotImplementedError()
+
+    def compute_flux_with_extrapolation(self, times, wavelengths, graph_state, **kwargs):
+        """Draw effect-free observations for this object, extrapolating
+        to wavelengths where the model is not defined.
+
+        Parameters
+        ----------
+        times : numpy.ndarray
+            A length T array of rest frame timestamps.
+        wavelengths : numpy.ndarray, optional
+            A length N array of wavelengths (in angstroms).
+        graph_state : GraphState
+            An object mapping graph parameters to their values.
+        **kwargs : dict, optional
+           Any additional keyword arguments.
+
+        Returns
+        -------
+        flux_density : numpy.ndarray
+            A length T x N matrix of SED values (in nJy).
+        """
+        min_query_wave = np.min(wavelengths)
+        min_valid_wave = self.minwave()
+        if min_valid_wave is None:
+            min_valid_wave = min_query_wave
+
+        max_query_wave = np.max(wavelengths)
+        max_valid_wave = self.maxwave()
+        if max_valid_wave is None:
+            max_valid_wave = max_query_wave
+
+        # If no extrapolation is needed, just call compute the flux.
+        if min_query_wave >= min_valid_wave and max_query_wave <= max_valid_wave:
+            return self.compute_flux(times, wavelengths, graph_state, **kwargs)
+
+        # Truncate the wavelengths on which we evaluate the model.
+        before_mask = wavelengths < min_valid_wave
+        after_mask = wavelengths > max_valid_wave
+        in_range = ~before_mask & ~after_mask
+
+        # Pad the wavelengths with the min and max values and compute the flux at those points.
+        query_waves = np.concatenate(([min_valid_wave], wavelengths[in_range], [max_valid_wave]))
+        computed_flux = self.compute_flux(times, query_waves, graph_state)
+
+        # Initially zero pad the full array until we fill in the values with extrapolation.
+        # We drop the first and last flux values since they were added to get the flux at the
+        # min and max wavelengths.
+        flux_density = np.zeros((len(times), len(wavelengths)))
+        flux_density[:, in_range] = computed_flux[:, 1:-1]
+
+        # Do extrapolation for wavelengths that fell outside the model's bounds.
+        if self.wave_extrapolation is not None:
+            # Compute the flux values before the model's first valid wavelength.
+            flux_density[:, before_mask] = self.wave_extrapolation(
+                min_valid_wave,
+                computed_flux[:, 0],
+                wavelengths[before_mask],
+            )
+
+            # Compute the flux values after the model's last valid wavelength.
+            flux_density[:, after_mask] = self.wave_extrapolation(
+                max_valid_wave,
+                computed_flux[:, -1],
+                wavelengths[after_mask],
+            )
+
+        return flux_density
 
     def evaluate(self, times, wavelengths, graph_state=None, given_args=None, rng_info=None, **kwargs):
         """Draw observations for this object and apply the noise.
@@ -251,9 +352,9 @@ class PhysicalModel(ParameterizedNode):
 
             # Compute the flux density for the current object, add in anything behind
             # the object, such as a host galaxy, and then apply rest frame effects.
-            flux_density = self.compute_flux(rest_times, rest_wavelengths, state, **kwargs)
+            flux_density = self.compute_flux_with_extrapolation(rest_times, rest_wavelengths, state, **kwargs)
             if self.background is not None:
-                flux_density += self.background.compute_flux(
+                flux_density += self.background.compute_flux_with_extrapolation(
                     rest_times,
                     rest_wavelengths,
                     state,

--- a/src/tdastro/sources/physical_model.py
+++ b/src/tdastro/sources/physical_model.py
@@ -123,7 +123,7 @@ class PhysicalModel(ParameterizedNode):
 
         Returns
         -------
-        minwave : float or Nonw
+        minwave : float or None
             The minimum wavelength of the model (in angstroms) or None
             if the model does not have a defined minimum wavelength.
         """
@@ -134,7 +134,7 @@ class PhysicalModel(ParameterizedNode):
 
         Returns
         -------
-        maximum : float or Nonw
+        maximum : float or None
             The maximum wavelength of the model (in angstroms) or None
             if the model does not have a defined maximum wavelength.
         """

--- a/src/tdastro/sources/sncomso_models.py
+++ b/src/tdastro/sources/sncomso_models.py
@@ -99,7 +99,7 @@ class SncosmoWrapperModel(PhysicalModel, CiteClass):
 
         Returns
         -------
-        minwave : float or Nonw
+        minwave : float or None
             The minimum wavelength of the model (in angstroms) or None
             if the model does not have a defined minimum wavelength.
         """
@@ -110,7 +110,7 @@ class SncosmoWrapperModel(PhysicalModel, CiteClass):
 
         Returns
         -------
-        maximum : float or Nonw
+        maximum : float or None
             The maximum wavelength of the model (in angstroms) or None
             if the model does not have a defined maximum wavelength.
         """
@@ -247,7 +247,7 @@ class SncosmoWrapperModel(PhysicalModel, CiteClass):
         if np.any(wavelengths < self.source.minwave()) or np.any(wavelengths > self.source.maxwave()):
             return self.compute_flux_with_extrapolation(times, wavelengths, graph_state, **kwargs)
 
-        # Query the model and convery the output to nJy.
+        # Query the model and convert the output to nJy.
         model_flam = self.source.flux(times - params["t0"], wavelengths)
         model_fnu = flam_to_fnu(
             model_flam,

--- a/src/tdastro/sources/sncomso_models.py
+++ b/src/tdastro/sources/sncomso_models.py
@@ -37,9 +37,6 @@ class SncosmoWrapperModel(PhysicalModel, CiteClass):
         The name used to set the source.
     source_param_names : list
         A list of the source model's parameters that we need to set.
-    wave_extrapolation : WaveExtrapolationModel, optional
-        The extrapolation model to use for wavelengths that fall outside
-        the sncosmo model's bounds.  If None then the model will use all zeros.
 
     Parameters
     ----------
@@ -49,7 +46,9 @@ class SncosmoWrapperModel(PhysicalModel, CiteClass):
         An identifier (or name) for the current node.
     wave_extrapolation : WaveExtrapolationModel, optional
         The extrapolation model to use for wavelengths that fall outside
-        the sncosmo model's bounds.  If None then the model will use all zeros
+        the model's defined bounds.  If None then the model will use all zeros.
+    seed : int, optional
+        The seed for a random number generator.
     **kwargs : dict, optional
         Any additional keyword arguments.
     """
@@ -62,14 +61,20 @@ class SncosmoWrapperModel(PhysicalModel, CiteClass):
         source_name,
         node_label=None,
         wave_extrapolation=None,
+        seed=None,
         **kwargs,
     ):
-        super().__init__(node_label=node_label, **kwargs)
+        # We explicitly ask for and pass along the PhysicalModel parameters such
+        # as node_label and wave_extrapolation so they do not go into kwargs
+        # and get added to the sncosmo model below.
+        super().__init__(
+            node_label=node_label,
+            wave_extrapolation=wave_extrapolation,
+            seed=seed,
+            **kwargs,
+        )
         self.source_name = source_name
         self.source = get_source(source_name)
-
-        # Set the extrapolation for values outside the sncosmo bounds.
-        self.wave_extrapolation = wave_extrapolation
 
         # Use the kwargs to initialize the sncosmo model's parameters.
         self.source_param_names = []
@@ -88,6 +93,28 @@ class SncosmoWrapperModel(PhysicalModel, CiteClass):
     def parameter_values(self):
         """Return a list of the model's parameter values."""
         return self.source.parameters
+
+    def minwave(self):
+        """Get the minimum wavelength of the model.
+
+        Returns
+        -------
+        minwave : float or Nonw
+            The minimum wavelength of the model (in angstroms) or None
+            if the model does not have a defined minimum wavelength.
+        """
+        return self.source.minwave()
+
+    def maxwave(self):
+        """Get the maximum wavelength of the model.
+
+        Returns
+        -------
+        maximum : float or Nonw
+            The maximum wavelength of the model (in angstroms) or None
+            if the model does not have a defined maximum wavelength.
+        """
+        return self.source.maxwave()
 
     def _update_sncosmo_model_parameters(self, graph_state):
         """Update the parameters for the wrapped sncosmo model."""
@@ -215,47 +242,18 @@ class SncosmoWrapperModel(PhysicalModel, CiteClass):
         params = self.get_local_params(graph_state)
         self._update_sncosmo_model_parameters(graph_state)
 
-        # sncosmo gives an error if the wavelengths are out of bounds, so we truncate for the actual call.
-        before_mask = wavelengths < self.source.minwave()
-        after_mask = wavelengths > self.source.maxwave()
-        in_range = ~before_mask & ~after_mask
+        # sncosmo gives an error if the wavelengths are out of bounds, so we need to use
+        # extrapolation if the wavelengths are out of bounds.
+        if np.any(wavelengths < self.source.minwave()) or np.any(wavelengths > self.source.maxwave()):
+            return self.compute_flux_with_extrapolation(times, wavelengths, graph_state, **kwargs)
 
-        # Pad the wavelengths with the min and max values and compute the flux (flam) at those points.
-        query_waves = np.concatenate(
-            ([self.source.minwave()], wavelengths[in_range], [self.source.maxwave()])
-        )
-        model_flam = self.source.flux(times - params["t0"], query_waves)
-
-        # Convert the flux to the desired units. We only bother converting the
-        # wavelengths that are in range.
+        # Query the model and convery the output to nJy.
+        model_flam = self.source.flux(times - params["t0"], wavelengths)
         model_fnu = flam_to_fnu(
             model_flam,
-            query_waves,
+            wavelengths,
             wave_unit=u.AA,
             flam_unit=self._FLAM_UNIT,
             fnu_unit=u.nJy,
         )
-
-        # Initially zero pad the fnu array until we fill in the values with extrapolation.
-        flux_fnu = np.zeros((len(times), len(wavelengths)))
-        flux_fnu[:, in_range] = model_fnu[:, 1:-1]
-
-        # Do extrapolation for wavelengths that fell outside the model's bounds
-        # using the fnu values. The endpoints of model_fnu are the first and last
-        # valid values for the model.
-        if self.wave_extrapolation is not None:
-            # Compute the flux values before the model's first valid wavelength.
-            flux_fnu[:, before_mask] = self.wave_extrapolation(
-                self.source.minwave(),
-                model_fnu[:, 0],
-                wavelengths[before_mask],
-            )
-
-            # Compute the flux values after the model's last valid wavelength.
-            flux_fnu[:, after_mask] = self.wave_extrapolation(
-                self.source.maxwave(),
-                model_fnu[:, -1],
-                wavelengths[after_mask],
-            )
-
-        return flux_fnu
+        return model_fnu

--- a/src/tdastro/sources/spline_model.py
+++ b/src/tdastro/sources/spline_model.py
@@ -18,7 +18,7 @@ class SplineModel(PhysicalModel):
 
     The model is defined by a 2D grid of flux values as a function of time
     and wavelength. Time is given in decimal days since t0 and wavelength
-    is given in angstroms:
+    is given in angstroms.
 
     Parameterized values include:
       * amplitude - A unitless scaling parameter for the flux density values.
@@ -38,8 +38,6 @@ class SplineModel(PhysicalModel):
         (in angstroms).
     _spline : RectBivariateSpline
         The spline object for predicting the flux from a given (time, wavelength).
-    name : str
-        The name of the model being used.
 
     Parameters
     ----------
@@ -130,6 +128,28 @@ class SplineModel(PhysicalModel):
         """
         times, wavelengths, flux = read_grid_data(input_file, format=format, validate=True)
         return cls(times, wavelengths, flux, amplitude, time_degree, wave_degree, **kwargs)
+
+    def minwave(self):
+        """Get the minimum wavelength of the model.
+
+        Returns
+        -------
+        minwave : float or Nonw
+            The minimum wavelength of the model (in angstroms) or None
+            if the model does not have a defined minimum wavelength.
+        """
+        return self._wavelengths[0]
+
+    def maxwave(self):
+        """Get the maximum wavelength of the model.
+
+        Returns
+        -------
+        maximum : float or Nonw
+            The maximum wavelength of the model (in angstroms) or None
+            if the model does not have a defined maximum wavelength.
+        """
+        return self._wavelengths[-1]
 
     def compute_flux(self, times, wavelengths, graph_state, **kwargs):
         """Draw effect-free observations for this object.

--- a/src/tdastro/sources/spline_model.py
+++ b/src/tdastro/sources/spline_model.py
@@ -134,7 +134,7 @@ class SplineModel(PhysicalModel):
 
         Returns
         -------
-        minwave : float or Nonw
+        minwave : float or None
             The minimum wavelength of the model (in angstroms) or None
             if the model does not have a defined minimum wavelength.
         """
@@ -145,7 +145,7 @@ class SplineModel(PhysicalModel):
 
         Returns
         -------
-        maximum : float or Nonw
+        maximum : float or None
             The maximum wavelength of the model (in angstroms) or None
             if the model does not have a defined maximum wavelength.
         """

--- a/src/tdastro/utils/wave_extrapolate.py
+++ b/src/tdastro/utils/wave_extrapolate.py
@@ -21,7 +21,7 @@ class WaveExtrapolationModel:
             The last valid wavelength (in AA).
         last_flux : numpy.ndarray
             A length T array of the last valid flux values at each time
-            at the last valid wavelength (in the model's units).
+            at the last valid wavelength (in nJy).
         query_waves : numpy.ndarray
             A length W array of the query wavelengths (in AA) at which to extrapolate.
 
@@ -39,12 +39,12 @@ class WaveExtrapolationModel:
 
 
 class ConstantExtrapolation(WaveExtrapolationModel):
-    """Extrapolate using a constant value.
+    """Extrapolate using a constant value in nJy.
 
     Attributes
     ----------
     value : float
-        The value (in the model's flux units) to use for the extrapolation.
+        The value (in nJy) to use for the extrapolation.
     """
 
     def __init__(self, value=0.0):
@@ -97,14 +97,14 @@ class LastValueExtrapolation(WaveExtrapolationModel):
             The last valid wavelength (in AA).
         last_flux : numpy.ndarray
             A length T array of the last valid flux values at each time
-            at the last valid wavelength (in the model's units).
+            at the last valid wavelength (in nJy).
         query_waves : numpy.ndarray
             A length W array of the query wavelengths (in AA) at which to extrapolate.
 
         Returns
         -------
         flux : numpy.ndarray
-            A T x W matrix of extrapolated values.
+            A T x W matrix of extrapolated values (in nJy).
         """
         last_flux = np.asarray(last_flux)
         query_waves = np.asarray(query_waves)
@@ -140,14 +140,14 @@ class LinearDecay(WaveExtrapolationModel):
             The last valid wavelength (in AA).
         last_flux : numpy.ndarray
             A length T array of the last valid flux values at each time
-            at the last valid wavelength (in the model's units).
+            at the last valid wavelength (in nJy).
         query_waves : numpy.ndarray
             A length W array of the query wavelengths (in AA) at which to extrapolate.
 
         Returns
         -------
         flux : numpy.ndarray
-            A T x W matrix of extrapolated values.
+            A T x W matrix of extrapolated values (in nJy).
         """
         last_flux = np.asarray(last_flux)
         query_waves = np.asarray(query_waves)
@@ -186,14 +186,14 @@ class ExponentialDecay(WaveExtrapolationModel):
             The last valid wavelength (in AA).
         last_flux : numpy.ndarray
             A length T array of the last valid flux values at each time
-            at the last valid wavelength (in the model's units).
+            at the last valid wavelength (in nJy)
         query_waves : numpy.ndarray
             A length W array of the query wavelengths (in AA) at which to extrapolate.
 
         Returns
         -------
         flux : numpy.ndarray
-            A T x W matrix of extrapolated values.
+            A T x W matrix of extrapolated values (in nJy).
         """
         last_flux = np.asarray(last_flux)
         query_waves = np.asarray(query_waves)

--- a/tests/tdastro/sources/test_basic_sources.py
+++ b/tests/tdastro/sources/test_basic_sources.py
@@ -213,7 +213,7 @@ def test_linear_wavelength_source_bounds() -> None:
     wavelengths = np.array([500.0, 1000.0, 1500.0, 2000.0, 2500.0])
     values = model.evaluate(times, wavelengths, state)
 
-    # Without any extrapolation, we zero bad the data.
+    # Without any extrapolation, we zero pad the data.
     expected = np.tile(np.array([0.0, 101.0, 151.0, 201.0, 0.0]), (len(times), 1))
     assert np.allclose(values, expected)
 


### PR DESCRIPTION
Other models beyond `SncosmoWrapperModel` may need extrapolation, such as `SplineModel`.  This PR enables extrapolation for **all** models with provided wavelength bounds, by moving the computation into `PhysicalModel`.