### PR TITLE
Add a LSST_test preset passband group

### DIFF
--- a/docs/notebooks/introduction.ipynb
+++ b/docs/notebooks/introduction.ipynb
@@ -223,7 +223,7 @@
    "source": [
     "from tdastro.astro_utils.passbands import PassbandGroup\n",
     "\n",
-    "passband_group = PassbandGroup(preset=\"LSST\")\n",
+    "passband_group = PassbandGroup(preset=\"LSST_test\")\n",
     "print(passband_group)"
    ]
   },

--- a/docs/notebooks/lightcurve_source_demo.ipynb
+++ b/docs/notebooks/lightcurve_source_demo.ipynb
@@ -44,7 +44,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "passband_group = PassbandGroup(preset=\"LSST\")\n",
+    "passband_group = PassbandGroup(preset=\"LSST_test\")\n",
     "filters = passband_group.passbands.keys()\n",
     "print(passband_group)\n",
     "\n",

--- a/docs/notebooks/passband-demo.ipynb
+++ b/docs/notebooks/passband-demo.ipynb
@@ -42,7 +42,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "passband_group = PassbandGroup(preset=\"LSST\")\n",
+    "passband_group = PassbandGroup(preset=\"LSST_test\")\n",
     "print(passband_group)\n",
     "\n",
     "wavelengths = passband_group.waves\n",
@@ -111,7 +111,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "passband_group_rg = PassbandGroup(preset=\"LSST\", filters_to_load=[\"r\", \"g\"])\n",
+    "passband_group_rg = PassbandGroup(preset=\"LSST_test\", filters_to_load=[\"r\", \"g\"])\n",
     "print(passband_group_rg)\n",
     "\n",
     "min_wave, max_wave = passband_group_rg.wave_bounds()\n",

--- a/docs/notebooks/pre_executed/plasticc_snia.ipynb
+++ b/docs/notebooks/pre_executed/plasticc_snia.ipynb
@@ -54,7 +54,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "da09419a-cf38-4d6f-b44c-e1110caaf541",
    "metadata": {
     "execution": {
@@ -131,7 +131,11 @@
     "\n",
     "# Load the passband data for the griz filters only.\n",
     "passband_group = PassbandGroup(\n",
-    "    preset=\"LSST\", filters_to_load=[\"g\", \"r\", \"i\", \"z\"], units=\"nm\", trim_quantile=0.001, delta_wave=1\n",
+    "    preset=\"LSST_test\",\n",
+    "    filters_to_load=[\"g\", \"r\", \"i\", \"z\"],\n",
+    "    units=\"nm\",\n",
+    "    trim_quantile=0.001,\n",
+    "    delta_wave=1,\n",
     ")\n",
     "print(f\"Loaded Passbands: {passband_group}\")"
    ]

--- a/src/tdastro/astro_utils/passbands.py
+++ b/src/tdastro/astro_utils/passbands.py
@@ -278,6 +278,7 @@ class PassbandGroup:
         elif preset == "LSST_test":
             # Use an old cached version of the LSST passbands
             table_dir = Path(_TDASTRO_TEST_DATA_DIR, "passbands", "LSST")
+            print(f"Loading LSST passbands from: {table_dir}")
             for filter_name in ["u", "g", "r", "i", "z", "y"]:
                 pb = Passband.from_file(
                     "LSST",

--- a/src/tdastro/astro_utils/passbands.py
+++ b/src/tdastro/astro_utils/passbands.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from pathlib import Path
 from typing import Literal, Optional, Union
 
@@ -278,6 +279,13 @@ class PassbandGroup:
         elif preset == "LSST_test":
             # Use an old cached version of the LSST passbands
             table_dir = Path(_TDASTRO_TEST_DATA_DIR, "passbands", "LSST")
+
+            current_directory = os.getcwd()
+            print(f"Current directory: {current_directory}")
+
+            items = os.listdir(current_directory)
+            print(f"Contents of directory: {items}")
+
             print(f"Loading LSST passbands from: {table_dir}")
             for filter_name in ["u", "g", "r", "i", "z", "y"]:
                 pb = Passband.from_file(

--- a/src/tdastro/astro_utils/passbands.py
+++ b/src/tdastro/astro_utils/passbands.py
@@ -9,7 +9,7 @@ import scipy.integrate
 from citation_compass import cite_function
 from sncosmo import Bandpass, get_bandpass
 
-from tdastro import _TDASTRO_BASE_DATA_DIR
+from tdastro import _TDASTRO_BASE_DATA_DIR, _TDASTRO_TEST_DATA_DIR
 from tdastro.consts import lsst_filter_plot_colors
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
@@ -272,6 +272,18 @@ class PassbandGroup:
                     filter_name,
                     table_path=Path(table_dir, f"{filter_name}.dat"),
                     table_url=url,
+                    **kwargs,
+                )
+                self.passbands[pb.full_name] = pb
+        elif preset == "LSST_test":
+            # Use an old cached version of the LSST passbands
+            table_dir = Path(_TDASTRO_TEST_DATA_DIR, "passbands", "LSST")
+            for filter_name in ["u", "g", "r", "i", "z", "y"]:
+                pb = Passband.from_file(
+                    "LSST",
+                    filter_name,
+                    table_path=Path(table_dir, f"{filter_name}.dat"),
+                    table_url=None,
                     **kwargs,
                 )
                 self.passbands[pb.full_name] = pb

--- a/tests/tdastro/sources/test_physical_models.py
+++ b/tests/tdastro/sources/test_physical_models.py
@@ -128,7 +128,7 @@ def test_physical_model_get_band_fluxes(passbands_dir):
     f_nu = np.random.lognormal()
     static_source = StaticSource(brightness=f_nu)
     state = static_source.sample_parameters()
-    passbands = PassbandGroup(preset="LSST")
+    passbands = PassbandGroup(preset="LSST_test")
     n_passbands = len(passbands)
 
     times = np.arange(n_passbands, dtype=float)

--- a/tests/tdastro/test_simulate.py
+++ b/tests/tdastro/test_simulate.py
@@ -13,7 +13,7 @@ def test_simulate_lightcurves(test_data_dir):
 
     # Load the passband data for the griz filters only.
     passband_group = PassbandGroup(
-        preset="LSST",
+        preset="LSST_test",
         table_dir=test_data_dir / "passbands",
         filters_to_load=["g", "r", "i", "z"],
     )


### PR DESCRIPTION
The github actions are failing because we have exceeded the number of requests to download the LSST passband data. This PR fixes the problem by pulling data from local files. It adds a "LSST_test" preset that pulls from the test/data/passbands/lsst directory instead of downloading from github.