### PR TITLE
Do not download passbands in tests or notebooks

### DIFF
--- a/docs/notebooks/introduction.ipynb
+++ b/docs/notebooks/introduction.ipynb
@@ -223,7 +223,9 @@
    "source": [
     "from tdastro.astro_utils.passbands import PassbandGroup\n",
     "\n",
-    "passband_group = PassbandGroup(preset=\"LSST\")\n",
+    "# Use a (possibly older) cached version of the passbands to avoid downloading them.\n",
+    "table_dir = \"../../tests/tdastro/data/passbands\"\n",
+    "passband_group = PassbandGroup(preset=\"LSST\", table_dir=table_dir)\n",
     "print(passband_group)"
    ]
   },

--- a/docs/notebooks/lightcurve_source_demo.ipynb
+++ b/docs/notebooks/lightcurve_source_demo.ipynb
@@ -34,7 +34,7 @@
    "id": "d5098537",
    "metadata": {},
    "source": [
-    "We start be loading the passbands that we will use to define the model. In this case we use the passbands from the LSST preset."
+    "We start be loading the passbands that we will use to define the model. In this case we use the passbands from the LSST preset (but use a cached local version to avoid a download)."
    ]
   },
   {
@@ -44,7 +44,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "passband_group = PassbandGroup(preset=\"LSST\")\n",
+    "# Use a (possibly older) cached version of the passbands to avoid downloading them.\n",
+    "table_dir = \"../../tests/tdastro/data/passbands\"\n",
+    "passband_group = PassbandGroup(preset=\"LSST\", table_dir=table_dir)\n",
     "filters = passband_group.passbands.keys()\n",
     "print(passband_group)\n",
     "\n",

--- a/docs/notebooks/passband-demo.ipynb
+++ b/docs/notebooks/passband-demo.ipynb
@@ -33,7 +33,7 @@
     "\n",
     "### Loading present passbands\n",
     "\n",
-    "We start this notebook by loading the default passbands for LSST and printing basic information. "
+    "We start this notebook by loading the default passbands for LSST and printing basic information. In general we would want to leave out the table directory to allow the code to use the latest version, but here we use (older) cached data from the testing directory to avoid a download in the notebook."
    ]
   },
   {
@@ -42,7 +42,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "passband_group = PassbandGroup(preset=\"LSST\")\n",
+    "table_dir = \"../../tests/tdastro/data/passbands\"\n",
+    "passband_group = PassbandGroup(preset=\"LSST\", table_dir=table_dir)\n",
     "print(passband_group)\n",
     "\n",
     "wavelengths = passband_group.waves\n",
@@ -111,7 +112,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "passband_group_rg = PassbandGroup(preset=\"LSST\", filters_to_load=[\"r\", \"g\"])\n",
+    "passband_group_rg = PassbandGroup(preset=\"LSST\", filters_to_load=[\"r\", \"g\"], table_dir=table_dir)\n",
     "print(passband_group_rg)\n",
     "\n",
     "min_wave, max_wave = passband_group_rg.wave_bounds()\n",

--- a/docs/notebooks/pre_executed/plasticc_snia.ipynb
+++ b/docs/notebooks/pre_executed/plasticc_snia.ipynb
@@ -54,7 +54,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "da09419a-cf38-4d6f-b44c-e1110caaf541",
    "metadata": {
     "execution": {
@@ -130,8 +130,15 @@
     "print(f\"Loaded OpSim with {len(opsim_db)} rows and times [{t_min}, {t_max}]\")\n",
     "\n",
     "# Load the passband data for the griz filters only.\n",
+    "# Use a (possibly older) cached version of the passbands to avoid downloading them.\n",
+    "table_dir = \"../../tests/tdastro/data/passbands\"\n",
     "passband_group = PassbandGroup(\n",
-    "    preset=\"LSST\", filters_to_load=[\"g\", \"r\", \"i\", \"z\"], units=\"nm\", trim_quantile=0.001, delta_wave=1\n",
+    "    preset=\"LSST\",\n",
+    "    filters_to_load=[\"g\", \"r\", \"i\", \"z\"],\n",
+    "    units=\"nm\",\n",
+    "    trim_quantile=0.001,\n",
+    "    delta_wave=1,\n",
+    "    table_dir=table_dir,\n",
     ")\n",
     "print(f\"Loaded Passbands: {passband_group}\")"
    ]

--- a/tests/tdastro/sources/test_physical_models.py
+++ b/tests/tdastro/sources/test_physical_models.py
@@ -128,7 +128,7 @@ def test_physical_model_get_band_fluxes(passbands_dir):
     f_nu = np.random.lognormal()
     static_source = StaticSource(brightness=f_nu)
     state = static_source.sample_parameters()
-    passbands = PassbandGroup(preset="LSST")
+    passbands = PassbandGroup(preset="LSST", table_dir=passbands_dir)
     n_passbands = len(passbands)
 
     times = np.arange(n_passbands, dtype=float)


### PR DESCRIPTION
The github actions are failing because we have exceeded the number of allowed requests to download the LSST passband data. This PR fixes the problem by pulling data from local files in both the tests and notebooks (needed for the auto-build of documentation).
