### PR TITLE
Fix units for LSST preset

### DIFF
--- a/src/tdastro/astro_utils/passbands.py
+++ b/src/tdastro/astro_utils/passbands.py
@@ -263,6 +263,15 @@ class PassbandGroup:
         """
         logger.info(f"Loading passbands from preset {preset}")
         if preset == "LSST":
+            # Check that units are what is expected for this preset.
+            if "units" not in kwargs:
+                kwargs["units"] = "nm"
+            elif kwargs["units"] != "nm":
+                raise ValueError(
+                    "LSST passbands are expected to be in nanometers (nm). "
+                    "Please set units='nm' in the kwargs."
+                )
+
             if table_dir is None:
                 table_dir = Path(_TDASTRO_BASE_DATA_DIR, "passbands", "LSST")
             else:

--- a/tests/tdastro/astro_utils/test_passband_groups.py
+++ b/tests/tdastro/astro_utils/test_passband_groups.py
@@ -131,6 +131,16 @@ def test_passband_group_init(tmp_path, passbands_dir):
     assert "LSST_y" in lsst_passband_group
     assert "LSST_purple" not in lsst_passband_group
 
+    # Test that we fail if we use the wrong units for the LSST preset
+    with pytest.raises(ValueError):
+        _ = PassbandGroup(
+            preset="LSST",
+            table_dir=passbands_dir,
+            delta_wave=5.0,
+            trim_quantile=None,
+            units="A",
+        )
+
     # We can access passbands using the [] notation.
     assert lsst_passband_group["LSST_u"].filter_name == "u"
     with pytest.raises(KeyError):


### PR DESCRIPTION
The LSST data files are provided in nm.  This was not always manually specified in the notebooks.  So add a check and specify it if not units provided.