### PR TITLE
Provide alternate for NP's choice function

### DIFF
--- a/src/tdastro/math_nodes/given_sampler.py
+++ b/src/tdastro/math_nodes/given_sampler.py
@@ -80,8 +80,9 @@ class GivenValueSampler(NumpyRandomFunc):
 
     Attributes
     ----------
-    values : list or numpy.ndarray
-        The values to select from.
+    values : int, list, or numpy.ndarray
+        The values to select from. If an integer is provided, it is treated as a range
+        from 0 to that value - 1.
     _num_values : int
         The number of values that can be sampled.
     _weights : numpy.ndarray, optional
@@ -89,7 +90,10 @@ class GivenValueSampler(NumpyRandomFunc):
     """
 
     def __init__(self, values, weights=None, seed=None, **kwargs):
+        if isinstance(values, int):
+            values = np.arange(values)
         self.values = np.asarray(values)
+
         self._num_values = len(values)
         if self._num_values == 0:
             raise ValueError("No values provided for NumpySamplerNode")

--- a/src/tdastro/math_nodes/np_random.py
+++ b/src/tdastro/math_nodes/np_random.py
@@ -37,6 +37,8 @@ class NumpyRandomFunc(FunctionNode):
     and use that generator's functions, we cannot pass in the function directly.
     Instead we need to pass in the function's name.
 
+    The NumpyRandomFunc node does not support the `choice` function.
+
     Examples
     --------
     # Create a uniform random number generator between 100.0 and 150.0
@@ -48,6 +50,12 @@ class NumpyRandomFunc(FunctionNode):
 
     def __init__(self, func_name, size=1, seed=None, **kwargs):
         self.func_name = func_name
+
+        # The node does not support the 'choice' function since it cannot take a list of different
+        # lists to use for each sampling run (sample 1 chooses a value from list 1, sample 2 from
+        # list 2, etc.).
+        if func_name == "choice":
+            raise ValueError("The 'choice' function is not supported. Use GivenValueSampler instead.")
 
         # Convert the given size into a tuple of dimensions or None for a single value per sample.
         if size is None or size == 1:

--- a/tests/tdastro/math_nodes/test_given_sampler.py
+++ b/tests/tdastro/math_nodes/test_given_sampler.py
@@ -113,6 +113,19 @@ def test_given_value_sampler():
     assert len(results[results == 7]) > 1000
 
 
+def test_given_value_sampler_int():
+    """Test that we can retrieve numbers from a GivenValueSampler representing a range."""
+    given_node = GivenValueSampler(5)
+
+    # Check that we have sampled uniformly from the given options.
+    state = GraphState(num_samples=5_000)
+    results = given_node.compute(state)
+    assert len(results) == 5_000
+    assert np.all((results >= 0) & (results < 5))
+    for i in range(5):
+        assert len(results[results == i]) > 500
+
+
 def test_given_value_selector():
     """Test that we can retrieve numbers from a GivenValueSelector."""
     index_node = GivenValueList([0, 1, 2, 3, 2, 3, 1, 2], node_label="index_node")

--- a/tests/tdastro/math_nodes/test_np_random.py
+++ b/tests/tdastro/math_nodes/test_np_random.py
@@ -95,3 +95,9 @@ def test_numpy_random_given_rng():
     value1 = np_node1.generate(rng_info=np.random.default_rng(1))
     value2 = np_node2.generate(rng_info=np.random.default_rng(2))
     assert value1 != pytest.approx(value2)
+
+
+def test_numpy_choice_fails():
+    """Test that we cannot use NumpyRandomFunc with a choice distribution."""
+    with pytest.raises(ValueError):
+        NumpyRandomFunc("choice", a=5)


### PR DESCRIPTION
The choice function does not work as expected for the `NumpyRandomFunc` node. We raise an error to indicate that it is not a supported function and point the user to the `GivenValueSampler` node instead. This PR also extends the `GivenValueSampler` node to take an integer N to return a choice of [0, N-1)