### PR TITLE
Small documentation updates

### DIFF
--- a/docs/notebooks/adding_sources.ipynb
+++ b/docs/notebooks/adding_sources.ipynb
@@ -13,9 +13,17 @@
     "All sources are subclasses of the `PhysicalModel` class in `src/tdastro/sources/physical_models.py`. This class implements a bunch of helper functions to handle parameters and simulate the output of an object, but users only need to override two of them to create a new subclass:\n",
     "\n",
     "  * The `__init__()` method sets up the parameters.\n",
-    "  * The `compute_flux()` draws effect-free observations for the object.\n",
+    "  * The `compute_flux()` draws effect-free observations for the object in the object's rest frame.\n",
+    "\n",
+    "If the object has a redshift value, the `PhysicalModel` class takes care of accounting for the shift in both times and wavelengths from the observer's frame to the rest frame (and back). So each source only needs to worry about generating fluxes in their rest frame.\n",
+    "\n",
+    "Similarly effects are applied within the `PhysicalModel` helper functions, so you do not need to worry about calling them from `compute_flux()`.\n",
+    "\n",
+    "### Parameterization\n",
     "\n",
     "As discussed in the introduction_demo notebook, all nodes in TDAStro accept dynamic parameterization. These are parameters that change with each sampling run. For example if we have a node modeling the source's output as a sin wave, we may want to include two parameters: the peak `brightness` of the object and the `frequency` of the underlying wave.  We specify both of these parameters with the `ParameterizedNode`'s `add_parameter()` function. Behind the scenes this function does the heavy lifting to understand how the parameter is actually set during each run (from a constant, another `ParameterizedNode`, the computation of a function, etc.).\n",
+    "\n",
+    "### Example Model Node\n",
     "\n",
     "Consider the example below, which implements the sin wave model.  There are some details in the implementation below that we do not cover immediately (such as the `get_local_params()` function), but will describe below. "
    ]
@@ -80,7 +88,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As described above the `__init__()` function adds two parameters `brightness` and `frequency`. These are set from the input arguments of the same name, but, as we will see below, could be set by a variety of inputs. In each parameterized node inherits the parameters set by its parent node. For the `PhysicalModel` class this includes: `dec`, `distance`, `ra`, `redshift`, `t0`, and `white_noise_sigma`.\n",
+    "As described above, the `__init__()` function adds two parameters `brightness` and `frequency`. These are set from the input arguments of the same name, but, as we will see below, could be set by a variety of inputs. In each parameterized node inherits the parameters set by its parent node. For the `PhysicalModel` class this includes: `dec`, `distance`, `ra`, `redshift`, `t0`, and `white_noise_sigma`.\n",
     "\n",
     "We can create a model node and request information about its settable parameters."
    ]
@@ -103,7 +111,7 @@
     "\n",
     "Each `ParameterizedNode` is stateless by design, so it does **not** store the values for any of its parameters. Instead it stores information on how to get those values when sampled. Thus the `compute_flux()` function must take a `GraphState` object that contains the parameter information. This is usually generated with a call to `sample_parameters()`, but will also be automatically generated internally if the `evaluate()` function is called without this information.\n",
     "\n",
-    "As a natural consequence of this statelessness, the `compute_flux()` function needs to call `self.get_local_params(graph_state)` to extract the current' node's parameters from the `GraphState` object. This function returns a dictionary mapping the parameter's name to its value.\n",
+    "The `compute_flux()` function can use the `self.get_local_params(graph_state)` to extract the current node's parameters from the `GraphState` object. This function returns a dictionary mapping the parameter's name to its value.\n",
     "\n",
     "### Evaluating the Node\n",
     "\n",


### PR DESCRIPTION
Add a note to the documentation that new models do not need to implement redshift conversions themselves. This is already handled by the parent class.