### PR TITLE
Fix broken Salt2JAX model

### DIFF
--- a/src/tdastro/sources/salt2_jax.py
+++ b/src/tdastro/sources/salt2_jax.py
@@ -38,7 +38,7 @@ class SALT2JaxModel(PhysicalModel, CiteClass):
       * redshift - The object's redshift. [from PhysicalModel]
       * t0 - The t0 of the zero phase, date. [from PhysicalModel]
       * x0 - The SALT2 x0 parameter.
-      * x1 - The SALT2 x0 parameter.
+      * x1 - The SALT2 x1 parameter.
 
     References
     ----------
@@ -86,7 +86,6 @@ class SALT2JaxModel(PhysicalModel, CiteClass):
         x0=None,
         x1=None,
         c=None,
-        t0=0.0,
         model_dir="",
         m0_filename="salt2_template_0.dat",
         m1_filename="salt2_template_1.dat",

--- a/tests/tdastro/sources/test_salt2.py
+++ b/tests/tdastro/sources/test_salt2.py
@@ -30,6 +30,19 @@ def test_salt2_model_parity(test_data_dir):
     assert np.allclose(flux_td, flux_sn)
 
 
+def test_salt2_model_no_t0(test_data_dir):
+    """Test that the model fails if t0 is not provided, but redshift is."""
+    dir_name = test_data_dir / "truncated-salt2-h17"
+    td_model = SALT2JaxModel(x0=0.4, x1=0.3, c=1.1, redshift=0.1, model_dir=dir_name)
+
+    with pytest.raises(ValueError):
+        _ = td_model.evaluate(np.arange(-1.0, 15.0, 0.01), np.arange(3800.0, 4200.0, 0.5))
+
+    # The same models works if t0 is provided.
+    td_model = SALT2JaxModel(x0=0.4, x1=0.3, c=1.1, redshift=0.1, t0=0.0, model_dir=dir_name)
+    _ = td_model.evaluate(np.arange(-1.0, 15.0, 0.01), np.arange(3800.0, 4200.0, 0.5))
+
+
 def test_salt2_no_model(test_data_dir):
     """Test that we fail if using the wrong model directory."""
     dir_name = test_data_dir / "no_such_salt2_model_dir"


### PR DESCRIPTION
The `SALT2JaxModel` was failing when redshift != 0.0 because the `t0` parameter was not being passed along to the `PhysicalModel` constructor. By including `t0=0.0` in the argument list, that parameter was not included in `**kwargs` and hence not passed along. This PR fixes that and adds a corresponding test.