### PR TITLE
modified salt2jax model 

### DIFF
--- a/src/tdastro/sources/salt2_jax.py
+++ b/src/tdastro/sources/salt2_jax.py
@@ -145,12 +145,12 @@ class SALT2JaxModel(PhysicalModel, CiteClass):
         good_times = (times > t0 + -20.0 * (1.0 + z)) & (times < t0 + 50.0 * (1.0 + z))
         return good_times
 
-    def compute_flux(self, phase, wavelengths, graph_state, **kwargs):
+    def compute_flux(self, times, wavelengths, graph_state, **kwargs):
         """Draw effect-free observations for this object.
 
         Parameters
         ----------
-        phase : numpy.ndarray
+        times : numpy.ndarray
             A length T array of rest frame timestamps.
         wavelengths : numpy.ndarray, optional
             A length N array of wavelengths (in angstroms).
@@ -165,9 +165,12 @@ class SALT2JaxModel(PhysicalModel, CiteClass):
         flux_density : numpy.ndarray
             A length T x N matrix of SED values (in nJy).
         """
+
+        params = self.get_local_params(graph_state)
+        phase = times - params["t0"]
+
         m0_vals = self._m0_model(phase, wavelengths)
         m1_vals = self._m1_model(phase, wavelengths)
-        params = self.get_local_params(graph_state)
 
         flux_density = (
             params["x0"]

--- a/tests/tdastro/sources/test_salt2.py
+++ b/tests/tdastro/sources/test_salt2.py
@@ -11,17 +11,17 @@ def test_salt2_model_parity(test_data_dir):
     results as the sncosmo version.
     """
     dir_name = test_data_dir / "truncated-salt2-h17"
-    td_model = SALT2JaxModel(x0=0.4, x1=0.3, c=1.1, t0=0.0, model_dir=dir_name)
+    td_model = SALT2JaxModel(x0=0.4, x1=0.3, c=1.1, t0=10.0, model_dir=dir_name)
 
     # We need to overwrite the source parameter to correspond to
     # the truncated directory data.
-    sn_model = SncosmoWrapperModel("SALT2", x0=0.4, x1=0.3, c=1.1, t0=0.0)
+    sn_model = SncosmoWrapperModel("SALT2", x0=0.4, x1=0.3, c=1.1, t0=10.0)
     sn_model.source = SALT2Source(modeldir=dir_name)
 
     # Test compared to values computed via sncosmo's implementation that
     # fall within the range of the truncated grid. We multiple by 1e12
     # for comparison precision purposes.
-    times = np.arange(-1.0, 15.0, 0.01)
+    times = np.arange(-1.0, 15.0, 0.01) + 10.0
     waves = np.arange(3800.0, 4200.0, 0.5)
 
     # Allow TDAstro to return both sets of results in f_nu.


### PR DESCRIPTION
`SALT2JaxModel`'s `compute_flux()` was taking phase instead of times and was giving wrong values. updated to calculate phase from times, and updated tests to use non-zero t0. (Old tests did not fail because t0=0 so phase=times)