### PR TITLE
Add helpers for recreating a GraphState

### DIFF
--- a/docs/notebooks/introduction.ipynb
+++ b/docs/notebooks/introduction.ipynb
@@ -300,7 +300,7 @@
    "source": [
     "As shown each row in the `lightcurves` table includes all the information for that source and an embedded table containing the source's lightcurve according to the survey strategy.\n",
     "\n",
-    "Finally we can extract the parameters used to generate the source (the `GraphState`) from the \"params\" column:"
+    "Finally we can extract the parameters used to generate the source (the `GraphState` as a flattened dictionary) from the \"params\" column:"
    ]
   },
   {
@@ -310,6 +310,28 @@
    "outputs": [],
    "source": [
     "print(lightcurves.iloc[0].params)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can convert those flatten dictionaries back to the `GraphState` objects (which allows use to replay the simulation) using `from_dict` for a single state or `from_list` for multiple states:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from tdastro.graph_state import GraphState\n",
+    "\n",
+    "state_0 = GraphState.from_dict(lightcurves[\"params\"][0])\n",
+    "print(\"First sample: \", state_0)\n",
+    "\n",
+    "all_states = GraphState.from_list(lightcurves[\"params\"].values)\n",
+    "print(\"All samples: \", all_states)"
    ]
   },
   {

--- a/docs/notebooks/introduction.ipynb
+++ b/docs/notebooks/introduction.ipynb
@@ -316,7 +316,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can convert those flatten dictionaries back to the `GraphState` objects (which allows use to replay the simulation) using `from_dict` for a single state or `from_list` for multiple states:"
+    "We can convert those flattened dictionaries back to the `GraphState` objects (which allows us to replay the simulation) using `from_dict` for a single state or `from_list` for multiple states:"
    ]
   },
   {

--- a/src/tdastro/graph_state.py
+++ b/src/tdastro/graph_state.py
@@ -229,6 +229,20 @@ class GraphState:
         data_table = ascii.read(filename, format="ecsv")
         return GraphState.from_table(data_table)
 
+    def get_all_params_names(self):
+        """Get the full name of all the parameters.
+
+        Returns
+        -------
+        names : list
+            A list of all the parameter names.
+        """
+        names = []
+        for node_name, params in self.states.items():
+            for param_name in params:
+                names.append(self.extended_param_name(node_name, param_name))
+        return names
+
     def get_node_state(self, node_name, sample_num=0):
         """Get a dictionary of all parameters local to the given node
         for a single sample state.
@@ -453,7 +467,7 @@ class GraphState:
     def to_table(self):
         """Flatten the graph state to an AstroPy Table with columns for each parameter.
 
-        The column names are: {node_name}{separator}{param_name}
+        The column names are: {node_name}.{param_name}
 
         Returns
         -------
@@ -469,7 +483,7 @@ class GraphState:
     def to_dict(self):
         """Flatten the graph state to a dictionary with columns for each parameter.
 
-        The column names are: {node_name}{separator}{param_name}
+        The column names are: {node_name}.{param_name}
 
         Returns
         -------

--- a/src/tdastro/graph_state.py
+++ b/src/tdastro/graph_state.py
@@ -229,6 +229,40 @@ class GraphState:
         data_table = ascii.read(filename, format="ecsv")
         return GraphState.from_table(data_table)
 
+    @classmethod
+    def from_dict(cls, data, num_samples=1):
+        """Create a GraphState from either a flattened dictionary, where the keys of the
+        dictionary are {node_name}.{param_name}, or a nested dictionary, where
+        data[node_name][param_name] = value.
+
+        Parameters
+        ----------
+        data : dict
+            The dictionary mapping the parameter identifier (node name and parameter name)
+            to their values.
+        num_samples : int
+            The number of samples.
+            Default:  1
+
+        Returns
+        -------
+        GraphState
+            The corresponding graph state.
+        """
+        state = GraphState(num_samples=num_samples)
+        for id1, val1 in data.items():
+            if "." in id1:
+                # Handle the flattened array by splitting the key.
+                node_name, param_name = id1.split(".")
+                state.set(node_name, param_name, val1, force_copy=True, fixed=False)
+            elif isinstance(val1, dict):
+                # Handle the nested array by iterating over the second dictionary's entries.
+                for param_name, values in val1.items():
+                    state.set(id1, param_name, values, force_copy=True, fixed=False)
+            else:
+                raise ValueError("Input dictionary must either be flattened or nested.")
+        return state
+
     def get_all_params_names(self):
         """Get the full name of all the parameters.
 

--- a/src/tdastro/graph_state.py
+++ b/src/tdastro/graph_state.py
@@ -278,8 +278,8 @@ class GraphState:
         GraphState
             The corresponding graph state.
         """
-        if data is None or len(data) == 0:
-            raise ValueError("Cannot concatenate an empty list")
+        if len(data) == 0:
+            raise ValueError("Cannot concatenate an empty list.")
 
         # Convert everything into GraphStates (if they are not already) and extract
         # the basic information.

--- a/tests/tdastro/test_graph_state.py
+++ b/tests/tdastro/test_graph_state.py
@@ -258,6 +258,37 @@ def test_create_single_graph_state_from_nested_dict():
         _ = GraphState.from_dict(input, num_samples=2)
 
 
+def test_create_single_graph_state_from_list():
+    """Test that we can create a single GraphState from a list of states."""
+    state1 = GraphState(num_samples=1)
+    state1.set("a", "v1", 1.0)
+    state1.set("a", "v2", 2.0)
+    state1.set("b", "v1", 3.0)
+
+    state2 = GraphState(num_samples=2)
+    state2.set("a", "v1", [1.0, 2.0])
+    state2.set("a", "v2", [2.0, 3.0])
+    state2.set("b", "v1", [3.0, 4.0])
+
+    dict1 = {"a.v1": 10.0, "a.v2": 11.0, "b.v1": 12.0}
+    state = GraphState.from_list([state1, dict1, state2])
+
+    assert len(state) == 3
+    assert state.num_samples == 4
+    assert np.array_equal(state["a"]["v1"], [1.0, 10.0, 1.0, 2.0])
+    assert np.array_equal(state["a"]["v2"], [2.0, 11.0, 2.0, 3.0])
+    assert np.array_equal(state["b"]["v1"], [3.0, 12.0, 3.0, 4.0])
+
+    # We raise an error if we get a state with different parameters.
+    state_missing = GraphState.from_dict({"a.v1": 10.0, "a.v2": 11.0})
+    with pytest.raises(ValueError):
+        _ = GraphState.from_list([state1, dict1, state2, state_missing])
+
+    state_extra = GraphState.from_dict({"a.v1": 10.0, "a.v2": 11.0, "b.v1": 12.0, "c.v1": 12.0})
+    with pytest.raises(ValueError):
+        _ = GraphState.from_list([state1, dict1, state2, state_extra])
+
+
 def test_create_multi_sample_graph_state_reference():
     """Test that we can create and access a multi-sample GraphState with variables
     that were created from each other (with and without references)."""

--- a/tests/tdastro/test_graph_state.py
+++ b/tests/tdastro/test_graph_state.py
@@ -98,6 +98,50 @@ def test_create_single_sample_graph_state():
         _ = state.extract_single_sample(5)
 
 
+def test_create_single_graph_state_from_flattened_dict():
+    """Test that we can create a single GraphState from a flattened dictionary."""
+    input = {
+        "a.v1": 1.0,
+        "b.v1": 2.0,
+        "c.v3": 3.0,
+        "a.v2": 4.0,
+        "c.v2": 5.0,
+    }
+    state = GraphState.from_dict(input, num_samples=1)
+
+    assert len(state) == 5
+    assert state.num_samples == 1
+    assert state["a"]["v1"] == 1.0
+    assert state["b"]["v1"] == 2.0
+    assert state["c"]["v3"] == 3.0
+    assert state["a"]["v2"] == 4.0
+    assert state["c"]["v2"] == 5.0
+
+    # We can access a list of all the parameter names.
+    assert state.get_all_params_names() == ["a.v1", "a.v2", "b.v1", "c.v3", "c.v2"]
+
+
+def test_create_multiple_graph_state_from_nested_dict():
+    """Test that we can create a single GraphState from a nested dictionary."""
+    input = {
+        "a": {"v1": 1.0, "v2": 4.0},
+        "b": {"v1": 2.0},
+        "c": {"v3": 3.0, "v2": 5.0},
+    }
+    state = GraphState.from_dict(input, num_samples=1)
+
+    assert len(state) == 5
+    assert state.num_samples == 1
+    assert state["a"]["v1"] == 1.0
+    assert state["b"]["v1"] == 2.0
+    assert state["c"]["v3"] == 3.0
+    assert state["a"]["v2"] == 4.0
+    assert state["c"]["v2"] == 5.0
+
+    # We can access a list of all the parameter names.
+    assert state.get_all_params_names() == ["a.v1", "a.v2", "b.v1", "c.v3", "c.v2"]
+
+
 def test_graph_state_contains():
     """Test that we can use the 'in' operator in GraphState."""
     state = GraphState()
@@ -166,6 +210,52 @@ def test_create_multi_sample_graph_state():
     # Error if we send an array of the wrong length.
     with pytest.raises(ValueError):
         state.set("b", "v2", [-2.0, -2.5, -3.0, -3.5, -4.0, 1.0])
+
+
+def test_create_multi_graph_state_from_flattened_dict():
+    """Test that we can create a multi-sample GraphState from a flattened dictionary."""
+    input = {
+        "a.v1": [1.0, 2.0, 3.0],
+        "b.v1": [2.0, 4.0, 6.0],
+        "c.v3": [3.0, 6.0, 9.0],
+        "a.v2": [4.0, 3.0, 2.0],
+        "c.v2": [5.0, 5.0, 5.0],
+    }
+    state = GraphState.from_dict(input, num_samples=3)
+
+    assert len(state) == 5
+    assert state.num_samples == 3
+    assert np.array_equal(state["a"]["v1"], [1.0, 2.0, 3.0])
+    assert np.array_equal(state["a"]["v2"], [4.0, 3.0, 2.0])
+    assert np.array_equal(state["b"]["v1"], [2.0, 4.0, 6.0])
+    assert np.array_equal(state["c"]["v2"], [5.0, 5.0, 5.0])
+    assert np.array_equal(state["c"]["v3"], [3.0, 6.0, 9.0])
+
+    # We raise an error if we get the number of samples wrong.
+    with pytest.raises(ValueError):
+        _ = GraphState.from_dict(input, num_samples=4)
+
+
+def test_create_single_graph_state_from_nested_dict():
+    """Test that we can create a single GraphState from a nested dictionary."""
+    input = {
+        "a": {"v1": [1.0, 2.0, 3.0], "v2": [4.0, 3.0, 2.0]},
+        "b": {"v1": [2.0, 4.0, 6.0]},
+        "c": {"v3": [3.0, 6.0, 9.0], "v2": [5.0, 5.0, 5.0]},
+    }
+    state = GraphState.from_dict(input, num_samples=3)
+
+    assert len(state) == 5
+    assert state.num_samples == 3
+    assert np.array_equal(state["a"]["v1"], [1.0, 2.0, 3.0])
+    assert np.array_equal(state["a"]["v2"], [4.0, 3.0, 2.0])
+    assert np.array_equal(state["b"]["v1"], [2.0, 4.0, 6.0])
+    assert np.array_equal(state["c"]["v2"], [5.0, 5.0, 5.0])
+    assert np.array_equal(state["c"]["v3"], [3.0, 6.0, 9.0])
+
+    # We raise an error if we get the number of samples wrong.
+    with pytest.raises(ValueError):
+        _ = GraphState.from_dict(input, num_samples=2)
 
 
 def test_create_multi_sample_graph_state_reference():

--- a/tests/tdastro/test_graph_state.py
+++ b/tests/tdastro/test_graph_state.py
@@ -32,6 +32,9 @@ def test_create_single_sample_graph_state():
     with pytest.raises(KeyError):
         _ = state["a.v1.v2"]
 
+    # We can access a list of all the parameter names.
+    assert state.get_all_params_names() == ["a.v1", "a.v2", "b.v1"]
+
     # We can create a human readable string representation of the GraphState.
     debug_str = str(state)
     assert debug_str == "a:\n    v1: 1.0\n    v2: 2.0\nb:\n    v1: 3.0"
@@ -137,6 +140,9 @@ def test_create_multi_sample_graph_state():
     assert np.allclose(state["a"]["v1"], [1.0, 1.0, 1.0, 1.0, 1.0])
     assert np.allclose(state["a"]["v2"], [2.0, 2.5, 3.0, 3.5, 4.0])
     assert np.allclose(state["b"]["v1"], [-2.0, -2.5, -3.0, -3.5, -4.0])
+
+    # We can access a list of all the parameter names.
+    assert state.get_all_params_names() == ["a.v1", "a.v2", "b.v1"]
 
     # Check tht we can get all the values for a specific node and sample.
     a_vals = state.get_node_state("a")

--- a/tests/tdastro/test_graph_state.py
+++ b/tests/tdastro/test_graph_state.py
@@ -9,6 +9,7 @@ def test_create_single_sample_graph_state():
     state = GraphState()
     assert len(state) == 0
     assert state.num_samples == 1
+    assert state.get_all_params_names() == []
 
     state.set("a", "v1", 1.0)
     state.set("a", "v2", 2.0)
@@ -140,6 +141,10 @@ def test_create_multiple_graph_state_from_nested_dict():
 
     # We can access a list of all the parameter names.
     assert state.get_all_params_names() == ["a.v1", "a.v2", "b.v1", "c.v3", "c.v2"]
+
+    # Fail is we use nested names (no separator), but do not have dictionaries.
+    with pytest.raises(ValueError):
+        GraphState.from_dict({"a": 1, "b": 2}, num_samples=1)
 
 
 def test_graph_state_contains():
@@ -287,6 +292,14 @@ def test_create_single_graph_state_from_list():
     state_extra = GraphState.from_dict({"a.v1": 10.0, "a.v2": 11.0, "b.v1": 12.0, "c.v1": 12.0})
     with pytest.raises(ValueError):
         _ = GraphState.from_list([state1, dict1, state2, state_extra])
+
+    # Fail on invalid list item.
+    with pytest.raises(TypeError):
+        _ = GraphState.from_list([state1, dict1, state2, 1.0])
+
+    # Fail on empty list.
+    with pytest.raises(ValueError):
+        _ = GraphState.from_list([])
 
 
 def test_create_multi_sample_graph_state_reference():

--- a/tests/tdastro/test_simulate.py
+++ b/tests/tdastro/test_simulate.py
@@ -1,5 +1,6 @@
 import numpy as np
 from tdastro.astro_utils.passbands import PassbandGroup
+from tdastro.graph_state import GraphState
 from tdastro.math_nodes.given_sampler import GivenValueList
 from tdastro.opsim.opsim import OpSim
 from tdastro.simulate import simulate_lightcurves
@@ -53,6 +54,13 @@ def test_simulate_lightcurves(test_data_dir):
         # Check that we extract one of the parameters.
         assert results["source_brightness"][idx] == given_brightness[idx]
 
+    # Check that we saved and can reassemble the GraphStates
+    assert "params" in results
+    state = GraphState.from_list(results["params"].values)
+    assert state.num_samples == 5
+    assert np.allclose(state["source.ra"], opsim_db["ra"].values[0:5])
+    assert np.allclose(state["source.dec"], opsim_db["dec"].values[0:5])
+
 
 def test_simulate_single_lightcurve(test_data_dir):
     """Test an end to end run of simulating a single lightcurves."""
@@ -87,3 +95,10 @@ def test_simulate_single_lightcurve(test_data_dir):
         param_cols=["source.brightness"],
     )
     assert len(results) == 1
+
+    # Check that we saved and can reassemble the GraphStates
+    assert "params" in results
+    state = GraphState.from_list(results["params"].values)
+    assert state.num_samples == 1
+    assert state["source.ra"] == opsim_db["ra"].values[0]
+    assert state["source.dec"] == opsim_db["dec"].values[0]


### PR DESCRIPTION
Closes #371 

Add helpers to recreate a `GraphState` object from the dictionaries that we store in the output table.