### PR TITLE
Remove references to background model

### DIFF
--- a/src/tdastro/sources/lightcurve_source.py
+++ b/src/tdastro/sources/lightcurve_source.py
@@ -404,12 +404,8 @@ class BaseLightcurveSource(BandfluxModel, ABC):
         self.all_waves = passbands.waves
         self.sed_values = self._create_sed_basis(self.filters, passbands)
 
-        # Override some of the defaults of PhysicalModel. Never apply redshift and
-        # do not allow background models.
+        # Never apply redshift.
         self.apply_redshift = False
-        if "background" in kwargs:
-            raise ValueError("Lightcurve models do not support background models.")
-        self.background = None
 
         # Check that t0 is set.
         if "t0" not in kwargs or kwargs["t0"] is None:

--- a/src/tdastro/sources/multi_source_model.py
+++ b/src/tdastro/sources/multi_source_model.py
@@ -126,8 +126,7 @@ class MultiSourceModel(PhysicalModel):
         graph_state : GraphState
             An object mapping graph parameters to their values.
         """
-        # If the graph has not been sampled ever, update the node positions for
-        # every node (model, background, effects).
+        # If the graph has not been sampled ever, update the node positions for every node.
         if self.node_pos is None:
             self.set_graph_positions()
 

--- a/src/tdastro/sources/physical_model.py
+++ b/src/tdastro/sources/physical_model.py
@@ -424,8 +424,7 @@ class PhysicalModel(ParameterizedNode):
         graph_state : GraphState
             An object mapping graph parameters to their values.
         """
-        # If the graph has not been sampled ever, update the node positions for
-        # every node (model, background, effects).
+        # If the graph has not been sampled ever, update the node positions for every node.
         if self.node_pos is None:
             self.set_graph_positions()
 
@@ -519,12 +518,8 @@ class BandfluxModel(PhysicalModel, ABC):
         super().__init__(*args, **kwargs)
         self.band_pass_effects = []
 
-        # Override some of the defaults of PhysicalModel. Never apply redshift and
-        # do not allow background models.
+        # Never apply redshift.
         self.apply_redshift = False
-        if "background" in kwargs:
-            raise ValueError("Lightcurve models do not support background models.")
-        self.background = None
 
     def set_apply_redshift(self, apply_redshift):
         """Toggles the apply_redshift setting.


### PR DESCRIPTION
We removed background models a while back (and instead use `AdditiveMultiSourceModel`). But we left in some of the (now unneeded) checks that background model is not set. This cleans those up.
