### PR TITLE
Add a constant bandflux model

### DIFF
--- a/src/tdastro/sources/static_sed_source.py
+++ b/src/tdastro/sources/static_sed_source.py
@@ -1,9 +1,9 @@
-"""Models that generate the a constant SED or at all times."""
+"""Models that generate a constant SED or bandflux at all times."""
 
 import numpy as np
 
 from tdastro.math_nodes.given_sampler import GivenValueSampler
-from tdastro.sources.physical_model import PhysicalModel
+from tdastro.sources.physical_model import BandfluxModel, PhysicalModel
 
 
 class StaticSEDSource(PhysicalModel):
@@ -137,3 +137,80 @@ class StaticSEDSource(PhysicalModel):
         # We repeat the interpolated SED values at each time.
         flux_density = np.tile(sed_fluxes, num_times).reshape(num_times, num_waves)
         return flux_density
+
+
+class StaticBandfluxSource(BandfluxModel):
+    """A StaticBandfluxSource randomly selects a mapping of bandfluxes at each evaluation
+    and uses that at all time steps.
+
+    Parameterized values include:
+      * dec - The object's declination in degrees. [from PhysicalModel]
+      * distance - The object's luminosity distance in pc. [from PhysicalModel]
+      * ra - The object's right ascension in degrees. [from PhysicalModel]
+      * redshift - The object's redshift. [from PhysicalModel]
+      * t0 - The t0 of the zero phase, date. [from PhysicalModel. Not used.]
+
+    Attributes
+    ----------
+    bandflux_values : list of dict
+       A list of bandflux mappings from which to sample. Each mapping is represented as a
+       dictionary where the key is the filter name and the value is the bandflux (in nJy).
+
+    Parameters
+    ----------
+    bandflux_values : dict or list
+       A single bandflux mapping or a list of bandflux mappings from which to sample. Each mapping is
+       represented as a dictionary where the key is the filter name and the value is the bandflux (in nJy).
+    weights : numpy.ndarray, optional
+        A length N array indicating the relative weight from which to select
+        a source at random. If None, all sources will be weighted equally.
+    """
+
+    def __init__(
+        self,
+        bandflux_values,
+        weights=None,
+        **kwargs,
+    ):
+        # If only a single bandflux mapping was passed, then put it in a list by itself.
+        if isinstance(bandflux_values, dict):
+            self.bandflux_values = [bandflux_values]
+        else:
+            self.bandflux_values = bandflux_values
+
+        super().__init__(**kwargs)
+
+        # Create a parameter that indicates which bandflux mapping was sampled in each simulation.
+        source_inds = [i for i in range(len(self.bandflux_values))]
+        self._sampler_node = GivenValueSampler(source_inds, weights=weights)
+        self.add_parameter("selected_idx", value=self._sampler_node, allow_gradient=False)
+
+    def __len__(self):
+        """Get the number of lightcurves."""
+        return len(self.bandflux_values)
+
+    def compute_bandflux(self, times, filters, state, rng_info=None):
+        """Evaluate the model at the passband level for a single, given graph state.
+
+        Parameters
+        ----------
+        times : numpy.ndarray
+            A length T array of observer frame timestamps in MJD.
+        filters : numpy.ndarray
+            A length T array of filter names.
+        state : GraphState
+            An object mapping graph parameters to their values with num_samples=1.
+        rng_info : numpy.random._generator.Generator, optional
+            A given numpy random number generator to use for this computation. If not
+            provided, the function uses the node's random number generator.
+        """
+        # Get the selected bandflux mapping index and values.
+        model_ind = self.get_param(state, "selected_idx")
+        model_bandflux = self.bandflux_values[model_ind]
+
+        # Fill in the bandflux values corresponding to the filter at each time.
+        bandflux = np.zeros(len(times), dtype=float)
+        for filter in np.unique(filters):
+            filter_mask = filters == filter
+            bandflux[filter_mask] = model_bandflux[filter]
+        return bandflux

--- a/tests/tdastro/sources/test_static_sed_source.py
+++ b/tests/tdastro/sources/test_static_sed_source.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
-from tdastro.sources.static_sed_source import StaticSEDSource
+from tdastro.astro_utils.passbands import Passband, PassbandGroup
+from tdastro.sources.static_sed_source import StaticBandfluxSource, StaticSEDSource
 
 
 def test_single_static_sed() -> None:
@@ -127,3 +128,65 @@ def test_multiple_static_seds_min_max():
         _ = model.minwave()
     with pytest.raises(ValueError):
         _ = model.maxwave()
+
+
+def _create_toy_passbands() -> PassbandGroup:
+    """Create a toy passband group with three passbands where the first passband
+    has no overlap while the second two overlap each other for half the range.
+    """
+    a_band = Passband(np.array([[400, 0.5], [500, 0.5], [600, 0.5]]), "LSST", "u")
+    b_band = Passband(np.array([[800, 0.8], [900, 0.8], [1000, 0.8]]), "LSST", "g")
+    c_band = Passband(np.array([[900, 0.6], [1000, 0.6], [1100, 0.6]]), "LSST", "r")
+    d_band = Passband(np.array([[900, 0.6], [1000, 0.6], [1100, 0.6]]), "LSST", "b")
+    return PassbandGroup(given_passbands=[a_band, b_band, c_band, d_band])
+
+
+def test_single_static_bandflux() -> None:
+    """Test that we can create and sample a StaticBandfluxSource object with a single bandflux."""
+    pb_group = _create_toy_passbands()
+    bandflux = {
+        "r": 10.0,
+        "g": 20.0,
+        "b": 30.0,
+    }
+    model = StaticBandfluxSource(bandflux, node_label="test")
+    assert len(model) == 1
+
+    times = np.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+    filters = ["r", "r", "g", "b", "r", "g", "b", "g", "b", "r"]
+    expected = np.array([10.0, 10.0, 20.0, 30.0, 10.0, 20.0, 30.0, 20.0, 30.0, 10.0])
+
+    state = model.sample_parameters(num_samples=1)
+    fluxes = model.get_band_fluxes(pb_group, times, filters, state)
+    assert len(fluxes) == 10
+    assert np.array_equal(fluxes, expected)
+
+
+def test_multiple_static_bandflux() -> None:
+    """Test that we can create and sample a StaticBandfluxSource object with multiple bandfluxes."""
+    pb_group = _create_toy_passbands()
+    bandflux0 = {"r": 10.0, "g": 20.0, "b": 30.0}
+    bandflux1 = {"r": 15.0, "g": 25.0, "b": 35.0}
+    model = StaticBandfluxSource([bandflux0, bandflux1], weights=[0.25, 0.75], node_label="test")
+    assert len(model) == 2
+
+    # Check that all of the indices are 0 or 1 and the split is approximately 25/75
+    params = model.sample_parameters(num_samples=10_000)
+    inds_0 = params["test"]["selected_idx"] == 0
+    inds_1 = params["test"]["selected_idx"] == 1
+    assert np.all(inds_0 | inds_1)
+    assert 1_500 < np.count_nonzero(inds_0) < 3_500
+    assert 6_500 < np.count_nonzero(inds_1) < 8_500
+
+    times = np.array([1, 2, 3, 4, 5])
+    filters = ["r", "r", "g", "b", "r"]
+    expected0 = np.array([10.0, 10.0, 20.0, 30.0, 10.0])
+    expected1 = np.array([15.0, 15.0, 25.0, 35.0, 15.0])
+
+    fluxes = model.get_band_fluxes(pb_group, times, filters, params)
+    assert fluxes.shape == (10_000, 5)
+    for idx in range(10_000):
+        if inds_0[idx]:
+            assert np.array_equal(fluxes[idx], expected0)
+        else:
+            assert np.array_equal(fluxes[idx], expected1)


### PR DESCRIPTION
Create a version of the `StaticSEDSource` that works at the bandflux level. This could be done using the current `LightcurveSource`, but this implementation is more efficient. The main motivation is two fold: 1) creating constant "stars" where we just have bandflux level data and 2) add another helper for testing.