### PR TITLE
Make VBMicrolensing an optional dependency

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -74,6 +74,11 @@ You can install TDAstro from PyPI with pip or from conda-forge with conda. We re
           >> # Install from conda-forge channel
           >> conda install conda-forge::tdastro
 
+Since TDAstro relies on a large number of existing packages, not all of the packages
+are installed in the default configuration. For example the microlensing package
+(`VBMicrolensing`) is not included by default. If you try to import a module that is
+not installed, TDAstro will raise an ImportError with information on which packages
+you need to install. You will need to install these manually.
 
 See our selection of :doc:`tutorial notebooks <notebooks>` for usage examples.
 We recommend starting with the :doc:`introduction notebook <notebooks/introduction>`

--- a/docs/notebooks/microlensing.ipynb
+++ b/docs/notebooks/microlensing.ipynb
@@ -7,7 +7,9 @@
    "source": [
     "# Microlensing Effect Example\n",
     "\n",
-    "In this notebook we look at how we can apply a simple microlensing effect that wraps the [VBMicrolensing package](https://github.com/valboz/VBMicrolensing)."
+    "In this notebook we look at how we can apply a simple microlensing effect that wraps the [VBMicrolensing package](https://github.com/valboz/VBMicrolensing).  \n",
+    "\n",
+    "Note that the VBMicrolensing package is not installed as part of the default TDAstro installation. Users will need to manually install VBMicrolensing via pip (e.g. `pip install VBMicrolensing`) in order to run this notebook."
    ]
   },
   {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ dependencies = [
     "pzflow",
     "scipy",
     "sncosmo",
-    "VBMicrolensing",
 ]
 
 [project.urls]
@@ -47,6 +46,10 @@ dev = [
     "pytest",
     "pytest-cov", # Used to report total code coverage
     "ruff", # Used for static linting of files
+    "VBMicrolensing",  # used for microlensing tests
+]
+microlensing = [
+    "VBMicrolensing",  # used for microlensing tests
 ]
 
 [build-system]

--- a/src/tdastro/effects/microlensing.py
+++ b/src/tdastro/effects/microlensing.py
@@ -1,7 +1,15 @@
 """An effect that adds microlensing magnification."""
 
 import numpy as np
-import VBMicrolensing
+
+try:
+    import VBMicrolensing
+except ImportError as err:
+    raise ImportError(
+        "VBMicrolensing package is not installed be default. To use the microlensing effect, "
+        "please install it. For example, you can install it with `pip install VBMicrolensing`."
+    ) from err
+
 from citation_compass import CiteClass
 
 from tdastro.effects.effect_model import EffectModel

--- a/tests/tdastro/effects/test_microlensing.py
+++ b/tests/tdastro/effects/test_microlensing.py
@@ -1,8 +1,17 @@
 import numpy as np
-from tdastro.effects.microlensing import Microlensing
+import pytest
 from tdastro.sources.basic_sources import StaticSource
 
+try:
+    from tdastro.effects.microlensing import Microlensing
+except ImportError:
+    # If the microlensing effect is not available, we skip the tests.
+    _skip_microlensing_tests = True
+else:
+    _skip_microlensing_tests = False
 
+
+@pytest.mark.skipif(_skip_microlensing_tests, reason="Microlensing package not available")
 def test_microlensing() -> None:
     """Test that we can apply a basic microlensing effect."""
     num_times = 50
@@ -33,6 +42,7 @@ def test_microlensing() -> None:
         assert np.all(np.diff(values[5:num_times, wave_idx]) <= 0)
 
 
+@pytest.mark.skipif(_skip_microlensing_tests, reason="Microlensing package not available")
 def test_microlensing_bandflux() -> None:
     """Test that we can apply a basic microlensing effect at the bandflux level."""
     num_times = 50
@@ -61,6 +71,7 @@ def test_microlensing_bandflux() -> None:
     assert np.all(np.diff(values[5:num_times]) <= 0)
 
 
+@pytest.mark.skipif(_skip_microlensing_tests, reason="Microlensing package not available")
 def test_static_source_microlensing() -> None:
     """Test that we can apply microlensing to a StaticSource."""
     num_times = 50


### PR DESCRIPTION
VBMicrolensing is not currently available on conda-forge, so we make it an optional dependency and skip the its tests if it is not installed. Note that the github actions, including the precommit are updated to force its installation, so those github tests should always be run.