### PR TITLE
Reorganize get_band_fluxes

### DIFF
--- a/src/tdastro/sources/physical_model.py
+++ b/src/tdastro/sources/physical_model.py
@@ -14,7 +14,7 @@ from os import urandom
 
 import numpy as np
 
-from tdastro.astro_utils.passbands import Passband
+from tdastro.astro_utils.passbands import Passband, PassbandGroup
 from tdastro.astro_utils.redshift import RedshiftDistFunc, obs_to_rest_times_waves, rest_to_obs_flux
 from tdastro.base_models import ParameterizedNode
 from tdastro.graph_state import GraphState
@@ -162,7 +162,7 @@ class PhysicalModel(ParameterizedNode):
         """
         self.apply_redshift = apply_redshift
 
-    def add_effect(self, effect):
+    def add_effect(self, effect, skip_params=False):
         """Add an effect to the model. This effect will be applied to all
         fluxes densities simulated by the model.
 
@@ -173,11 +173,17 @@ class PhysicalModel(ParameterizedNode):
         ----------
         effect : EffectModel
             The effect to add.
+        skip_params : bool
+            Skip adding the parameters to the model. This should only be done
+            in very limited cases where the parameters are added via another mechanism.
+            Most users should NOT change this setting.
+            Default: False
         """
         # Add any effect parameters that are not already in the model.
-        for param_name, setter in effect.parameters.items():
-            if param_name not in self.setters:
-                self.add_parameter(param_name, setter, allow_gradient=False)
+        if not skip_params:
+            for param_name, setter in effect.parameters.items():
+                if param_name not in self.setters:
+                    self.add_parameter(param_name, setter, allow_gradient=False)
 
         # Add the effect to the appropriate list.
         if effect.rest_frame:
@@ -400,6 +406,17 @@ class PhysicalModel(ParameterizedNode):
                 given_args=given_args, num_samples=1, rng_info=rng_info, **kwargs
             )
 
+        # If we only have a single sample, do not bother to iterate through the states.
+        if graph_state.num_samples == 1:
+            return self._evaluate_single(
+                times,
+                wavelengths,
+                graph_state,
+                rng_info=rng_info,
+                **kwargs,
+            )
+
+        # Iterate through each graph state computing the flux for each sample.
         results = np.empty((graph_state.num_samples, len(times), len(wavelengths)))
         for sample_num, state in enumerate(graph_state):
             # Compute the flux (handling redshift and applying all effects)
@@ -411,9 +428,6 @@ class PhysicalModel(ParameterizedNode):
                 rng_info=rng_info,
                 **kwargs,
             )
-
-        if graph_state.num_samples == 1:
-            return results[0, :, :]
         return results
 
     def sample_parameters(self, given_args=None, num_samples=1, rng_info=None):
@@ -455,6 +469,41 @@ class PhysicalModel(ParameterizedNode):
 
         return graph_state
 
+    def _get_band_fluxes_single(self, passband_group, times, filters, state, rng_info=None) -> np.ndarray:
+        """Get the band fluxes for a given PassbandGroup and a single, given graph state.
+
+        Parameters
+        ----------
+        passband_group : PassbandGroup
+            The passband group to use.
+        times : numpy.ndarray
+            A length T array of observer frame timestamps in MJD.
+        filters : numpy.ndarray
+            A length T array of filter names.
+        state : GraphState
+            An object mapping graph parameters to their values.
+        rng_info : numpy.random._generator.Generator, optional
+            A given numpy random number generator to use for this computation. If not
+            provided, the function uses the node's random number generator.
+
+        Returns
+        -------
+        band_fluxes : numpy.ndarray
+            A length T array of band fluxes for this sample.
+        """
+        band_fluxes = np.empty(len(times))
+        for filter_name in np.unique(filters):
+            # Compute the band fluxes for the times at which this filter is used.
+            passband = passband_group[filter_name]
+            filter_mask = filters == filter_name
+
+            # Compute the spectral fluxes at the same wavelengths used to define the passband.
+            # The evaluate function applies all effects (rest and observation frame) for the source
+            # as well as handling all the redshift conversions.
+            spectral_fluxes = self.evaluate(times[filter_mask], passband.waves, state, rng_info=rng_info)
+            band_fluxes[filter_mask] = passband.fluxes_to_bandflux(spectral_fluxes)
+        return band_fluxes
+
     def get_band_fluxes(self, passband_or_group, times, filters, state, rng_info=None) -> np.ndarray:
         """Get the band fluxes for a given Passband or PassbandGroup.
 
@@ -480,34 +529,39 @@ class PhysicalModel(ParameterizedNode):
             then returns a length T array. Otherwise returns a size S x T array where S is the
             number of samples in the graph state.
         """
-        if isinstance(passband_or_group, Passband):
-            if filters is not None and not np.all(filters == passband_or_group.filter_name):
-                raise ValueError(
-                    "If passband_or_group is a Passband, filters must either be None "
-                    "or a list where every entry matches the given filter's name: "
-                    f"{passband_or_group.filter_name}."
-                )
+        # Check if we need to sample the graph.
+        if state is None:
+            state = self.sample_parameters(num_samples=1, rng_info=rng_info)
 
-            # Compute the spectral fluxes at the same wavelengths used to define the passband.
-            spectral_fluxes = self.evaluate(times, passband_or_group.waves, state, rng_info=rng_info)
-            return passband_or_group.fluxes_to_bandflux(spectral_fluxes)
+        if isinstance(passband_or_group, Passband):
+            # If we are just given a passband, turn it into a passband group and save
+            # the list of the filter name (repeated).
+            passband_group = PassbandGroup([passband_or_group])
+            if filters is None:
+                filters = np.full(len(times), passband_or_group.filter_name)
+        else:
+            # This could be a PassbandGroup or (in limited cases) None.
+            passband_group = passband_or_group
 
         if filters is None:
             raise ValueError("If passband_or_group is a PassbandGroup, filters must be provided.")
         filters = np.asarray(filters)
 
-        band_fluxes = np.empty((state.num_samples, len(times)))
-        for filter_name in np.unique(filters):
-            # Compute the band fluxes for the times at which this filter is used.
-            passband = passband_or_group[filter_name]
-            filter_mask = filters == filter_name
-
-            # Compute the spectral fluxes at the same wavelengths used to define the passband.
-            spectral_fluxes = self.evaluate(times[filter_mask], passband.waves, state, rng_info=rng_info)
-            band_fluxes[:, filter_mask] = passband.fluxes_to_bandflux(spectral_fluxes)
-
+        # If we only have a single sample, we can return the band fluxes directly.
         if state.num_samples == 1:
-            return band_fluxes[0, :]
+            return self._get_band_fluxes_single(passband_group, times, filters, state, rng_info=rng_info)
+
+        # Fill in the band fluxes one at a time and return them all.
+        band_fluxes = np.empty((state.num_samples, len(times)))
+        for sample_num, current_state in enumerate(state):
+            current_fluxes = self._get_band_fluxes_single(
+                passband_group,
+                times,
+                filters,
+                current_state,
+                rng_info=rng_info,
+            )
+            band_fluxes[sample_num, :] = current_fluxes[np.newaxis, :]
         return band_fluxes
 
 
@@ -547,18 +601,24 @@ class BandfluxModel(PhysicalModel, ABC):
         """
         raise NotImplementedError("Lightcurve models do not support apply_redshift.")
 
-    def add_effect(self, effect):
+    def add_effect(self, effect, skip_params=False):
         """Add an effect to the model.
 
         Parameters
         ----------
         effect : EffectModel
             The effect to add.
+        skip_params : bool
+            Skip adding the parameters to the model. This should only be done
+            in very limited cases where the parameters are added via another mechanism.
+            Most users should NOT change this setting.
+            Default: False
         """
         # Add any effect parameters that are not already in the model.
-        for param_name, setter in effect.parameters.items():
-            if param_name not in self.setters:
-                self.add_parameter(param_name, setter, allow_gradient=False)
+        if not skip_params:
+            for param_name, setter in effect.parameters.items():
+                if param_name not in self.setters:
+                    self.add_parameter(param_name, setter, allow_gradient=False)
 
         # Add the effect to the band pass effects list.
         self.band_pass_effects.append(effect)
@@ -584,24 +644,17 @@ class BandfluxModel(PhysicalModel, ABC):
         """
         raise NotImplementedError
 
-    def get_band_fluxes(self, passband_or_group, times, filters, state, rng_info=None):
-        """Get the band fluxes for a given Passband or PassbandGroup.
-
-        Note
-        ----
-        This function does not compute SEDs and integrate them through the passbands, but
-        rather uses band fluxes directly.
+    def _get_band_fluxes_single(self, passband_group, times, filters, state, rng_info=None) -> np.ndarray:
+        """Get the band fluxes for a given PassbandGroup and a single, given graph state.
 
         Parameters
         ----------
-        passband_or_group : Passband or PassbandGroup.
-            The passband (or passband group) to use. For BandfluxModel based sources, this is
-            not used (since the model does not compute SEDs) and can safely be set to None.
+        passband_group : PassbandGroup
+            The passband group to use.
         times : numpy.ndarray
             A length T array of observer frame timestamps in MJD.
-        filters : numpy.ndarray or None
-            A length T array of filter names. It may be None if
-            passband_or_group is a Passband.
+        filters : numpy.ndarray
+            A length T array of filter names.
         state : GraphState
             An object mapping graph parameters to their values.
         rng_info : numpy.random._generator.Generator, optional
@@ -610,35 +663,20 @@ class BandfluxModel(PhysicalModel, ABC):
 
         Returns
         -------
-        band_fluxes : numpy.ndarray
-            A matrix of the band fluxes. If only one sample is provided in the GraphState,
-            then returns a length T array. Otherwise returns a size S x T array where S is the
-            number of samples in the graph state.
+        band_flux : numpy.ndarray
+            A length T array of band fluxes for this sample.
         """
-        if filters is None:
-            raise ValueError("A list of filters must be provided for BandfluxModel based sources.")
-        filters = np.asarray(filters)
+        params = self.get_local_params(state)
 
-        # Check if we need to sample the graph.
-        if state is None:
-            state = self.sample_parameters(num_samples=1, rng_info=rng_info)
-
-        results = np.empty((state.num_samples, len(times)))
-        for sample_num, current_state in enumerate(state):
-            params = self.get_local_params(current_state)
-
-            # Compute the flux (applying all effects) and save the result.
-            band_flux = self.compute_bandflux(times, filters, current_state, rng_info=rng_info)
-            for effect in self.band_pass_effects:
-                band_flux = effect.apply_bandflux(
-                    band_flux,
-                    times=times,
-                    filters=filters,
-                    rng_info=rng_info,
-                    **params,  # Provide all the node's parameters to the effect.
-                )
-            results[sample_num, :] = band_flux
-
-        if state.num_samples == 1:
-            return results[0, :]
-        return results
+        # Compute the flux (applying all effects) and save the result. Note that
+        # BandfluxModel do not apply redshift, so all effects are applied in observer frame.
+        band_fluxes = self.compute_bandflux(times, filters, state, rng_info=rng_info)
+        for effect in self.band_pass_effects:
+            band_fluxes = effect.apply_bandflux(
+                band_fluxes,
+                times=times,
+                filters=filters,
+                rng_info=rng_info,
+                **params,  # Provide all the node's parameters to the effect.
+            )
+        return band_fluxes

--- a/tests/tdastro/effects/test_basic_effects.py
+++ b/tests/tdastro/effects/test_basic_effects.py
@@ -46,7 +46,10 @@ def test_static_source_constant_dimming() -> None:
     assert len(model.rest_frame_effects) == 1
     assert len(model.obs_frame_effects) == 0
 
+    # Check that the flux_fraction parameter is stores in the source node.
     state = model.sample_parameters()
+    assert state["my_static_source"]["flux_fraction"] == 0.1
+
     times = np.array([1, 2, 3, 4, 5, 10])
     wavelengths = np.array([100.0, 200.0, 300.0])
     values = model.evaluate(times, wavelengths, state)
@@ -64,3 +67,20 @@ def test_static_source_constant_dimming() -> None:
     values2 = model2.evaluate(times, wavelengths, state2)
     assert values2.shape == (6, 3)
     assert np.all(values2 == 5.0)
+
+
+def test_static_source_constant_dimming_alt_params() -> None:
+    """Test that we can turn off adding parameters, but this will fail."""
+    model = StaticSource(brightness=10.0, node_label="my_static_source")
+    effect = ConstantDimming(flux_fraction=0.2)
+    model.add_effect(effect, skip_params=True)
+
+    # Check that we sample the value from source node.
+    state = model.sample_parameters()
+    print(state)
+    assert "flux_fraction" not in state["my_static_source"]
+
+    times = np.array([1, 2, 3, 4, 5, 10])
+    wavelengths = np.array([100.0, 200.0, 300.0])
+    with pytest.raises(ValueError):
+        _ = model.evaluate(times, wavelengths, state)

--- a/tests/tdastro/sources/test_physical_models.py
+++ b/tests/tdastro/sources/test_physical_models.py
@@ -138,7 +138,7 @@ def test_physical_model_get_band_fluxes(passbands_dir):
     with pytest.raises(ValueError):
         _band_fluxes = static_source.get_band_fluxes(passbands, times=times, filters=None, state=state)
     # It should fail if single passband is provided, but with multiple filter names.
-    with pytest.raises(ValueError):
+    with pytest.raises(KeyError):
         _band_fluxes = static_source.get_band_fluxes(passbands.passbands["LSST_r"], times, filters, state)
 
     band_fluxes = static_source.get_band_fluxes(passbands, times, filters, state)


### PR DESCRIPTION
Reorganize the `get_band_fluxes()` function so we can reuse more of the logic in `BandfluxModel`. This is a precursor change to expanding the support for various additive models.

Also allow effects to not propagate their parameters in case they are added via other mechanisms (also a precursor change). 