### PR TITLE
Fix broken benchmark

### DIFF
--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -242,7 +242,7 @@ class TimeSuite:
 
         # Sample the lightcurve source to ensure it works.
         graph_state = lc_source.sample_parameters(num_samples=100)
-        _ = lc_source.evaluate_band_fluxes(
+        _ = lc_source.evaluate_bandfluxes(
             self.passbands,
             self.times,
             ["r" for _ in range(len(self.times))],

--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -241,7 +241,13 @@ class TimeSuite:
         )
 
         # Sample the lightcurve source to ensure it works.
-        _ = lc_source.evaluate_sed(self.times, self.wavelengths)
+        graph_state = lc_source.sample_parameters(num_samples=100)
+        _ = lc_source.evaluate_band_fluxes(
+            self.passbands,
+            self.times,
+            ["r" for _ in range(len(self.times))],
+            graph_state,
+        )
 
     def time_additive_multi_model_source(self):
         """Time the creation and query of an AdditiveMultiSourceModel."""


### PR DESCRIPTION
Fix the broken test, which is failing because we removed `evaluate_sed()` from Bandflux models.