### PR TITLE
Create a more efficient mechanism for sampling from an ObsTable's coverage

### DIFF
--- a/docs/notebooks/opsim_notebook.ipynb
+++ b/docs/notebooks/opsim_notebook.ipynb
@@ -120,6 +120,29 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "We can create a Multi-Order Coverage Map (MOC) of the area covered by the `OpSim` (or any `ObsTable`) and plot its coverage on the sky."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "moc = ops_data.build_moc()\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "fig = plt.figure(figsize=(10, 10))\n",
+    "wcs = moc.wcs(fig)\n",
+    "ax = fig.add_subplot(projection=wcs)\n",
+    "moc.border(ax, wcs, color=\"blue\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Spatial Matching\n",
     "\n",
     "`OpSim` provides a framework for efficiently determining when an object was observed given its (RA, Dec). We use the `range_search()` function to retrieve all pointings within a given radius of the query point.\n",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "extinction>=0.4.7",  # Needed by sncosmo
     "jax",
     "matplotlib",
+    "mocpy",
     "nested-pandas",
     "numpy>2.0",
     "pandas",

--- a/src/tdastro/math_nodes/ra_dec_sampler.py
+++ b/src/tdastro/math_nodes/ra_dec_sampler.py
@@ -282,8 +282,8 @@ class ApproximateMOCSampler(NumpyRandomFunc):
         # Choose a starting pixel ID for each sample. Then randomly traverse
         # down the healpix tree by moving to one of the children pixels until
         # we reach level=29 (approximately 4.5 * 10^18 possible locations).
-        pixel_ids12 = rng.choice(self.moc, size=graph_state.num_samples).astype(np.uint64)
-        start_pixel_ids29 = np.left_shift(pixel_ids12, 2 * (29 - self.depth))
+        pixel_ids = rng.choice(self.moc, size=graph_state.num_samples).astype(np.uint64)
+        start_pixel_ids29 = np.left_shift(pixel_ids, 2 * (29 - self.depth))
         offset_range = np.uint64(1) << np.uint64(2 * (29 - self.depth))
         pixel_ids29 = start_pixel_ids29 + rng.integers(
             offset_range, size=graph_state.num_samples, dtype=np.uint64

--- a/src/tdastro/math_nodes/ra_dec_sampler.py
+++ b/src/tdastro/math_nodes/ra_dec_sampler.py
@@ -282,13 +282,15 @@ class ApproximateMOCSampler(NumpyRandomFunc):
         # Choose a starting pixel ID for each sample. Then randomly traverse
         # down the healpix tree by moving to one of the children pixels until
         # we reach level=29 (approximately 4.5 * 10^18 possible locations).
-        pixel_ids = rng.choice(self.moc, size=graph_state.num_samples).astype(np.uint64)
-        for _ in range(self.depth + 1, 30):
-            offset = np.floor(4 * rng.random(size=graph_state.num_samples)).astype(np.uint64)
-            pixel_ids = np.left_shift(pixel_ids, 2) + offset
+        pixel_ids12 = rng.choice(self.moc, size=graph_state.num_samples).astype(np.uint64)
+        start_pixel_ids29 = np.left_shift(pixel_ids12, 2 * (29 - self.depth))
+        offset_range = np.uint64(1) << np.uint64(2 * (29 - self.depth))
+        pixel_ids29 = start_pixel_ids29 + rng.integers(
+            offset_range, size=graph_state.num_samples, dtype=np.uint64
+        )
 
         # Convert back the healpix centers to RA and dec.
-        coords = healpix_to_skycoord(pixel_ids, depth=29)
+        coords = healpix_to_skycoord(pixel_ids29, depth=29)
         ra = coords.ra.deg
         dec = coords.dec.deg
 

--- a/src/tdastro/math_nodes/ra_dec_sampler.py
+++ b/src/tdastro/math_nodes/ra_dec_sampler.py
@@ -1,6 +1,7 @@
 """Samplers used for generating (RA, dec) coordinates."""
 
 import numpy as np
+from cdshealpix.nested import healpix_to_skycoord
 
 from tdastro.math_nodes.given_sampler import TableSampler
 from tdastro.math_nodes.np_random import NumpyRandomFunc
@@ -219,6 +220,77 @@ class ObsTableUniformRADECSampler(NumpyRandomFunc):
             mask = np.asarray(self.data.is_observed(ra, dec, self.radius))
             num_missing = np.sum(~mask)
             iter_num += 1
+
+        # If we are generating a single sample, return floats.
+        if graph_state.num_samples == 1:
+            ra = ra[0]
+            dec = dec[0]
+
+        # Set the outputs and return the results. This takes the place of
+        # function node's _save_results() function because we know the outputs.
+        graph_state.set(self.node_string, "ra", ra)
+        graph_state.set(self.node_string, "dec", dec)
+        return (ra, dec)
+
+
+class ApproximateMOCSampler(NumpyRandomFunc):
+    """A FunctionNode that samples RA and dec (approximately) from the coverage of
+    a Multi-Order Coverage Map.
+
+    Attributes
+    ----------
+    moc : MOC
+        The Multi-Order Coverage Map to use for sampling.
+    depth : int
+        The healpix depth to use as an approximation. Must be [2, 29].
+    """
+
+    def __init__(self, moc, *, outputs=None, seed=None, depth=12, **kwargs):
+        if depth < 2 or depth > 29:
+            raise ValueError("Depth must be [2, 29]. Received {depth}")
+        self.depth = depth
+        self.moc = moc.to_order(depth).flatten()
+
+        # Override key arguments. We create a uniform sampler function, but
+        # won't need it because the subclass overloads compute().
+        func_name = "uniform"
+        outputs = ["ra", "dec"]
+        super().__init__(func_name, outputs=outputs, seed=seed, **kwargs)
+
+    def compute(self, graph_state, rng_info=None, **kwargs):
+        """Return the given values.
+
+        Parameters
+        ----------
+        graph_state : GraphState
+            An object mapping graph parameters to their values. This object is modified
+            in place as it is sampled.
+        rng_info : numpy.random._generator.Generator, optional
+            A given numpy random number generator to use for this computation. If not
+            provided, the function uses the node's random number generator.
+        **kwargs : dict, optional
+            Additional function arguments.
+
+        Returns
+        -------
+        (ra, dec) : tuple of floats or np.ndarray
+            If a single sample is generated, returns a tuple of floats. Otherwise,
+            returns a tuple of np.ndarrays.
+        """
+        rng = rng_info if rng_info is not None else self._rng
+
+        # Choose a starting pixel ID for each sample. Then randomly traverse
+        # down the healpix tree by moving to one of the children pixels until
+        # we reach level=29 (approximately 4.5 * 10^18 possible locations).
+        pixel_ids = rng.choice(self.moc, size=graph_state.num_samples).astype(np.uint64)
+        for _ in range(self.depth + 1, 30):
+            offset = np.floor(4 * rng.random(size=graph_state.num_samples)).astype(np.uint64)
+            pixel_ids = np.left_shift(pixel_ids, 2) + offset
+
+        # Convert back the healpix centers to RA and dec.
+        coords = healpix_to_skycoord(pixel_ids, depth=29)
+        ra = coords.ra.deg
+        dec = coords.dec.deg
 
         # If we are generating a single sample, return floats.
         if graph_state.num_samples == 1:

--- a/src/tdastro/obstable/obs_table.py
+++ b/src/tdastro/obstable/obs_table.py
@@ -221,7 +221,7 @@ class ObsTable:
             raise KeyError("No filters column found in ObsTable.")
         return np.unique(self._table["filter"])
 
-    def build_moc(self, *, radius=None, max_depth=16):
+    def build_moc(self, *, radius=None, max_depth=12):
         """Build a Multi-Order Coverage Map from the regions in the data set.
 
         Parameters
@@ -230,7 +230,7 @@ class ObsTable:
             The radius to use for each image (in degrees). If not provided, the default
             radius from the survey values will be used.
         max_depth : int, optional
-            The maximum depth of the MOC. Default is 16.
+            The maximum depth of the MOC. Default is 12.
 
         Returns
         -------

--- a/src/tdastro/obstable/obs_table.py
+++ b/src/tdastro/obstable/obs_table.py
@@ -221,7 +221,7 @@ class ObsTable:
             raise KeyError("No filters column found in ObsTable.")
         return np.unique(self._table["filter"])
 
-    def build_moc(self, *, radius=None, max_depth=12):
+    def build_moc(self, *, radius=None, max_depth=10):
         """Build a Multi-Order Coverage Map from the regions in the data set.
 
         Parameters
@@ -230,7 +230,7 @@ class ObsTable:
             The radius to use for each image (in degrees). If not provided, the default
             radius from the survey values will be used.
         max_depth : int, optional
-            The maximum depth of the MOC. Default is 12.
+            The maximum depth of the MOC. Default is 10.
 
         Returns
         -------
@@ -248,6 +248,7 @@ class ObsTable:
             lat=latitudes,
             radius=radius * u.deg,
             max_depth=max_depth,
+            delta_depth=0,
             union_strategy="large_cones",
         )
         return moc

--- a/tests/tdastro/math_nodes/test_ra_dec_sampler.py
+++ b/tests/tdastro/math_nodes/test_ra_dec_sampler.py
@@ -178,3 +178,7 @@ def test_approximate_moc_sampler():
     assert np.all(ra[northern_mask] < 92.0)
     assert np.all(ra[~northern_mask] > 13.0)
     assert np.all(ra[~northern_mask] < 17.0)
+    assert np.all(dec[northern_mask] > 18.0)
+    assert np.all(dec[northern_mask] < 22.0)
+    assert np.all(dec[~northern_mask] > -22.0)
+    assert np.all(dec[~northern_mask] < -18.0)

--- a/tests/tdastro/obstable/test_obs_table.py
+++ b/tests/tdastro/obstable/test_obs_table.py
@@ -494,7 +494,7 @@ def test_build_moc():
 
     moc = ops_data.build_moc(radius=1.5)
     assert moc is not None
-    assert moc.max_order > 10
+    assert moc.max_order == 10
 
     # Test that the MOC covers the correct area.
     assert moc.contains_skycoords(SkyCoord(ra=10.0, dec=0.0, unit="deg"))

--- a/tests/tdastro/obstable/test_obs_table.py
+++ b/tests/tdastro/obstable/test_obs_table.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 import pytest
+from astropy.coordinates import SkyCoord
 from tdastro.obstable.obs_table import ObsTable
 
 
@@ -474,3 +475,34 @@ def test_read_obs_table_shorten(opsim_shorten):
     }
     ops_data = ObsTable.from_db(opsim_shorten, colmap=colmap)
     assert len(ops_data) == 100
+
+
+def test_build_moc():
+    """Test building a Multi-Order Coverage Map (MOC) from the ObsTable."""
+    # Create an ObsTable with three pointings.
+    values = {
+        "time": np.array([0.0, 1.0, 2.0]),
+        "ra": np.array([10.0, 11.0, 45.0]),
+        "dec": np.array([0.0, 0.0, -10.0]),
+        "zp": np.ones(3),
+    }
+    ops_data = ObsTable(values)
+
+    # We fail if no radius is given (including no default.)
+    with pytest.raises(ValueError):
+        _ = ops_data.build_moc()
+
+    moc = ops_data.build_moc(radius=1.5)
+    assert moc is not None
+    assert moc.max_order > 10
+
+    # Test that the MOC covers the correct area.
+    assert moc.contains_skycoords(SkyCoord(ra=10.0, dec=0.0, unit="deg"))
+    assert moc.contains_skycoords(SkyCoord(ra=11.0, dec=1.0, unit="deg"))
+    assert moc.contains_skycoords(SkyCoord(ra=10.5, dec=0.5, unit="deg"))
+    assert moc.contains_skycoords(SkyCoord(ra=45.0, dec=-10.0, unit="deg"))
+    assert moc.contains_skycoords(SkyCoord(ra=45.01, dec=-9.99, unit="deg"))
+    assert moc.contains_skycoords(SkyCoord(ra=44.98, dec=-10.01, unit="deg"))
+    assert not moc.contains_skycoords(SkyCoord(ra=46.00, dec=0.0, unit="deg"))
+    assert not moc.contains_skycoords(SkyCoord(ra=14.00, dec=0.0, unit="deg"))
+    assert not moc.contains_skycoords(SkyCoord(ra=52.00, dec=-10.0, unit="deg"))


### PR DESCRIPTION
Closes #416 

Instead of sampling from an survey's coverage using rejection sampling, provide an approach that creates a `MOC` from the `ObsTable` and then samples the `MOC`. This has the additional benefit that we can create MOCs that are the union or intersection of survey footprints.