### PR TITLE
Added full location of intro notebook in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The software package consists of multiple stages:
 4. Survey characteristics (such as cadence, filters, and noise).
 
 For an overview of the package, we recommend starting with introduction notebook 
-(at `notebooks/introduction.ipynb`).
+(at `docs/notebooks/introduction.ipynb`).
 
 
 ## Installation


### PR DESCRIPTION
Assuming the README is supposed to be in root, I believe the location is ```docs/notebooks/introduction.ipynb``` with respect to the root.

If that's not the case, feel free to delete this PR!