### PR TITLE
Add a node that can sample from Bilby

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "asv==0.6.4", # Used to compute performance benchmarks
+    "bilby",  # Used for Bayesian inference
     "fsspec[http]",  # Read OpSim file from the web with utils/make_opsim_shorten.py
     "jupyter", # Clears output from Jupyter notebooks
     "pre-commit", # Used to run checks before finalizing a git commit
@@ -54,6 +55,7 @@ dev = [
 # Install all the optional astro dependencies with `pip install '.[all]'`
 # (include the single quotes)
 all = [
+    "bilby",  # Used for Bayesian inference
     "pzflow",
     "sncosmo",
     "synphot",  # used for SED modeling tests

--- a/src/tdastro/math_nodes/bilby_priors.py
+++ b/src/tdastro/math_nodes/bilby_priors.py
@@ -10,13 +10,13 @@ class BilbyPriorNode(FunctionNode, CiteClass):
 
     Attributes
     ----------
-    prior : bilby.prior.Prior
+    prior : bilby.prior.PriorDict
         The Bilby prior object to sample from.
 
     Parameters
     ----------
-    prior : bilby.prior.Prior
-        The Bilby prior object to sample from.
+    prior : dict or bilby.prior.PriorDict
+        A dictionary mapping the names of the parameters to their prior distributions.
     seed : int, optional
         The seed to use.
 
@@ -41,10 +41,22 @@ class BilbyPriorNode(FunctionNode, CiteClass):
         if seed is not None:
             self.set_seed(seed)
 
-        # Set the prior and the outputs.
+        # Set the prior. If the prior is provided as a dictionary, convert it to a Bilby
+        # PriorDict object.
+        if isinstance(prior, dict):
+            try:
+                from bilby.core.prior import PriorDict
+            except ImportError as err:
+                raise ImportError(
+                    "Bilby package is not installed be default. To use the bilby priors, "
+                    "please install it. For example, you can install it with `pip install bilby`."
+                ) from err
+            prior = PriorDict(prior)
         if len(prior) == 0:
             raise ValueError("The provided prior is empty.")
         self.prior = prior
+
+        # Set the outputs to be the names of the parameters in the prior.
         outputs = [param for param in prior]
         super().__init__(self._non_func, outputs=outputs, **kwargs)
 

--- a/tests/tdastro/math_nodes/test_bilby_priors.py
+++ b/tests/tdastro/math_nodes/test_bilby_priors.py
@@ -48,8 +48,8 @@ def test_bilby_priors_single():
         b=Uniform(0, 10, "b"),
         c=Cosine(-2, 2, "c"),
     )
-    prior_dict = PriorDict(priors)
-    node = BilbyPriorNode(prior=prior_dict, seed=100, node_label="sampler")
+    # Pass the dictionary in directly to the BilbyPriorNode.
+    node = BilbyPriorNode(prior=priors, seed=100, node_label="sampler")
 
     params = node.sample_parameters(num_samples=1)
 

--- a/tests/tdastro/math_nodes/test_bilby_priors.py
+++ b/tests/tdastro/math_nodes/test_bilby_priors.py
@@ -1,0 +1,75 @@
+import numpy as np
+import pytest
+from bilby.core.prior import Cosine, PriorDict, Uniform
+from tdastro.math_nodes.bilby_priors import BilbyPriorNode
+
+
+def test_bilby_priors_simple():
+    """Test that we can generate numbers from a simple Bilby prior."""
+    priors = dict(
+        a=Uniform(0, 5, "a"),
+        b=Uniform(0, 10, "b"),
+        c=Cosine(-2, 2, "c"),
+    )
+    prior_dict = PriorDict(priors)
+    node = BilbyPriorNode(prior=prior_dict, seed=100, node_label="sampler")
+    assert "a" in node.outputs
+    assert "b" in node.outputs
+    assert "c" in node.outputs
+
+    params = node.sample_parameters(num_samples=10_000)
+
+    # "a" should be 10,000 samples from a uniform distribution between 0 and 5.
+    assert params["sampler"]["a"].shape == (10_000,)
+    assert np.all(params["sampler"]["a"] >= 0)
+    assert np.all(params["sampler"]["a"] <= 5)
+    for bin in np.linspace(0, 4, 5):
+        in_bin = np.sum((params["sampler"]["a"] >= bin) & (params["sampler"]["a"] < bin + 1))
+        assert 1_500 < in_bin < 2_500
+
+    # "b" should be 10,000 samples from a uniform distribution between 0 and 10.
+    assert params["sampler"]["b"].shape == (10_000,)
+    assert np.all(params["sampler"]["b"] >= 0)
+    assert np.all(params["sampler"]["b"] <= 10)
+    for bin in np.linspace(0, 9, 10):
+        in_bin = np.sum((params["sampler"]["b"] >= bin) & (params["sampler"]["b"] < bin + 1))
+        assert 500 < in_bin < 1_500
+
+    # "c" should be 10,000 samples from a cosine distribution between -2 and 2.
+    assert params["sampler"]["c"].shape == (10_000,)
+    assert np.all(params["sampler"]["c"] >= -2)
+    assert np.all(params["sampler"]["c"] <= 2)
+
+
+def test_bilby_priors_single():
+    """Test that we can generate numbers from a simple Bilby prior with a single sample."""
+    priors = dict(
+        a=Uniform(0, 5, "a"),
+        b=Uniform(0, 10, "b"),
+        c=Cosine(-2, 2, "c"),
+    )
+    prior_dict = PriorDict(priors)
+    node = BilbyPriorNode(prior=prior_dict, seed=100, node_label="sampler")
+
+    params = node.sample_parameters(num_samples=1)
+
+    # "a" should be a single sample from a uniform distribution between 0 and 5.
+    assert np.isscalar(params["sampler"]["a"])
+    assert params["sampler"]["a"] >= 0
+    assert params["sampler"]["a"] <= 5
+
+    # "b" should be a single sample from a uniform distribution between 0 and 10.
+    assert np.isscalar(params["sampler"]["b"])
+    assert params["sampler"]["b"] >= 0
+    assert params["sampler"]["b"] <= 10
+
+    # "c" should be a single sample from a cosine distribution between -2 and 2.
+    assert np.isscalar(params["sampler"]["c"])
+    assert params["sampler"]["c"] >= -2
+    assert params["sampler"]["c"] <= 2
+
+
+def test_bilby_priors_errors():
+    """Test that BilbyPriorNode raises errors when given an empty prior model."""
+    with pytest.raises(ValueError):
+        BilbyPriorNode(prior=dict(), seed=100, node_label="sampler")


### PR DESCRIPTION
This is a step toward #419, but is not redback specific. Allow the code to sample the parameters from one of Bibly's `PriorDict` objects.