### PR TITLE
Fix test warning

### DIFF
--- a/src/tdastro/astro_utils/passbands.py
+++ b/src/tdastro/astro_utils/passbands.py
@@ -357,7 +357,7 @@ class PassbandGroup:
         # Load the table, convert the wavelengths from microns to Angstroms, create Passband objects.
         # The table contains effective area in m^2, but since we normalize the transmission tables,
         # we can just use this directly.
-        table = pd.read_csv(table_path, comment="#", sep=r"[\s,]+")
+        table = pd.read_csv(table_path, comment="#", sep=r"[\s,]+", engine="python")
         waves = table["Wave"].values * 10_000  # Convert microns to Angstroms
 
         for filter_name in ["F062", "F087", "F106", "F129", "F146", "F158", "F184", "F213"]:


### PR DESCRIPTION
Fix the warning that:

```
tests/tdastro/astro_utils/test_passband_groups.py::test_passband_group_roman_preset
  /Users/jkubica/h/tdastro/src/tdastro/astro_utils/passbands.py:360: ParserWarning: Falling back to the 'python' engine because the 'c' engine does not support regex separators (separators > 1 char and different from '\s+' are interpreted as regex); you can avoid this warning by specifying engine='python'.
    table = pd.read_csv(table_path, comment="#", sep=r"[\s,]+")
```

by adding the `engine='python'` argument.