### PR TITLE
Add a helper function to create a DAG of parameters

### DIFF
--- a/src/tdastro/base_models.py
+++ b/src/tdastro/base_models.py
@@ -676,13 +676,13 @@ class ParameterizedNode:
 
         # Add each parameter to the dependency graph.
         for param_name, setter in self.setters.items():
-            full_name = f"{node_name}.{param_name}"
+            full_name = GraphState.extended_param_name(node_name, param_name)
             dependency_graph.add_parameter(param_name, node_name)
 
             # Recursively process any dependencies first, including constants.
             dep_name = None
             if setter.dependency is not None and setter.dependency != self:
-                dep_name = f"{setter.dependency.node_string}.{setter.value}"
+                dep_name = GraphState.extended_param_name(setter.dependency.node_string, setter.value)
                 setter.dependency._dependency_graph_helper(dependency_graph)
             elif setter.source_type == ParameterSource.CONSTANT:
                 dep_name = dependency_graph.add_constant(setter.value)
@@ -924,9 +924,9 @@ class FunctionNode(ParameterizedNode):
         # For each computed parameter, add the cross product of inputs to outputs.
         for param_name, setter in self.setters.items():
             if setter.source_type == ParameterSource.COMPUTE_OUTPUT:
-                out_full_name = f"{node_name}.{param_name}"
+                out_full_name = GraphState.extended_param_name(node_name, param_name)
                 for input_name in self.arg_names:
-                    input_full_name = f"{node_name}.{input_name}"
+                    input_full_name = GraphState.extended_param_name(node_name, input_name)
                     dependency_graph.add_edge(input_full_name, out_full_name)
 
     def compute(self, graph_state, rng_info=None, **kwargs):

--- a/src/tdastro/graph_state.py
+++ b/src/tdastro/graph_state.py
@@ -535,12 +535,15 @@ class GraphState:
 
                         # Start by expanding the result we have already seen if needed.
                         if param_name in results:
-                            full_name_existing = f"{first_seen_node[param_name]}.{param_name}"
+                            full_name_existing = GraphState.extended_param_name(
+                                first_seen_node[param_name],
+                                param_name,
+                            )
                             results[full_name_existing] = results[param_name]
                             del results[param_name]
 
                         # Add the result from the current node.
-                        full_name_current = f"{node_name}.{param_name}"
+                        full_name_current = GraphState.extended_param_name(node_name, param_name)
                         results[full_name_current] = param_value
                     else:
                         # This is the first time we have seen the node. Save it with
@@ -607,12 +610,13 @@ class GraphState:
 
 class DependencyGraph:
     """A class to hold the dependencies between parameters in a model. Used for
-    analysis, documentation, and visualization of the model structure.
+    analysis, documentation, testing, and visualization of the model structure.
+    The full parameter names are in the same form used by GraphState.
 
     Attributes
     ----------
     all_params : set
-        A set of all parameter names in the graph.
+        A set of all (full) parameter names in the graph.
     all_nodes : set
         A set of all node names in the graph.
     incoming : dict
@@ -647,7 +651,7 @@ class DependencyGraph:
             The name of the parameter to add.
         node_name : str, optional
             The name of the node holding this parameter. If provided, the full parameter
-            name will be "{node_name}.{param_name}".
+            name will be in the same form used by GraphState for storage.
             Default: None
         """
         # If a node name is provided, create the expanded parameter name.
@@ -655,7 +659,7 @@ class DependencyGraph:
         if node_name is not None:
             if node_name not in self.all_nodes:
                 self.all_nodes.add(node_name)
-            param_name = f"{node_name}.{param_name}"
+            param_name = GraphState.extended_param_name(node_name, param_name)
 
         # If we haven't seen the parameter before, add it to the graph.
         if param_name not in self.all_params:

--- a/tests/tdastro/math_nodes/test_np_random.py
+++ b/tests/tdastro/math_nodes/test_np_random.py
@@ -71,7 +71,7 @@ def test_numpy_random_uniform_mutli_dim():
 
 def test_numpy_random_normal():
     """Test that we can generate numbers from a normal distribution."""
-    np_node = NumpyRandomFunc("normal", loc=100.0, scale=10.0, seed=100)
+    np_node = NumpyRandomFunc("normal", loc=100.0, scale=10.0, seed=100, node_label="normal1")
 
     values = np.array([np_node.generate() for _ in range(10_000)])
     assert np.abs(np.mean(values) - 100.0) < 0.5
@@ -81,6 +81,13 @@ def test_numpy_random_normal():
     np_node2 = NumpyRandomFunc("normal", loc=100.0, scale=10.0, seed=100)
     values2 = np.array([np_node2.generate() for _ in range(10_000)])
     assert np.allclose(values, values2)
+
+    # Check that we can get a dependency graph that correctly includes this node.
+    dep_graph = np_node.build_dependency_graph()
+    assert dep_graph.all_nodes == {"normal1"}
+    assert dep_graph.incoming["normal1.function_node_result"] == ["normal1.loc", "normal1.scale"]
+    assert dep_graph.outgoing["normal1.loc"] == ["normal1.function_node_result"]
+    assert dep_graph.outgoing["normal1.scale"] == ["normal1.function_node_result"]
 
 
 def test_numpy_random_given_rng():


### PR DESCRIPTION
Adds the ability to create a DAG of parameters for testing, analysis, visualization, and documentation. This is the first step of automatically building the DAG from the graph of `ParameterizedNode`. Ultimately we want to use this to provide tools (such as a dependency visualizer) that helps the user understand the current model.